### PR TITLE
feat: FM-302 Create the Level End Scene UI in HTML, supporting DOM ma…

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -513,6 +513,22 @@ img {
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) {
+  #rivecanvas{
+    bottom: 22%;
+  }
+  .summer .ftm-fence{
+      left: -200px;
+      bottom: 175px;
+      position: absolute;
+      width: 100%;
+  }
+  .summer .ftm-totem {
+    position: absolute;
+    bottom: 18%;
+    width: 55%;
+    z-index: 1;
+    right: -100px;
+}
   .autumn-bg .ftm-totem,
   .winter-bg .ftm-totem {
     right: -130px;
@@ -527,8 +543,9 @@ img {
   }
 
   .autumn-bg .ftm-fence {
-    bottom: 148px;
+    bottom: 185px;
     width: auto;
+    left: -175px;
   }
 }
 

--- a/src/gameStateService/game-state-service.ts
+++ b/src/gameStateService/game-state-service.ts
@@ -20,6 +20,7 @@ export class GameStateService extends PubSub {
         GAMEPLAY_DATA_EVENT: string;
         GAME_PAUSE_STATUS_EVENT: string;
         GAME_TRAIL_EFFECT_TOGGLE_EVENT: string;
+        LEVEL_END_BACKGROUND_TOGGLE: string;
     }
     public data: null | DataModal;
     public canvas: null | HTMLCanvasElement;
@@ -68,14 +69,15 @@ export class GameStateService extends PubSub {
         great: string
     };
     public clickTrailToggle: boolean
-
+    private isLevelEndBackgroundVisible = false;
     constructor() {
         super();
         this.EVENTS = {
             SCENE_LOADING_EVENT: 'SCENE_LOADING_EVENT',
             GAMEPLAY_DATA_EVENT: 'GAMEPLAY_DATA_EVENT',
             GAME_PAUSE_STATUS_EVENT: 'GAME_PAUSE_STATUS_EVENT',
-            GAME_TRAIL_EFFECT_TOGGLE_EVENT: 'GAME_TRAIL_EFFECT_TOGGLE_EVENT' // To move this event on DOM Event once created.
+            GAME_TRAIL_EFFECT_TOGGLE_EVENT: 'GAME_TRAIL_EFFECT_TOGGLE_EVENT', // To move this event on DOM Event once created.
+            LEVEL_END_BACKGROUND_TOGGLE: 'LEVEL_END_BACKGROUND_TOGGLE'
         };
         this.data = null;
         /* Canvas States */
@@ -104,6 +106,15 @@ export class GameStateService extends PubSub {
         this.subscribe(this.EVENTS.GAMEPLAY_DATA_EVENT, (data) => { this.gameStateGamePlayDataListener(data); });
         this.subscribe(this.EVENTS.GAME_PAUSE_STATUS_EVENT, (data) => { this.updateGamePauseActivity(data); });
         this.subscribe(this.EVENTS.GAME_TRAIL_EFFECT_TOGGLE_EVENT, (data) => { this.updateGameTrailToggle(data); }); // To move this event on DOM Event once created.
+    }
+
+    toggleLevelEndBackground(shouldShow: boolean) {
+        this.isLevelEndBackgroundVisible = shouldShow;
+        this.publish(this.EVENTS.LEVEL_END_BACKGROUND_TOGGLE, shouldShow);
+    }
+
+    isLevelendBackgroundVisible() {
+        return this.isLevelEndBackgroundVisible;
     }
 
     private gameStateGamePlayDataListener(updatedGamePlayData) {

--- a/src/gameStateService/game-state-service.ts
+++ b/src/gameStateService/game-state-service.ts
@@ -20,7 +20,6 @@ export class GameStateService extends PubSub {
         GAMEPLAY_DATA_EVENT: string;
         GAME_PAUSE_STATUS_EVENT: string;
         GAME_TRAIL_EFFECT_TOGGLE_EVENT: string;
-        LEVEL_END_BACKGROUND_TOGGLE: string;
     }
     public data: null | DataModal;
     public canvas: null | HTMLCanvasElement;
@@ -69,7 +68,6 @@ export class GameStateService extends PubSub {
         great: string
     };
     public clickTrailToggle: boolean
-    private isLevelEndBackgroundVisible = false;
     constructor() {
         super();
         this.EVENTS = {
@@ -77,7 +75,6 @@ export class GameStateService extends PubSub {
             GAMEPLAY_DATA_EVENT: 'GAMEPLAY_DATA_EVENT',
             GAME_PAUSE_STATUS_EVENT: 'GAME_PAUSE_STATUS_EVENT',
             GAME_TRAIL_EFFECT_TOGGLE_EVENT: 'GAME_TRAIL_EFFECT_TOGGLE_EVENT', // To move this event on DOM Event once created.
-            LEVEL_END_BACKGROUND_TOGGLE: 'LEVEL_END_BACKGROUND_TOGGLE'
         };
         this.data = null;
         /* Canvas States */
@@ -106,15 +103,6 @@ export class GameStateService extends PubSub {
         this.subscribe(this.EVENTS.GAMEPLAY_DATA_EVENT, (data) => { this.gameStateGamePlayDataListener(data); });
         this.subscribe(this.EVENTS.GAME_PAUSE_STATUS_EVENT, (data) => { this.updateGamePauseActivity(data); });
         this.subscribe(this.EVENTS.GAME_TRAIL_EFFECT_TOGGLE_EVENT, (data) => { this.updateGameTrailToggle(data); }); // To move this event on DOM Event once created.
-    }
-
-    toggleLevelEndBackground(shouldShow: boolean) {
-        this.isLevelEndBackgroundVisible = shouldShow;
-        this.publish(this.EVENTS.LEVEL_END_BACKGROUND_TOGGLE, shouldShow);
-    }
-
-    isLevelendBackgroundVisible() {
-        return this.isLevelEndBackgroundVisible;
     }
 
     private gameStateGamePlayDataListener(updatedGamePlayData) {

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -81,11 +81,6 @@ export class SceneHandler {
     this.activeScene = this.scenes[key];
   }
 
-  // Call this method where necessary to hide the background when level ends
-  hideLevelEndScreen() {
-    gameStateService.toggleLevelEndBackground(false); // Publish hide event
-  }
-
   private timerWrapper = (callback: () => void, customTime:number = 800) => {
     //This is for reusable setTimeout with default 800 miliseconds.
     setTimeout(() => { callback(); }, customTime);
@@ -139,9 +134,6 @@ export class SceneHandler {
           )
         );
         this.gotoScene(SCENE_NAME_LEVEL_SELECT);
-        if (gameStateService.isLevelendBackgroundVisible()) { //check if level end background is present in DOM and hide it.
-          this.hideLevelEndScreen();
-        }
         this.titleTextElement.style.display = "none";
       }
     );
@@ -161,9 +153,6 @@ export class SceneHandler {
             reloadScene: this.switchSceneToGameplay
           })
         );
-        if (gameStateService.isLevelendBackgroundVisible()) { //check if level end background is present in DOM and hide it.
-          this.hideLevelEndScreen();
-        } 
         this.gotoScene(SCENE_NAME_GAME_PLAY);
       }
     );

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -81,6 +81,11 @@ export class SceneHandler {
     this.activeScene = this.scenes[key];
   }
 
+  // Call this method where necessary to hide the background when level ends
+  hideLevelEndScreen() {
+    gameStateService.toggleLevelEndBackground(false); // Publish hide event
+  }
+
   private timerWrapper = (callback: () => void, customTime:number = 800) => {
     //This is for reusable setTimeout with default 800 miliseconds.
     setTimeout(() => { callback(); }, customTime);
@@ -134,12 +139,15 @@ export class SceneHandler {
           )
         );
         this.gotoScene(SCENE_NAME_LEVEL_SELECT);
+        if (gameStateService.isLevelendBackgroundVisible()) { //check if level end background is present in DOM and hide it.
+          this.hideLevelEndScreen();
+        }
         this.titleTextElement.style.display = "none";
       }
     );
   };
 
-  switchSceneToGameplay = () => {
+  switchSceneToGameplay = () => {  
     this.timerWrapper(
       () => {
         this.addScene(
@@ -153,6 +161,9 @@ export class SceneHandler {
             reloadScene: this.switchSceneToGameplay
           })
         );
+        if (gameStateService.isLevelendBackgroundVisible()) { //check if level end background is present in DOM and hide it.
+          this.hideLevelEndScreen();
+        } 
         this.gotoScene(SCENE_NAME_GAME_PLAY);
       }
     );

--- a/src/scenes/levelend-scene.ts
+++ b/src/scenes/levelend-scene.ts
@@ -70,7 +70,7 @@ export class LevelEndScene {
     this.starCount = starCount;
     this.currentLevel = currentLevel;
     // Subscribe to the LEVEL_END_BACKGROUND_TOGGLE event
-    gameStateService.subscribe(gameStateService.EVENTS.LEVEL_END_BACKGROUND_TOGGLE, this.toggleLevelEndBackground);
+    this.toggleLevelEndBackground(true);
     this.isLastLevel =
       this.currentLevel !==
       this.data.levels[this.data.levels.length - 1].levelMeta.levelNumber &&
@@ -93,7 +93,7 @@ export class LevelEndScene {
 
   // Call this method where necessary to show the background when level ends
   showLevelEndScreen() {
-    gameStateService.toggleLevelEndBackground(true); // Publish show event
+    this.toggleLevelEndBackground(true); // Publish show event
     // Render the stars dynamically based on the star count
     this.renderStarsHTML();
   }
@@ -150,8 +150,15 @@ export class LevelEndScene {
   }
 
   private handlePublishEvent(shouldShowLoading: boolean, gamePlayData = null) {
-    gamePlayData && gameStateService.publish(gameStateService.EVENTS.GAMEPLAY_DATA_EVENT, gamePlayData);
+    if (gamePlayData) {
+      gameStateService.publish(gameStateService.EVENTS.GAMEPLAY_DATA_EVENT, gamePlayData);
+    }
     gameStateService.publish(gameStateService.EVENTS.SCENE_LOADING_EVENT, shouldShowLoading);
+    setTimeout(() => {
+      this.toggleLevelEndBackground(!shouldShowLoading);
+    },
+    800);
+
   }
 
   handleMouseClick = (event) => {

--- a/src/scenes/levelend-scene.ts
+++ b/src/scenes/levelend-scene.ts
@@ -1,5 +1,5 @@
 import { loadImages, CLICK, isDocumentVisible } from "@common";
-import { AudioPlayer, Monster } from "@components";
+import { AudioPlayer } from "@components";
 import { CloseButton, NextButton, RetryButton } from "@buttons";
 import {
   AUDIO_INTRO,
@@ -16,7 +16,6 @@ export class LevelEndScene {
   public height: number;
   public width: number;
   public context: CanvasRenderingContext2D;
-  public monster: Monster;
   public closeButton: CloseButton;
   public retryButton: RetryButton;
   public nextButton: NextButton;
@@ -70,27 +69,31 @@ export class LevelEndScene {
     this.audioPlayer = new AudioPlayer();
     this.starCount = starCount;
     this.currentLevel = currentLevel;
-
+    // Subscribe to the LEVEL_END_BACKGROUND_TOGGLE event
+    gameStateService.subscribe(gameStateService.EVENTS.LEVEL_END_BACKGROUND_TOGGLE, this.toggleLevelEndBackground);
     this.isLastLevel =
       this.currentLevel !==
       this.data.levels[this.data.levels.length - 1].levelMeta.levelNumber &&
       this.starCount >= 2;
-
-    this.monster = new Monster(
-      this.canvas,
-      monsterPhaseNumber,
-      this.switchToReactionAnimation
-    );
+    // this.monster = new Monster(
+    //   this.canvas,
+    //   monsterPhaseNumber,
+    //   this.switchToReactionAnimation
+    // );
     this.showLevelEndScreen();  // Display the level end screen
     this.addEventListener();
     this.renderStarsHTML();
   }
-
-  showLevelEndScreen() {
-    // Make the levelEnd element visible by setting display to block
+  // Method to show/hide the Level End background
+  toggleLevelEndBackground = (shouldShow: boolean) => {
     if (this.levelEndElement) {
-      this.levelEndElement.style.display = 'block';
+      this.levelEndElement.style.display = shouldShow ? 'block' : 'none';
     }
+  };
+
+  // Call this method where necessary to show the background when level ends
+  showLevelEndScreen() {
+    gameStateService.toggleLevelEndBackground(true); // Publish show event
     // Render the stars dynamically based on the star count
     this.renderStarsHTML();
   }
@@ -198,7 +201,7 @@ export class LevelEndScene {
   };
 
   dispose = () => {
-    this.monster.dispose();
+    // this.monster.dispose();
     this.audioPlayer.stopAllAudios();
     document
       .getElementById("canvas")


### PR DESCRIPTION
Create the Level End Scene UI in HTML, supporting DOM manipulation and other functionality.

# Changes
- The Level End Scene UI is built using HTML.
- DOM manipulation is supported for dynamic content display.
- The scene works consistently across all devices.

# How to test
- Open the app and select any level play the gameplay screen and complete each levels and go back to levels or move ahead to next level or play the level again.

Ref: [FM-302](https://curiouslearning.atlassian.net/browse/FM-302)


[FM-302]: https://curiouslearning.atlassian.net/browse/FM-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ