### PR TITLE
feat<FM-256>: Create reusable level button

### DIFF
--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -277,8 +277,8 @@ export class LevelSelectionScreen {
         ? this.context.fillText(
             this.data.levels[levelBtn.levelData.index + this.levelSelectionPageIndex - 1]
               .levelMeta.levelType,
-            levelBtn.levelData.x + levelBtn.levelData.size / 3.5,
-            levelBtn.levelData.y + levelBtn.levelData.size / 1.3
+            levelBtn.levelData.x + levelBtn.btnSize / 3.5,
+            levelBtn.levelData.y + levelBtn.btnSize / 1.3
           )
         : null;
     }


### PR DESCRIPTION
feat<FM-256>: Create reusable level button -> Fixed incorrect object attribute size for rendering debug level indicator.

# Changes
- level-selection-scene.ts -> Updated incorrect level size value.

# How to test
- Run FTM then press dev button to enable developer mode.
- Then press start button and all levels should be unlocked with the game level text displayed at the bottom of each buttons.

Ref: [JIRA-CODE](https://curiouslearning.atlassian.net/browse/FM-256)
