### PR TITLE
Feat: ensure feedback text effect fits properly in all devices (FM-278)

### DIFF
--- a/index.css
+++ b/index.css
@@ -201,7 +201,7 @@ img {
 
 .feedback-text {
   font-family: "AtmaSemiBold", system-ui;
-  font-size: 52px;
+  font-size: 8vw;
   font-weight: 700;
   position: absolute;
   top: 22%;

--- a/index.css
+++ b/index.css
@@ -201,7 +201,7 @@ img {
 
 .feedback-text {
   font-family: "AtmaSemiBold", system-ui;
-  font-size: 8vw;
+  font-size: 10vw;
   font-weight: 700;
   position: absolute;
   top: 22%;

--- a/src/components/feedback-text/index.ts
+++ b/src/components/feedback-text/index.ts
@@ -22,9 +22,6 @@ export class FeedbackTextEffects {
     if (!this.isFeedbackElementAvailable()) return;
     this.feedbackTextElement.textContent = text;
 
-    // Dynamically adjust the font size based on the length of the text
-    this.feedbackTextElement.style.fontSize = text.length >= 12 ? "30px" : "";
-
     hideElement(false, this.feedbackTextElement);
 
     this.setHideTimeout();


### PR DESCRIPTION
# Changes
- Fixed the issue on feedback text in some tablet device

# How to test
- In start screen
- Tap or click any part of the start screen to proceed to the next screen
- On the level selection screen, select any level icon to play
- On the game screen, select a correct word or stone
- Make sure the feedback text fits properly in devices/tablet

Ref: [FM-278](https://curiouslearning.atlassian.net/browse/FM-278)


[FM-278]: https://curiouslearning.atlassian.net/browse/FM-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ