### PR TITLE
Feat<FM-276>: Word Puzzle Multi-Letter Selection Feature

### DIFF
--- a/src/components/stone-handler.ts
+++ b/src/components/stone-handler.ts
@@ -14,7 +14,7 @@ import {
 
 export default class StoneHandler extends EventManager {
   public context: CanvasRenderingContext2D;
-  public canvas: { width: number; height?: number };
+  public canvas: HTMLCanvasElement;
   public currentPuzzleData: any;
   public targetStones: string[];
   public stonePos: number[][];
@@ -37,7 +37,7 @@ export default class StoneHandler extends EventManager {
   isGamePaused: boolean = false;
   constructor(
     context: CanvasRenderingContext2D,
-    canvas: { width: number; height?: number },
+    canvas,
     puzzleNumber: number,
     levelData,
     feedbackAudios,
@@ -104,6 +104,25 @@ export default class StoneHandler extends EventManager {
   draw(deltaTime: number) {
     for (let i = 0; i < this.foilStones.length; i++) {
       this.foilStones[i].draw(deltaTime);
+    }
+
+    if (
+      this.foilStones[this.foilStones.length - 1].frame >= 100 &&
+      !this.isGamePaused
+    ) {
+      this.timerTickingInstance.update(deltaTime);
+    }
+  }
+
+  drawWordPuzzleLetters(
+    deltaTime: number,
+    shouldHideStoneChecker,
+  ):void {
+    for (let i = 0; i < this.foilStones.length; i++) {
+
+      if (shouldHideStoneChecker(i)) {
+        this.foilStones[i].draw(deltaTime);
+      }
     }
 
     if (
@@ -190,6 +209,11 @@ export default class StoneHandler extends EventManager {
     feedBackIndex: number,
     isWord:boolean = false
   ): boolean {
+    /**
+     * To Do: Need to refactor or revome this completely and place something
+     * that is tailored to single letter puzzle since word puzzle no longer uses this.
+     * Will leave this for now to avoid messing witht the single letter puzzle.
+     */
     const isLetterDropCorrect = isWord
       ? droppedStone == this.correctTargetStone.substring(0, droppedStone.length)
       : droppedStone == this.correctTargetStone;
@@ -204,13 +228,12 @@ export default class StoneHandler extends EventManager {
     return isLetterDropCorrect
   }
 
-  private processLetterDropFeedbackAudio(
+  public processLetterDropFeedbackAudio(
     feedBackIndex: number,
     isLetterDropCorrect:boolean,
     isWord:boolean,
     droppedStone: string,
   ) {
-
     if (isLetterDropCorrect) {
       const condition = isWord
         ? droppedStone === this.getCorrectTargetStone() // condition for word puzzle
@@ -291,5 +314,87 @@ export default class StoneHandler extends EventManager {
     );
     // to play the audio parrallely.
     this.correctStoneAudio.play();
+  }
+
+  resetStonePosition(
+    width,
+    pickedStone,
+    pickedStoneObject
+  ) {
+    const stone = pickedStone;
+    const stoneObj = pickedStoneObject;
+    //Resets the previous stone letter to its original position.
+    if (
+        stone &&
+        stoneObj &&
+        stone.text &&
+        typeof stoneObj.origx === "number" &&
+        typeof stoneObj.origy === "number"
+    ) {
+      const xLimit = 50;
+      const halfWidth = width / 2;
+
+      stone.x = stone.text.length <= 3 &&
+        stoneObj.origx < xLimit &&
+        stoneObj.origx < halfWidth
+          ? stoneObj.origx + 25
+          : stoneObj.origx;
+      stone.y = stoneObj.origy;
+    }
+
+    return stone;
+  }
+
+  private computeCursorDistance(posX, posY, sc):number {
+    return Math.sqrt((posX - sc.x) ** 2 + (posY - sc.y) ** 2);
+  }
+
+  handlePickStoneUp(posX, posY) {
+    let stoneLetter = null;
+    let ctr = 0;
+    for (let sc of this.foilStones) {
+      const distance = this.computeCursorDistance(posX, posY, sc);
+      if (distance <= 40) {
+          stoneLetter = sc;
+          /* Adds a unique identifier to tell which letter is which in case there are two or more of the same letter.*/
+          stoneLetter['foilStoneIndex'] = ctr;
+          break;
+      }
+      ctr++;
+    };
+
+    return stoneLetter;
+  }
+
+  handleHoveringToAnotherStone(
+    posX,
+    posY,
+    shouldGroupLetter
+  ) {
+    /* Handle hovering of stones for word puzzle multi-letter select.*/
+    let stoneLetter = null;
+    let ctr = 0;
+    for (let sc of this.foilStones) {
+      const distance = this.computeCursorDistance(posX, posY, sc);
+
+      if (distance <= 40 && shouldGroupLetter(sc.text, ctr)) {
+        stoneLetter = sc;
+        /* Adds a unique identifier to tell which letter is which in case there are two or more of the same letter.*/
+        stoneLetter['foilStoneIndex'] = ctr;
+        break;
+      }
+      ctr++;
+    };
+
+    return stoneLetter;
+  }
+
+  handleMovingStoneLetter(draggingStone, posX, posY) {
+    const updatedStoneCoordinates = draggingStone;
+    const rect = this.canvas.getBoundingClientRect();
+    updatedStoneCoordinates.x = posX - rect.left;
+    updatedStoneCoordinates.y = posY - rect.top;
+
+    return updatedStoneCoordinates;
   }
 }

--- a/src/components/stone-handler.ts
+++ b/src/components/stone-handler.ts
@@ -116,7 +116,7 @@ export default class StoneHandler extends EventManager {
 
   drawWordPuzzleLetters(
     deltaTime: number,
-    shouldHideStoneChecker,
+    shouldHideStoneChecker: (index: number) => boolean,
   ):void {
     for (let i = 0; i < this.foilStones.length; i++) {
 
@@ -317,9 +317,9 @@ export default class StoneHandler extends EventManager {
   }
 
   resetStonePosition(
-    width,
-    pickedStone,
-    pickedStoneObject
+    width: number,
+    pickedStone: StoneConfig,
+    pickedStoneObject: StoneConfig
   ) {
     const stone = pickedStone;
     const stoneObj = pickedStoneObject;

--- a/src/gamepuzzles/index.ts
+++ b/src/gamepuzzles/index.ts
@@ -1,0 +1,4 @@
+import WordPuzzleLogic from './wordPuzzleLogic';
+//import here for single letter puzzle or other game puzzle logic.
+
+export { WordPuzzleLogic };

--- a/src/gamepuzzles/wordPuzzleLogic.ts
+++ b/src/gamepuzzles/wordPuzzleLogic.ts
@@ -59,8 +59,8 @@ export default class WordPuzzleLogic {
         hideListObj: { [key:number]: string },
     } {
         return {
-            groupedLetters: `${this.groupedLetters}`,
-            droppedLetters: `${this.droppedLetters}`,
+            groupedLetters: this.groupedLetters,
+            droppedLetters: this.droppedLetters,
             groupedObj: { ...this.groupedObj },
             droppedHistory: { ...this.droppedHistory },
             hideListObj: { ...this.hideListObj },

--- a/src/gamepuzzles/wordPuzzleLogic.ts
+++ b/src/gamepuzzles/wordPuzzleLogic.ts
@@ -1,0 +1,146 @@
+export default class WordPuzzleLogic {
+    /**
+        puzzleNumber - Puzzle stage level of current (Up to 5 stage levels) game level.
+        groupedLetters - String sequence of letters when performing the multi-letter seleciton.
+        droppedLetters - String sequence of letters when group of letters was fed to the monster.
+        groupedObj - Object with key properties of stone letter index, used for validating duplicate letters while hovering.
+        droppedHistory - Object with key properties of stone letter index that was fed to the monster.
+                        Used to preserve the list for hiding the stone letters.
+        hideListObj - Object with key properties of stone letter index.
+                    Used to hide stones that is part of the group or stones that was already fed to the monster.
+    **/
+    private levelData: {
+        levelNumber: number;
+        levelMeta: {
+            letterGroup: number;
+            levelNumber: number;
+            levelType: string;
+            promptFadeOut: number;
+            protoType: string;
+        };
+        puzzles: [
+            {
+                foilStones: string[];
+                prompt: {
+                    promptAudio: string;
+                    promptText: string;
+                };
+                segmentNumber: number;
+                targetStones: string[];
+            }
+        ];
+    }
+    private puzzleNumber: number;
+    private groupedLetters: string;
+    private droppedLetters: string;
+    private groupedObj: {} | { [key:number]: string };
+    private droppedHistory: {} | { [key:number]: string };
+    private hideListObj: {} | { [key:number]: string };
+
+    constructor(levelData, puzzleNumber) {
+        this.levelData = levelData;
+        this.puzzleNumber = puzzleNumber;
+        this.groupedLetters = '';
+        this.droppedLetters = '';
+        this.groupedObj = {};
+        this.droppedHistory = {};
+        this.hideListObj = {};
+    }
+
+    private getTargetWord():string {
+        return this.levelData.puzzles[this.puzzleNumber]?.prompt?.promptText;
+    }
+
+    getValues(): {
+        groupedLetters: string;
+        droppedLetters: string;
+        groupedObj: { [key:number]: string },
+        droppedHistory: { [key:number]: string },
+        hideListObj: { [key:number]: string },
+    } {
+        return {
+            groupedLetters: `${this.groupedLetters}`,
+            droppedLetters: `${this.droppedLetters}`,
+            groupedObj: { ...this.groupedObj },
+            droppedHistory: { ...this.droppedHistory },
+            hideListObj: { ...this.hideListObj },
+        }
+    }
+
+    checkIsWordPuzzle():boolean {
+        return this.levelData?.levelMeta?.levelType === 'Word';
+    }
+
+    updatePuzzleLevel(puzzleNumber: number):void {
+        this.clearAllValues();
+        this.puzzleNumber = puzzleNumber;
+    }
+
+    clearPickedUp():void {
+        this.groupedLetters = '';
+        this.groupedObj = {};
+        this.hideListObj = { ...this.droppedHistory };
+    }
+
+    private clearAllValues():void {
+        this.groupedLetters = '';
+        this.droppedLetters = '';
+        this.groupedObj = {};
+        this.droppedHistory = {};
+        this.hideListObj = {};
+        this.puzzleNumber = 0;
+    }
+
+    validateShouldHideLetter(foilStoneIndex):boolean {
+        //If stone key index is listed in hideListObj it should not be drawn.
+        return !this.hideListObj[foilStoneIndex];
+    }
+
+    handleCheckHoveredStone(foilStoneText:string, foilStoneIndex:number):boolean {
+        const combinedLetters = this.groupedLetters;
+        const targetWord = this.getTargetWord();
+
+        /* Goes inside here if there are no previous letter(s) were dropped
+        and grouping of letters starts in a incorrect letter. */
+        if ((!this.droppedLetters.length && targetWord[0] !== combinedLetters[0])) {
+            return false;
+        }
+
+        /*
+        isLetterAlreadyAdded - If the new stone text is NOT already included
+        isSameLetterUnique -If there is already of the same letter exist in group, validate using uniqe identifier which is the array index key in group object.
+        */
+        const isLetterAlreadyAdded = !combinedLetters.includes(foilStoneText);
+        const isSameLetterUnique = !this.groupedObj[foilStoneIndex];
+        const isMatchTargetWord = targetWord.includes(`${this.droppedLetters}${combinedLetters}${foilStoneText}`);
+
+        return isMatchTargetWord && (isLetterAlreadyAdded || isSameLetterUnique);
+    }
+
+    validateFedLetters():boolean {
+        const targetWord = this.getTargetWord();
+        return this.droppedLetters === targetWord.substring(0, this.droppedLetters.length);
+    }
+
+    validateWordPuzzle():boolean {
+        const targetWord = this.getTargetWord();
+        return this.droppedLetters === targetWord;
+    }
+
+    setGroupToDropped():void {
+        this.droppedLetters = `${this.droppedLetters}${this.groupedLetters}`;
+        this.droppedHistory = {
+            ...this.droppedHistory,
+            ...this.groupedObj
+        };
+    }
+
+    setPickUpLetter(letter: string, arrFoilStoneIndex: number):void {
+        this.hideListObj = {
+            ...this.hideListObj,
+            ...this.groupedObj
+        }; //Hide the previous letters except the new one.
+        this.groupedLetters = `${this.groupedLetters}${letter}`;
+        this.groupedObj[arrFoilStoneIndex] = letter;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,7 +55,9 @@
       "@sceneHandler": ["src/sceneHandler"],
       "@scenes": ["src/scenes"],
       "@events": ["src/events"],
-      "@feedbackText/*": ["src/components/feedback-text/*"]
+      "@feedbackText/*": ["src/components/feedback-text/*"],
+      "@gamepuzzles/*": ["src/gamepuzzles/*"],
+      "@gamepuzzles": ["src/gamepuzzles"]
     },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,8 @@ var config = {
       '@sceneHandler': path.resolve(__dirname, 'src/sceneHandler/'),
       '@scenes': path.resolve(__dirname, 'src/scenes/'),
       '@events': path.resolve(__dirname, 'src/events/'),
-      '@feedbackText': path.resolve(__dirname, 'src/components/feedback-text/')
+      '@feedbackText': path.resolve(__dirname, 'src/components/feedback-text/'),
+      '@gamepuzzles': path.resolve(__dirname, 'src/gamepuzzles/')
     },
     extensions: ['.tsx', '.ts', '.js', '.json', '.css', '.sh', '.babelrc', '.eslintignore', '.gitignore', '.d'],
   },


### PR DESCRIPTION
# Changes
- Added multi-letter selection for word puzzle.
- Moved conditions relating to word puzzle to a separate class.
- Moved conditions of updating coordinates to stone-handler class.

# How to test
Enable dev mode
- Option 1
1. In our FTM source code navigate to src/common/global-variables.ts.
2. Set the DebugMode from 'false' to 'true'.
3. Run the application with 'npm run dev' and in another cmd the command 'workbox injectManifest'.
4. Right click on the build/index.html and open it with LiveServer.
5. Game should run in developer mode with puzzle names indicated on level-selection.

- Option 2
1. On the start screen of the FTM app there is a gray button 'DEV'.
2. Press the 'DEV' button to enable the developer mode.
3. Game should run in developer mode with puzzle names indicated on level-selection.

After following the developer mode, do this steps:
- Press start and in level selection, select any "word" puzzle level (Follow dev mode to see the text indication of each levels).
- In the game play scene, you can now test this feature for multi-letter select.
- Follow the FM-276 for the acceptance criteria and full logic of the feature.


Ref: [<JIRA-CODE>](https://curiouslearning.atlassian.net/browse/FM-276)
