### PR TITLE
fm-285: Added pause publishing to false in no-retry-callback.

### DIFF
--- a/src/components/popups/pause-popup.ts
+++ b/src/components/popups/pause-popup.ts
@@ -88,6 +88,7 @@ export default class PausePopUp {
   noRetryCallback = () => {
     if (this.isRetryButtonClicked) {
       this.isRetryButtonClicked = false;
+      gameStateService.publish(gameStateService.EVENTS.GAME_PAUSE_STATUS_EVENT, false);
       this.callback();
     }
   };


### PR DESCRIPTION
# Changes
- Added pause publish to pause-popup no retry callback.

# How to test
- Start Game and make sure it is in English language
- Select any level
- In game play, press pause on upper right.
- A popup will appear and then select retry button.
- Another popup will appear and select no to cancel retry.
- The game should unpaused allowing you to continue the game

Ref: [FM-285](https://curiouslearning.atlassian.net/browse/FM-285)


[FM-285]: https://curiouslearning.atlassian.net/browse/FM-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ