### PR TITLE
Feat: subtle attention drawing animation on level icons (FM-271)

### DIFF
--- a/src/components/buttons/level-button.ts
+++ b/src/components/buttons/level-button.ts
@@ -28,7 +28,6 @@ export default class LevelBloonButton {
     private lockSize: number;
     private textFontSize: number;
     private pulse: boolean;
-    private isSpecial: boolean;
 
     constructor(
         canvas,
@@ -48,12 +47,10 @@ export default class LevelBloonButton {
         this.lockSize = canvas.height / 13;
         this.textFontSize = (this.size) / 6;
         this.pulse = false;
-        this.isSpecial = false;
     }
 
     setPulse(shouldPulse: boolean, isSpecial: boolean) {
         this.pulse = shouldPulse;
-        this.isSpecial = isSpecial;
     }
 
     isSpecialLevel(index){

--- a/src/components/buttons/level-button.ts
+++ b/src/components/buttons/level-button.ts
@@ -111,27 +111,36 @@ export default class LevelBloonButton {
     }
 
     private applyPulseEffect() {
-        const pulseDuration = 1500;
-        const maxOpacity = 0.5;
-        const baseColorRgba = '255, 255, 255';
-        const animationProgress = (Date.now() % pulseDuration) / pulseDuration;
-        const growPhase = animationProgress <= 0.7;
-        const progress = growPhase ? animationProgress / 0.7 : (animationProgress - 0.7) / 0.3;
-
-        const shadowSize = growPhase ? progress * 15 : 15 + progress * 45;
-        const shadowOpacity = growPhase ? maxOpacity * (1 - progress) : 0;
-
+        const PulseDuration = 1500;
+        const GrowPhaseThreshold = 0.7;
+        const BaseShadowSize = 15;
+        const MaxShadowSize = 45;
+        const MaxOpacity = 0.5;
+        const BaseColorRgba = '255, 255, 255';
+      
+        const animationProgress = (Date.now() % PulseDuration) / PulseDuration;
+        const growPhase = animationProgress <= GrowPhaseThreshold;
+      
+        const phaseDuration = growPhase ? GrowPhaseThreshold : (1 - GrowPhaseThreshold);
+        const progress = growPhase ? animationProgress / GrowPhaseThreshold : (animationProgress - GrowPhaseThreshold) / phaseDuration;
+      
+        const shadowSize = growPhase ? progress * BaseShadowSize : BaseShadowSize + progress * MaxShadowSize;
+        const shadowOpacity = growPhase ? MaxOpacity * (1 - progress) : 0;
+      
         if (shadowOpacity <= 0) return;
-
-        const sizeFactor = this.levelData?.isSpecial ? { x: 3, y: 2.5, radius: 2.2 } : { x: 3.4, y: 3.8, radius: 3.2 };
-        const centerX = this.posX + this.btnSize / sizeFactor.x;
-        const centerY = this.posY + this.btnSize / sizeFactor.y;
-        const radius = this.btnSize / sizeFactor.radius + shadowSize;
-
+      
+        const { x: scaleX, y: scaleY, radius: scaleRadius } = this.levelData?.isSpecial 
+          ? { x: 3, y: 2.5, radius: 2.2 } 
+          : { x: 3.4, y: 3.8, radius: 3.2 };
+      
+        const centerX = this.posX + this.btnSize / scaleX;
+        const centerY = this.posY + this.btnSize / scaleY;
+        const radius = this.btnSize / scaleRadius + shadowSize;
+      
         this.context.save();
         this.context.beginPath();
         this.context.arc(centerX, centerY, radius, 0, 2 * Math.PI);
-        this.context.fillStyle = `rgba(${baseColorRgba}, ${shadowOpacity})`;
+        this.context.fillStyle = `rgba(${BaseColorRgba}, ${shadowOpacity})`;
         this.context.fill();
         this.context.restore();
     }

--- a/src/components/buttons/level-button.ts
+++ b/src/components/buttons/level-button.ts
@@ -27,6 +27,8 @@ export default class LevelBloonButton {
     private btnSize: number;
     private lockSize: number;
     private textFontSize: number;
+    private pulse: boolean;
+    private isSpecial: boolean;
 
     constructor(
         canvas,
@@ -45,6 +47,13 @@ export default class LevelBloonButton {
         this.btnSize = this.bloonSize;
         this.lockSize = canvas.height / 13;
         this.textFontSize = (this.size) / 6;
+        this.pulse = false;
+        this.isSpecial = false;
+    }
+
+    setPulse(shouldPulse: boolean, isSpecial: boolean) {
+        this.pulse = shouldPulse;
+        this.isSpecial = isSpecial;
     }
 
     isSpecialLevel(index){
@@ -63,6 +72,10 @@ export default class LevelBloonButton {
         gameLevelData,
         totalGameLevels
     ) {
+        if (this.pulse) {
+            this.applyPulseEffect();
+        }
+
         this.context.drawImage(
             this.levelData?.balloonImg,
             this.posX,
@@ -95,6 +108,32 @@ export default class LevelBloonButton {
             gameLevelData,
             totalGameLevels
         );
+    }
+
+    private applyPulseEffect() {
+        const pulseDuration = 1500;
+        const maxOpacity = 0.5;
+        const baseColorRgba = '255, 255, 255';
+        const animationProgress = (Date.now() % pulseDuration) / pulseDuration;
+        const growPhase = animationProgress <= 0.7;
+        const progress = growPhase ? animationProgress / 0.7 : (animationProgress - 0.7) / 0.3;
+
+        const shadowSize = growPhase ? progress * 15 : 15 + progress * 45;
+        const shadowOpacity = growPhase ? maxOpacity * (1 - progress) : 0;
+
+        if (shadowOpacity <= 0) return;
+
+        const sizeFactor = this.levelData?.isSpecial ? { x: 3, y: 2.5, radius: 2.2 } : { x: 3.4, y: 3.8, radius: 3.2 };
+        const centerX = this.posX + this.btnSize / sizeFactor.x;
+        const centerY = this.posY + this.btnSize / sizeFactor.y;
+        const radius = this.btnSize / sizeFactor.radius + shadowSize;
+
+        this.context.save();
+        this.context.beginPath();
+        this.context.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+        this.context.fillStyle = `rgba(${baseColorRgba}, ${shadowOpacity})`;
+        this.context.fill();
+        this.context.restore();
     }
 
     drawIcons(

--- a/src/components/buttons/level-button.ts
+++ b/src/components/buttons/level-button.ts
@@ -27,7 +27,6 @@ export default class LevelBloonButton {
     private btnSize: number;
     private lockSize: number;
     private textFontSize: number;
-    private pulse: boolean;
 
     constructor(
         canvas,
@@ -46,11 +45,6 @@ export default class LevelBloonButton {
         this.btnSize = this.bloonSize;
         this.lockSize = canvas.height / 13;
         this.textFontSize = (this.size) / 6;
-        this.pulse = false;
-    }
-
-    setPulse(shouldPulse: boolean, isSpecial: boolean) {
-        this.pulse = shouldPulse;
     }
 
     isSpecialLevel(index){
@@ -69,10 +63,6 @@ export default class LevelBloonButton {
         gameLevelData,
         totalGameLevels
     ) {
-        if (this.pulse) {
-            this.applyPulseEffect();
-        }
-
         this.context.drawImage(
             this.levelData?.balloonImg,
             this.posX,
@@ -107,7 +97,7 @@ export default class LevelBloonButton {
         );
     }
 
-    private applyPulseEffect() {
+    applyPulseEffect() {
         const PulseDuration = 1500;
         const GrowPhaseThreshold = 0.7;
         const BaseShadowSize = 15;

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -266,8 +266,10 @@ export class LevelSelectionScreen {
   private drawLevel(levelBtn: any, gameLevelData: []) {
     const currentLevelIndex = levelBtn.levelData.index + this.levelSelectionPageIndex;
     const currentLevel = this.previousPlayedLevelNumber + 1;
-    
-    levelBtn.setPulse(currentLevelIndex === currentLevel, levelBtn.levelData.isSpecial);
+
+    if (currentLevelIndex === currentLevel) {
+      levelBtn.applyPulseEffect();
+    }
 
     if (currentLevelIndex <= this.data.levels.length) {
       this.checkUnlockedLevel(gameLevelData);

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -269,7 +269,7 @@ export class LevelSelectionScreen {
     
     levelBtn.setPulse(currentLevelIndex === currentLevel, levelBtn.levelData.isSpecial);
 
-    if (levelBtn.levelData.index + this.levelSelectionPageIndex <= this.data.levels.length) {
+    if (currentLevelIndex <= this.data.levels.length) {
       this.checkUnlockedLevel(gameLevelData);
       levelBtn.draw(
         this.levelSelectionPageIndex,
@@ -280,7 +280,7 @@ export class LevelSelectionScreen {
 
       Debugger.DebugMode
         ? this.context.fillText(
-            this.data.levels[levelBtn.levelData.index + this.levelSelectionPageIndex - 1]
+            this.data.levels[currentLevelIndex - 1]
               .levelMeta.levelType,
             levelBtn.levelData.x + levelBtn.btnSize / 3.5,
             levelBtn.levelData.y + levelBtn.btnSize / 1.3

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -264,6 +264,11 @@ export class LevelSelectionScreen {
   };
 
   private drawLevel(levelBtn: any, gameLevelData: []) {
+    const currentLevelIndex = levelBtn.levelData.index + this.levelSelectionPageIndex;
+    const currentLevel = this.previousPlayedLevelNumber + 1;
+    
+    levelBtn.setPulse(currentLevelIndex === currentLevel, levelBtn.levelData.isSpecial);
+
     if (levelBtn.levelData.index + this.levelSelectionPageIndex <= this.data.levels.length) {
       this.checkUnlockedLevel(gameLevelData);
       levelBtn.draw(


### PR DESCRIPTION
# Changes
- Created a pulse effect on current level icon

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen.
- On the level selection screen, ensure that the current level icon has a pulse effect animation.

Ref: [FM-271](https://curiouslearning.atlassian.net/browse/FM-271)


[FM-271]: https://curiouslearning.atlassian.net/browse/FM-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ