### PR TITLE
feat: BasePopupComponent class implementation (FM-297)

### DIFF
--- a/build/index.css
+++ b/build/index.css
@@ -297,3 +297,68 @@ img {
     2px 2px 0 #fff, -3px 0 0 #fff, 3px 0 0 #fff, 0 -3px 0 #fff, 0 3px 0 #fff;
   overflow: hidden;
 }
+
+/* TODO: move to scss */
+/* POPUPS */ 
+.popup {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  height: 100%;
+  width: 100%;
+}
+.popup.show {
+  display: block;
+}
+.popup .popup__overlay {
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0,0,0,0.5);
+}
+.popup .popup__content-wrapper {
+  position: absolute;
+  top: 20vh;
+  left: 10vw;
+  right: 10vw;
+  padding: 35px 50px;
+  height: 80vw;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.popup .popup__content-wrapper [data-click="close"] {
+  position: absolute;
+  top: -15px;
+  left: 15px;
+  
+  display: block;
+}
+
+.popup .popup__content-wrapper .popup__content-container {
+  padding: 15px;
+  color: #fff;
+}
+
+/* BUTTONS */
+.btn--icon {
+  height: calc(100vw * 0.19);
+  width: calc(100vw * 0.19);
+  display: inline-block;
+}
+
+.btn--icon img {
+  display: block;
+  height: 100%;
+  width: 100%;
+  transition: transform 300ms;
+}
+.btn--icon:hover img {
+  transform: scale(1.1);
+}
+.btn--icon:active img {
+  transform: scale(0.9);
+}

--- a/index.css
+++ b/index.css
@@ -297,3 +297,68 @@ img {
     2px 2px 0 #fff, -3px 0 0 #fff, 3px 0 0 #fff, 0 -3px 0 #fff, 0 3px 0 #fff;
   overflow: hidden;
 }
+
+/* TODO: move to scss */
+/* POPUPS */ 
+.popup {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  height: 100%;
+  width: 100%;
+}
+.popup.show {
+  display: block;
+}
+.popup .popup__overlay {
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0,0,0,0.5);
+}
+.popup .popup__content-wrapper {
+  position: absolute;
+  top: 20vh;
+  left: 10vw;
+  right: 10vw;
+  padding: 35px 50px;
+  height: 80vw;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.popup .popup__content-wrapper [data-click="close"] {
+  position: absolute;
+  top: -15px;
+  left: 15px;
+  
+  display: block;
+}
+
+.popup .popup__content-wrapper .popup__content-container {
+  padding: 15px;
+  color: #fff;
+}
+
+/* BUTTONS */
+.btn--icon {
+  height: calc(100vw * 0.19);
+  width: calc(100vw * 0.19);
+  display: inline-block;
+}
+
+.btn--icon img {
+  display: block;
+  height: 100%;
+  width: 100%;
+  transition: transform 300ms;
+}
+.btn--icon:hover img {
+  transform: scale(1.1);
+}
+.btn--icon:active img {
+  transform: scale(0.9);
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "feedTheMonster.js",
   "scripts": {
     "release": "release-it",
+    "workbox:inject": "workbox injectManifest",
     "dev": "webpack --config webpack.config.js"
   },
   "repository": {

--- a/src/components/popups/base-popup/base-popup-component.ts
+++ b/src/components/popups/base-popup/base-popup-component.ts
@@ -1,0 +1,187 @@
+import { CANCEL_BTN_IMG, POPUP_BG_IMG } from '@constants';
+
+const DEFAULT_SELECTORS = {
+  root: '.game-scene',
+  closeButton: '[data-close]'
+};
+
+const FIXED_SELECTORS = {
+  autoClickBind: '[data-click]'
+};
+
+const CSS_SHOW = 'show';
+
+export const POPUP_LAYOUT = (id: string, content: string, showClose: boolean = true): string => `
+  <div id="${id}" class="popup">
+    <div class="popup__overlay"></div>
+    <div class="popup__content-wrapper" style="background-image: url(${POPUP_BG_IMG})">
+      ${showClose ? `<div class="btn--icon" data-click="close"><img src="${CANCEL_BTN_IMG}"/></div>` : ''}
+      <div class="popup__content-container">${content}</div>
+    </div>
+  </div>
+`;
+
+export interface PopupOptions {
+  hideClose?: boolean;
+  selectors: {
+    root: string;
+    closeButton: string;
+  }
+}
+
+export interface PopupClickEvent {
+  data: any;
+  event: Event;
+}
+
+/**
+ * BasePopupComponent
+ * 
+ * The popup component also features a close handler by simply adding data-close attribute to an element.
+ * 
+ * Usage:
+ * 
+ * class MyPopup extends BasePopupComponent {
+ * 
+ *    template = 'my popup';
+ * 
+ * }
+ * 
+ * const myPopup = new MyPopup();
+ * 
+ * myPopup.show();
+ * 
+ */
+export class BasePopupComponent {
+  /**
+   * Designated id of the popup component. Must be unique, as this is used in the DOM as well. This needs to be overriden.
+   */
+  protected id: string = 'base-popup';
+
+  /**
+   * String literal template containing the dom elements of the popup.
+   */
+  protected template = `
+    <div>
+      <h1>Base Popup Template</h1>
+    </div>
+  `;
+  
+  private isRendered: boolean = false;
+  private popupEl?: Element;
+
+  constructor(
+    protected options: PopupOptions = { selectors: DEFAULT_SELECTORS }
+  ) {
+    this._init();
+  }
+  
+  /**
+   * This method is automatically called. This is where you put your event bindings and other side effects, like pub/sub.
+   */
+  init() {
+
+  }
+
+  /**
+   * Shows/Opens the popup
+   */
+  show() {
+    if (!this.isRendered) this.render();
+    this.setVisibility(true);
+  }
+
+  /**
+   * Hides/Closes the popup
+   */
+  hide() {
+    this.setVisibility(false);
+  }
+
+  /**
+   * Handle unsubscription and deleteing of DOM elements
+   * 
+   * When overriding, be sure to call super.destroy(); This ensures the popup element is removed.
+   */
+  destroy() {
+    this.popupEl.remove();
+  }
+
+  /**
+   * Button clicked event callback. Automatically called when an element with data-click attribute is clicked.
+   * @param event 
+   */
+  onButtonClick(event: PopupClickEvent) {
+    console.log(event);
+  }
+
+  /**
+   * Close event callback. Automatically called when an element with data-click="close" attribute is clicked.
+   * @param event 
+   */
+  onClose(event: PopupClickEvent) {
+    setTimeout(() => {
+      this.show();
+    }, 1000);
+  }
+
+  /**
+   * Initialiation logic,
+   */
+  private _init() {
+    this.render();
+    this.init();
+    this._addEventListeners();
+  }
+
+  private _click = (event: Event) => {
+    const target = event.target as HTMLElement;
+    const closestTarget = target.closest(FIXED_SELECTORS.autoClickBind) as HTMLElement;
+    const data = closestTarget.dataset.click;
+    const isClose = data === 'close';
+
+    // Added delay to visualize animation
+    setTimeout(() => {
+      if (isClose) {
+        this.hide();
+        this.onClose({
+          data,
+          event
+        });
+      } else {
+        this.onButtonClick({
+          data,
+          event
+        });
+      }
+    }, 300);
+  }
+
+  private _addEventListeners() {
+    const closeButtons = this.popupEl?.querySelectorAll(FIXED_SELECTORS.autoClickBind);
+    if (!closeButtons.length) return;
+
+    closeButtons.forEach((closeButton) => {
+      closeButton.addEventListener('click', this._click);
+    });
+  }
+
+  private render() {
+    if (this.isRendered) return;
+
+    const popupTemplate = POPUP_LAYOUT(this.id, this.template);
+    const { root } = this.options.selectors;
+    const rootEl = document.querySelector(root);
+    rootEl.insertAdjacentHTML('beforeend', popupTemplate);
+    this.popupEl = rootEl.querySelector(`#${this.id}`);
+    this.isRendered = true;
+  }
+
+  private setVisibility(toggle: boolean) {
+    if (toggle) {
+      this.popupEl.classList.add(CSS_SHOW);
+    } else {
+      this.popupEl.classList.remove(CSS_SHOW);
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,10 @@ var config = {
         use: 'ts-loader',
         exclude: /node_modules/,
       },
+      {
+        test: /\.html$/,
+        use: 'raw-loader'
+      }
     ],
   },
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,10 +20,6 @@ var config = {
         test: /\.ts?$/,
         use: 'ts-loader',
         exclude: /node_modules/,
-      },
-      {
-        test: /\.html$/,
-        use: 'raw-loader'
       }
     ],
   },


### PR DESCRIPTION
# Changes
- new: BasePopupComponent class implementation
- update: added css styles for html popup
- chore: added workbox script in package.json

# How to test
- import BasePopupComponent to any page
```
const popup = new BasePopupComponent ();
popup.show();
```
- popup should be visible
- close button should be clickale
  - clicking should close popup

Note: this is a base class and not meant for direct use. Actual usage would require creating a child class, extending this class.
i.e.
```
export class PausePopupComponent extends BasePopupComponent  {
  template = `
    ... // popup contents here
  `
}
```

Ref: [FM-297](https://curiouslearning.atlassian.net/browse/FM-297)


[FM-297]: https://curiouslearning.atlassian.net/browse/FM-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ