### PR TITLE
Feat: fix z index to feedback text in level end screen (FM-69)

### DIFF
--- a/src/sceneHandler/index.ts
+++ b/src/sceneHandler/index.ts
@@ -146,7 +146,6 @@ export class SceneHandler {
     setTimeout(
       () => {
         this.dispose(SCENE_NAME_GAME_PLAY);
-        document.getElementById("feedback-text").style.zIndex = "0";
         this.levelEndScene = new LevelEndScene(
           this.canvas,
           this.height,


### PR DESCRIPTION
# Changes
- src/sceneHandler/index.ts

# How to test
- make sure feedback text will still appear after switching to end level

Ref: [FM-69](https://curiouslearning.atlassian.net/browse/FM-69)


[FM-69]: https://curiouslearning.atlassian.net/browse/FM-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ