### PR TITLE
Feat: Refactor all the buttons on Level End screen from canvas to HTML  (FM-328)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
     </div>
     <div id="levelEnd" class="level-end-background">
       <div class="stars-container"></div>
-      <div class="buttons-container" id="buttons-container"></div>
+      <div class="buttons-container" id="levelEndButtons"></div>
     </div>
   </div>
   <script type="module" src="feedTheMonster.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -75,6 +75,7 @@
     </div>
     <div id="levelEnd" class="level-end-background">
       <div class="stars-container"></div>
+      <div class="buttons-container" id="buttons-container"></div>
     </div>
   </div>
   <script type="module" src="feedTheMonster.js"></script>

--- a/src/Firebase/firebase-event-interface.ts
+++ b/src/Firebase/firebase-event-interface.ts
@@ -36,3 +36,7 @@ export interface LevelCompletedEvent extends CommonEventProperties {
     number_of_successful_puzzles: number;
     duration: number;
 }  
+
+export interface levelEndButtonsCLick extends CommonEventProperties {
+    buttonType: string;
+}  

--- a/src/Firebase/firebase-integration.ts
+++ b/src/Firebase/firebase-integration.ts
@@ -1,5 +1,5 @@
 import { BaseFirebaseIntegration } from "./base-firebase-integration";
-import { DownloadCompleted, LevelCompletedEvent, PuzzleCompletedEvent, SelectedLevel, SessionEnd, SessionStart, TappedStart } from "./firebase-event-interface";
+import { DownloadCompleted, LevelCompletedEvent, levelEndButtonsCLick, PuzzleCompletedEvent, SelectedLevel, SessionEnd, SessionStart, TappedStart } from "./firebase-event-interface";
 
 export class FirebaseIntegration extends BaseFirebaseIntegration {
     static instance: FirebaseIntegration;
@@ -39,6 +39,10 @@ export class FirebaseIntegration extends BaseFirebaseIntegration {
     }
 
     public sendDownloadCompletedEvent(data: DownloadCompleted): void {
+        this.customEvents('download_completed', data);
+    }
+
+    public sendLevelEndButtonClick(data: levelEndButtonsCLick): void {
         this.customEvents('download_completed', data);
     }
 }

--- a/src/Firebase/firebase-integration.ts
+++ b/src/Firebase/firebase-integration.ts
@@ -1,5 +1,5 @@
 import { BaseFirebaseIntegration } from "./base-firebase-integration";
-import { DownloadCompleted, LevelCompletedEvent, levelEndButtonsCLick, PuzzleCompletedEvent, SelectedLevel, SessionEnd, SessionStart, TappedStart } from "./firebase-event-interface";
+import { DownloadCompleted, LevelCompletedEvent, PuzzleCompletedEvent, SelectedLevel, SessionEnd, SessionStart, TappedStart } from "./firebase-event-interface";
 
 export class FirebaseIntegration extends BaseFirebaseIntegration {
     static instance: FirebaseIntegration;
@@ -39,10 +39,6 @@ export class FirebaseIntegration extends BaseFirebaseIntegration {
     }
 
     public sendDownloadCompletedEvent(data: DownloadCompleted): void {
-        this.customEvents('download_completed', data);
-    }
-
-    public sendLevelEndButtonClick(data: levelEndButtonsCLick): void {
         this.customEvents('download_completed', data);
     }
 }

--- a/src/components/buttons/index.ts
+++ b/src/components/buttons/index.ts
@@ -3,7 +3,8 @@ import CloseButton from './close-button'; // once popup is applied. this will be
 import MapButton from './map-button/map-button';
 import CancelButton from './cancel-button'; // once popup is applied. this will be cancel-button component and this file can be removed
 import CancelButtonHtml from './cancel-button/cancel-button';
-import NextButton from './next-button';
+import NextButton from './next-button'; // once popup and levelend and level select buttons html is applied. this will be next-button-html component and this file can be removed
+import NextButtonHtml from './next-button/next-button';
 import PauseButton from './pause-button/pause-button';
 import RetryButton from './retry-button'; // once popup and levelend buttons html is applied. this will be retry-button-html component and this file can be removed
 import RetryButtonHtml from './retry-button/retry-button-html';
@@ -19,6 +20,7 @@ export {
   CancelButton,
   CancelButtonHtml,
   NextButton,
+  NextButtonHtml,
   PauseButton,
   RetryButton,
   RetryButtonHtml,

--- a/src/components/buttons/next-button/next-button.ts
+++ b/src/components/buttons/next-button/next-button.ts
@@ -1,0 +1,18 @@
+import {NEXT_BTN_IMG} from '@constants';
+import {
+  BaseButtonComponent,
+  ButtonOptions,
+} from '../base-button-component/base-button-component';
+
+export default class NextButtonHtml extends BaseButtonComponent {
+  constructor(options: Partial<ButtonOptions> = {}) {
+    super({
+      id: options.id || 'next-button',
+      className: options.className || 'next-button-image',
+      imageSrc: NEXT_BTN_IMG,
+      imageAlt: options.imageAlt || 'Next Icon',
+      targetId: options.targetId || 'game-control',
+      ...options, // Allows for additional overrides
+    });
+  }
+}

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -17,6 +17,10 @@ import {
 } from "@constants";
 import gameStateService from '@gameStateService';
 
+interface DrawableScene {
+  draw(deltaTime: number): void;
+}
+
 export class SceneHandler {
   private scenes: {
     LOADING_TRANSITION?: LoadingScene;
@@ -82,8 +86,12 @@ export class SceneHandler {
   }
 
   private timerWrapper = (callback: () => void, customTime:number = 800) => {
-    //This is for reusable setTimeout with default 800 miliseconds.
+    //This is for reusable setTimeout with default 800 milliseconds.
     setTimeout(() => { callback(); }, customTime);
+  }
+
+  private isDrawable(scene: any): scene is DrawableScene {
+    return typeof scene?.draw === "function";
   }
 
   startAnimationLoop() {
@@ -118,8 +126,14 @@ export class SceneHandler {
     const deltaTime = timeStamp - this.lastTime;
     this.lastTime = timeStamp;
     this.context.clearRect(0, 0, this.width, this.height);
-    this.scenes[LOADING_TRANSITION].draw(deltaTime);
-    this.activeScene.draw(deltaTime);
+
+    if (this.isDrawable(this.scenes[LOADING_TRANSITION])) {
+      this.scenes[LOADING_TRANSITION].draw(deltaTime);
+    }
+
+    if (this.isDrawable(this.activeScene)) {
+      this.activeScene.draw(deltaTime);
+    }
   };
 
   switchSceneToLevelSelection = () => {

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -17,10 +17,6 @@ import {
 } from "@constants";
 import gameStateService from '@gameStateService';
 
-interface DrawableScene {
-  draw(deltaTime: number): void;
-}
-
 export class SceneHandler {
   private scenes: {
     LOADING_TRANSITION?: LoadingScene;
@@ -86,12 +82,8 @@ export class SceneHandler {
   }
 
   private timerWrapper = (callback: () => void, customTime:number = 800) => {
-    //This is for reusable setTimeout with default 800 milliseconds.
+    //This is for reusable setTimeout with default 800 miliseconds.
     setTimeout(() => { callback(); }, customTime);
-  }
-
-  private isDrawable(scene: any): scene is DrawableScene {
-    return typeof scene?.draw === "function";
   }
 
   startAnimationLoop() {
@@ -126,12 +118,12 @@ export class SceneHandler {
     const deltaTime = timeStamp - this.lastTime;
     this.lastTime = timeStamp;
     this.context.clearRect(0, 0, this.width, this.height);
-
-    if (this.isDrawable(this.scenes[LOADING_TRANSITION])) {
-      this.scenes[LOADING_TRANSITION].draw(deltaTime);
-    }
-
-    if (this.isDrawable(this.activeScene)) {
+    this.scenes[LOADING_TRANSITION].draw(deltaTime);
+    
+    if (this.activeScene instanceof StartScene || 
+      this.activeScene instanceof LevelSelectionScreen || 
+      this.activeScene instanceof GameplayScene || 
+      this.activeScene instanceof LoadingScene) {
       this.activeScene.draw(deltaTime);
     }
   };

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -170,10 +170,8 @@ export class SceneHandler {
         this.addScene(
           SCENE_NAME_LEVEL_END,
           new LevelEndScene(
-            this.canvas, //to do - use DAO.
             this.height, //to do - use DAO.
             this.width, //to do - use DAO.
-            this.context, //to do - use DAO.
             starCount, //to do - use DAO.
             currentLevelNumber, //to do - use DAO.
             this.switchSceneToGameplay,

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -119,13 +119,8 @@ export class SceneHandler {
     this.lastTime = timeStamp;
     this.context.clearRect(0, 0, this.width, this.height);
     this.scenes[LOADING_TRANSITION].draw(deltaTime);
-    
-    if (this.activeScene instanceof StartScene || 
-      this.activeScene instanceof LevelSelectionScreen || 
-      this.activeScene instanceof GameplayScene || 
-      this.activeScene instanceof LoadingScene) {
-      this.activeScene.draw(deltaTime);
-    }
+
+    this.activeScene && !(this.activeScene instanceof LevelEndScene) && this.activeScene.draw(deltaTime);
   };
 
   switchSceneToLevelSelection = () => {

--- a/src/scenes/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene.ts
@@ -197,7 +197,7 @@ export class GameplayScene {
 
     this.setupBg();
     this.gameControl = document.getElementById("game-control") as HTMLCanvasElement;
-    this.gameControl.style.zIndex = "5"
+    this.gameControl.style.zIndex = "9"
   }
 
   private setupBg = () => {

--- a/src/scenes/index.ts
+++ b/src/scenes/index.ts
@@ -1,6 +1,6 @@
 import { GameplayScene } from "./gameplay-scene";
 import { LevelSelectionScreen } from "./level-selection-scene";
-import { LevelEndScene } from "./levelend-scene";
+import { LevelEndScene } from "./levelend-scene/levelend-scene";
 import { LoadingScene } from "./loading-scene";
 import { StartScene } from "./start-scene";
 import { TestGameplayScene } from "./test-gameplay-scene";

--- a/src/scenes/levelend-scene/levelend-scene.scss
+++ b/src/scenes/levelend-scene/levelend-scene.scss
@@ -1,0 +1,8 @@
+.buttons-container {
+  position: absolute;
+  width: 100%;
+  bottom: 100px;
+  display: flex;
+  gap: 40px;
+  justify-content: center;
+}

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,6 +1,6 @@
-import {MapButton, RetryButtonHtml, NextButtonHtml} from '@components/buttons';
+import { MapButton, RetryButtonHtml, NextButtonHtml } from '@components/buttons';
 
-describe('LevelEndScene Buttons', () => {
+describe('LevelEndScreen', () => {
   let mockSwitchToGameplayCB: jest.Mock;
   let mockSwitchToLevelSelectionCB: jest.Mock;
   let mockData: any;
@@ -10,7 +10,7 @@ describe('LevelEndScene Buttons', () => {
     mockSwitchToGameplayCB = jest.fn();
     mockSwitchToLevelSelectionCB = jest.fn();
     mockData = {
-      levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
+      levels: [{ levelMeta: { levelNumber: 1 } }, { levelMeta: { levelNumber: 2 } }],
     };
 
     const buttonsContainer = document.createElement('div');
@@ -24,13 +24,10 @@ describe('LevelEndScene Buttons', () => {
 
   function renderButton(
     id: string,
-    ButtonClass:
-      | typeof MapButton
-      | typeof RetryButtonHtml
-      | typeof NextButtonHtml,
-    onClick: () => void,
+    ButtonClass: typeof MapButton | typeof RetryButtonHtml | typeof NextButtonHtml,
+    onClick: () => void
   ) {
-    const button = new ButtonClass({targetId: 'levelEndButtons', id});
+    const button = new ButtonClass({ targetId: 'levelEndButtons', id });
     button.onClick(onClick);
   }
 
@@ -38,7 +35,7 @@ describe('LevelEndScene Buttons', () => {
     renderButton('levelend-map-btn', MapButton, mockSwitchToLevelSelectionCB);
     renderButton('levelend-retry-btn', RetryButtonHtml, () => {
       mockSwitchToGameplayCB({
-        currentLevelData: {...mockData.levels[1], levelNumber: 1},
+        currentLevelData: { ...mockData.levels[1], levelNumber: 1 },
         selectedLevelNumber: 1,
       });
     });
@@ -57,57 +54,61 @@ describe('LevelEndScene Buttons', () => {
     }
   }
 
-  describe('Button Rendering', () => {
-    it('should render MapButton and RetryButtonHtml by default', () => {
-      renderButtonsHTML(true);
-      expect(document.getElementById('levelend-map-btn')).not.toBeNull();
-      expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
-    });
+  describe('Given Default parameters', () => {
+    describe('When LevelEndScene renders', () => {
+      it('it should render MapButton', () => {
+        renderButtonsHTML(true);
+        expect(document.getElementById('levelend-map-btn')).not.toBeNull();
+      });
 
-    it('should render NextButtonHtml only if isLastLevel is false', () => {
-      renderButtonsHTML(false);
-      expect(document.getElementById('levelend-next-btn')).not.toBeNull();
-    });
+      it('it should render RetryButtonHtml', () => {
+        renderButtonsHTML(true);
+        expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
+      });
 
-    it('should not render NextButtonHtml if isLastLevel is true', () => {
-      renderButtonsHTML(true);
-      expect(document.getElementById('levelend-next-btn')).toBeNull();
-    });
-  });
+      it('it should render NextButtonHtml if isLastLevel is false', () => {
+        renderButtonsHTML(false);
+        expect(document.getElementById('levelend-next-btn')).not.toBeNull();
+      });
 
-  describe('Button Click Callbacks', () => {
-    it('should call switchToLevelSelectionCB when MapButton is clicked', () => {
-      renderButtonsHTML(true);
-      const mapButton = document.getElementById(
-        'levelend-map-btn',
-      ) as HTMLButtonElement;
-      mapButton.click();
-      expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
-    });
-
-    it('should call switchToGameplayCB with correct data when RetryButtonHtml is clicked', () => {
-      renderButtonsHTML(true);
-      const retryButton = document.getElementById(
-        'levelend-retry-btn',
-      ) as HTMLButtonElement;
-      retryButton.click();
-
-      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-        currentLevelData: {...mockData.levels[1], levelNumber: 1},
-        selectedLevelNumber: 1,
+      it('it should not render NextButtonHtml if isLastLevel is true', () => {
+        renderButtonsHTML(true);
+        expect(document.getElementById('levelend-next-btn')).toBeNull();
       });
     });
 
-    it('should call switchToGameplayCB with correct data when NextButtonHtml is clicked if isLastLevel is false', () => {
-      renderButtonsHTML(false);
-      const nextButton = document.getElementById(
-        'levelend-next-btn',
-      ) as HTMLButtonElement;
-      nextButton.click();
+    describe('When clicking MapButton', () => {
+      it('it should call switchToLevelSelectionCB', () => {
+        renderButtonsHTML(true);
+        const mapButton = document.getElementById('levelend-map-btn') as HTMLButtonElement;
+        mapButton.click();
+        expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
+      });
+    });
 
-      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-        currentLevelData: {...mockData.levels[2], levelNumber: 2},
-        selectedLevelNumber: 2,
+    describe('When clicking RetryButtonHtml', () => {
+      it('it should call switchToGameplayCB with correct data', () => {
+        renderButtonsHTML(true);
+        const retryButton = document.getElementById('levelend-retry-btn') as HTMLButtonElement;
+        retryButton.click();
+
+        expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+          currentLevelData: { ...mockData.levels[1], levelNumber: 1 },
+          selectedLevelNumber: 1,
+        });
+      });
+    });
+
+    describe('When clicking NextButtonHtml', () => {
+      it('it should call switchToGameplayCB with correct data if isLastLevel is false', () => {
+        renderButtonsHTML(false);
+        const nextButton = document.getElementById('levelend-next-btn') as HTMLButtonElement;
+        nextButton.click();
+
+        expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+          currentLevelData: { ...mockData.levels[2], levelNumber: 2 },
+          selectedLevelNumber: 2,
+        });
       });
     });
   });

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,4 +1,3 @@
-import { MapButton, RetryButtonHtml, NextButtonHtml } from '@components/buttons';
 import { LevelEndScene } from './levelend-scene';
 
 describe('LevelEndScreen', () => {

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -14,7 +14,7 @@ describe('LevelEndScene Buttons', () => {
     };
 
     const buttonsContainer = document.createElement('div');
-    buttonsContainer.id = 'buttons-container';
+    buttonsContainer.id = 'levelEndButtons';
     document.body.appendChild(buttonsContainer);
   });
 
@@ -30,7 +30,7 @@ describe('LevelEndScene Buttons', () => {
       | typeof NextButtonHtml,
     onClick: () => void,
   ) {
-    const button = new ButtonClass({targetId: 'buttons-container', id});
+    const button = new ButtonClass({targetId: 'levelEndButtons', id});
     button.onClick(onClick);
   }
 

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,21 +1,85 @@
-import { MapButton, RetryButtonHtml, NextButtonHtml } from '@components/buttons';
+import {MapButton, RetryButtonHtml, NextButtonHtml} from '@components/buttons';
+import {LevelEndScene} from './levelend-scene';
+
+// Mock the getContext method on HTMLCanvasElement to avoid "not implemented" errors
+beforeAll(() => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    value: () => ({
+      fillRect: jest.fn(),
+      clearRect: jest.fn(),
+      getImageData: jest.fn(),
+      putImageData: jest.fn(),
+      createImageData: jest.fn(),
+      setTransform: jest.fn(),
+      drawImage: jest.fn(),
+      save: jest.fn(),
+      fillText: jest.fn(),
+      restore: jest.fn(),
+      beginPath: jest.fn(),
+      moveTo: jest.fn(),
+      lineTo: jest.fn(),
+      closePath: jest.fn(),
+      stroke: jest.fn(),
+      translate: jest.fn(),
+      scale: jest.fn(),
+      rotate: jest.fn(),
+      arc: jest.fn(),
+      fill: jest.fn(),
+      measureText: jest.fn(() => ({width: 0})),
+      transform: jest.fn(),
+      rect: jest.fn(),
+      clip: jest.fn(),
+    }),
+  });
+});
 
 describe('LevelEndScreen', () => {
   let mockSwitchToGameplayCB: jest.Mock;
   let mockSwitchToLevelSelectionCB: jest.Mock;
   let mockData: any;
+  let levelEndScene: LevelEndScene;
 
   beforeEach(() => {
     document.body.innerHTML = '';
     mockSwitchToGameplayCB = jest.fn();
     mockSwitchToLevelSelectionCB = jest.fn();
     mockData = {
-      levels: [{ levelMeta: { levelNumber: 1 } }, { levelMeta: { levelNumber: 2 } }],
+      levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
     };
 
     const buttonsContainer = document.createElement('div');
     buttonsContainer.id = 'levelEndButtons';
     document.body.appendChild(buttonsContainer);
+
+    const starsContainer = document.createElement('div');
+    starsContainer.className = 'stars-container';
+    document.body.appendChild(starsContainer);
+
+    const levelEndElement = document.createElement('div');
+    levelEndElement.id = 'levelEnd';
+    document.body.appendChild(levelEndElement);
+
+    const gameControlElement = document.createElement('div');
+    gameControlElement.id = 'game-control';
+    document.body.appendChild(gameControlElement);
+
+    const mockCanvas = document.createElement('canvas');
+    mockCanvas.id = 'canvas';
+    document.body.appendChild(mockCanvas);
+    const mockContext = mockCanvas.getContext('2d');
+
+    levelEndScene = new LevelEndScene(
+      mockCanvas,
+      600, // height
+      800, // width
+      mockContext,
+      3, // starCount
+      1, // currentLevel
+      mockSwitchToGameplayCB,
+      mockSwitchToLevelSelectionCB,
+      mockData,
+      1, // monsterPhaseNumber
+    );
   });
 
   afterEach(() => {
@@ -24,10 +88,13 @@ describe('LevelEndScreen', () => {
 
   function renderButton(
     id: string,
-    ButtonClass: typeof MapButton | typeof RetryButtonHtml | typeof NextButtonHtml,
-    onClick: () => void
+    ButtonClass:
+      | typeof MapButton
+      | typeof RetryButtonHtml
+      | typeof NextButtonHtml,
+    onClick: () => void,
   ) {
-    const button = new ButtonClass({ targetId: 'levelEndButtons', id });
+    const button = new ButtonClass({targetId: 'levelEndButtons', id});
     button.onClick(onClick);
   }
 
@@ -39,7 +106,7 @@ describe('LevelEndScreen', () => {
         selectedLevelNumber: 1,
       });
     });
-
+  
     if (!isLastLevel) {
       renderButton('levelend-next-btn', NextButtonHtml, () => {
         const nextLevel = 2;
@@ -51,18 +118,21 @@ describe('LevelEndScreen', () => {
           selectedLevelNumber: nextLevel,
         });
       });
+    } else {
+      document.getElementById('levelend-next-btn').remove();
     }
   }
+  
 
   describe('Given Default parameters', () => {
     describe('When LevelEndScene renders', () => {
       it('it should render MapButton', () => {
-        renderButtonsHTML(true);
+        renderButtonsHTML(false);
         expect(document.getElementById('levelend-map-btn')).not.toBeNull();
       });
 
       it('it should render RetryButtonHtml', () => {
-        renderButtonsHTML(true);
+        renderButtonsHTML(false);
         expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
       });
 
@@ -71,16 +141,21 @@ describe('LevelEndScreen', () => {
         expect(document.getElementById('levelend-next-btn')).not.toBeNull();
       });
 
-      it('it should not render NextButtonHtml if isLastLevel is true', () => {
-        renderButtonsHTML(true);
-        expect(document.getElementById('levelend-next-btn')).toBeNull();
+      it('should not render NextButtonHtml if isLastLevel is true', () => {
+        renderButtonsHTML(true); // Pass true to simulate the last level
+      
+        const nextButton = document.getElementById('levelend-next-btn');
+        console.log(nextButton);
+        expect(nextButton).toBeNull(); // Confirm the button does not exist
       });
     });
 
     describe('When clicking MapButton', () => {
       it('it should call switchToLevelSelectionCB', () => {
         renderButtonsHTML(true);
-        const mapButton = document.getElementById('levelend-map-btn') as HTMLButtonElement;
+        const mapButton = document.getElementById(
+          'levelend-map-btn',
+        ) as HTMLButtonElement;
         mapButton.click();
         expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
       });
@@ -89,11 +164,13 @@ describe('LevelEndScreen', () => {
     describe('When clicking RetryButtonHtml', () => {
       it('it should call switchToGameplayCB with correct data', () => {
         renderButtonsHTML(true);
-        const retryButton = document.getElementById('levelend-retry-btn') as HTMLButtonElement;
+        const retryButton = document.getElementById(
+          'levelend-retry-btn',
+        ) as HTMLButtonElement;
         retryButton.click();
 
         expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-          currentLevelData: { ...mockData.levels[1], levelNumber: 1 },
+          currentLevelData: {...mockData.levels[1], levelNumber: 1},
           selectedLevelNumber: 1,
         });
       });
@@ -102,11 +179,13 @@ describe('LevelEndScreen', () => {
     describe('When clicking NextButtonHtml', () => {
       it('it should call switchToGameplayCB with correct data if isLastLevel is false', () => {
         renderButtonsHTML(false);
-        const nextButton = document.getElementById('levelend-next-btn') as HTMLButtonElement;
+        const nextButton = document.getElementById(
+          'levelend-next-btn',
+        ) as HTMLButtonElement;
         nextButton.click();
 
         expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-          currentLevelData: { ...mockData.levels[2], levelNumber: 2 },
+          currentLevelData: {...mockData.levels[2], levelNumber: 2},
           selectedLevelNumber: 2,
         });
       });

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,5 +1,5 @@
-import {MapButton, RetryButtonHtml, NextButtonHtml} from '@components/buttons';
-import {LevelEndScene} from './levelend-scene';
+import { MapButton, RetryButtonHtml, NextButtonHtml } from '@components/buttons';
+import { LevelEndScene } from './levelend-scene';
 
 describe('LevelEndScreen', () => {
   let mockSwitchToGameplayCB: jest.Mock;
@@ -7,147 +7,160 @@ describe('LevelEndScreen', () => {
   let mockData: any;
   let levelEndScene: LevelEndScene;
 
-  describe('Given Default', () => {
-    beforeEach(() => {
-      document.body.innerHTML = '';
-      mockSwitchToGameplayCB = jest.fn();
-      mockSwitchToLevelSelectionCB = jest.fn();
-      mockData = {
-        levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
-      };
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mockSwitchToGameplayCB = jest.fn();
+    mockSwitchToLevelSelectionCB = jest.fn();
+    mockData = {
+      levels: [
+        {
+          levelMeta: {
+            promptFadeOut: 0,
+            letterGroup: 18,
+            levelNumber: 1,
+            protoType: 'Visible',
+            levelType: 'LetterInWord',
+          },
+          puzzles: [],
+        },
+        {
+          levelMeta: {
+            promptFadeOut: 0,
+            letterGroup: 19,
+            levelNumber: 2,
+            protoType: 'Visible',
+            levelType: 'LetterInWord',
+          },
+          puzzles: [],
+        },
+      ],
+    };
 
-      const buttonsContainer = document.createElement('div');
-      buttonsContainer.id = 'levelEndButtons';
-      document.body.appendChild(buttonsContainer);
+    const buttonsContainer = document.createElement('div');
+    buttonsContainer.id = 'levelEndButtons';
+    document.body.appendChild(buttonsContainer);
 
-      const starsContainer = document.createElement('div');
-      starsContainer.className = 'stars-container';
-      document.body.appendChild(starsContainer);
+    const starsContainer = document.createElement('div');
+    starsContainer.className = 'stars-container';
+    document.body.appendChild(starsContainer);
 
-      const levelEndElement = document.createElement('div');
-      levelEndElement.id = 'levelEnd';
-      document.body.appendChild(levelEndElement);
+    const levelEndElement = document.createElement('div');
+    levelEndElement.id = 'levelEnd';
+    document.body.appendChild(levelEndElement);
 
-      const gameControlElement = document.createElement('div');
-      gameControlElement.id = 'game-control';
-      document.body.appendChild(gameControlElement);
+    const gameControlElement = document.createElement('div');
+    gameControlElement.id = 'game-control';
+    document.body.appendChild(gameControlElement);
+
+    levelEndScene = new LevelEndScene(
+      600, // height
+      800, // width
+      3, // starCount
+      1, // currentLevel
+      mockSwitchToGameplayCB,
+      mockSwitchToLevelSelectionCB,
+      mockData,
+      1, // monsterPhaseNumber
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('When instantiated', () => {
+    it('should call showLevelEndScreen', () => {
+      const initSpy = jest.spyOn(LevelEndScene.prototype, 'showLevelEndScreen');
+
+      // Re-instantiate to trigger the constructor after spying on the method
+      levelEndScene = new LevelEndScene(
+        600, // height
+        800, // width
+        3, // starCount
+        1, // currentLevel
+        mockSwitchToGameplayCB,
+        mockSwitchToLevelSelectionCB,
+        mockData,
+        1, // monsterPhaseNumber
+      );
+
+      expect(initSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Levelend buttons rendering', () => {
+    it('should render MapButton', () => {
+      levelEndScene.renderButtonsHTML();
+      expect(document.getElementById('levelend-map-btn')).not.toBeNull();
     });
 
-    afterEach(() => {
-      document.body.innerHTML = '';
+    it('should call switchToLevelSelectionCB when Map button is clicked', () => {
+      levelEndScene.renderButtonsHTML();
+      const mapButton = document.getElementById('levelend-map-btn') as HTMLButtonElement;
+      mapButton.click();
+      expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
     });
 
-    function renderButton(
-      id: string,
-      ButtonClass:
-        | typeof MapButton
-        | typeof RetryButtonHtml
-        | typeof NextButtonHtml,
-      onClick: () => void,
-    ) {
-      const button = new ButtonClass({targetId: 'levelEndButtons', id});
-      button.onClick(onClick);
-    }
+    it('should render RetryButtonHtml', () => {
+      levelEndScene.renderButtonsHTML();
+      expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
+    });
 
-    function renderButtonsHTML(isLastLevel: boolean) {
-      renderButton('levelend-map-btn', MapButton, mockSwitchToLevelSelectionCB);
-      renderButton('levelend-retry-btn', RetryButtonHtml, () => {
-        mockSwitchToGameplayCB({
-          currentLevelData: {...mockData.levels[1], levelNumber: 1},
-          selectedLevelNumber: 1,
-        });
-      });
+    it('should call switchToGameplayCB with correct data when Retry button is clicked', () => {
+      levelEndScene.renderButtonsHTML();
+      const retryButton = document.getElementById('levelend-retry-btn') as HTMLButtonElement;
+      retryButton.click();
 
-      if (!isLastLevel) {
-        renderButton('levelend-next-btn', NextButtonHtml, () => {
-          const nextLevel = 2;
-          mockSwitchToGameplayCB({
-            currentLevelData: {
-              ...mockData.levels[nextLevel],
-              levelNumber: nextLevel,
-            },
-            selectedLevelNumber: nextLevel,
-          });
-        });
-      }
-    }
-
-    describe('When instantiated', () => {
-      it('should call showLevelEndScreen', () => {
-        const initSpy = jest.spyOn(LevelEndScene.prototype, 'showLevelEndScreen');
-        levelEndScene = new LevelEndScene(
-          600, // height
-          800, // width
-          3, // starCount
-          1, // currentLevel
-          mockSwitchToGameplayCB,
-          mockSwitchToLevelSelectionCB,
-          mockData,
-          1, // monsterPhaseNumber
-        );
-        jest.runAllTimers();
-        expect(initSpy).toHaveBeenCalled();
+      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+        currentLevelData: {
+          levelMeta: {
+            promptFadeOut: 0,
+            letterGroup: 18,
+            levelNumber: 1,
+            protoType: 'Visible',
+            levelType: 'LetterInWord',
+          },
+          puzzles: [],
+          levelNumber: 1,
+        },
+        selectedLevelNumber: 1,
       });
     });
 
-    describe('Levelend buttons should be now HTML', () => {
-      it('it should render MapButton', () => {
-        renderButtonsHTML(false);
-        expect(document.getElementById('levelend-map-btn')).not.toBeNull();
+    it('should render NextButtonHtml if isLastLevel is false', () => {
+      levelEndScene.isLastLevel = false; // Explicitly set to false
+      levelEndScene.renderButtonsHTML();
+      expect(document.getElementById('levelend-next-btn')).not.toBeNull();
+    });
+
+    it('should call switchToGameplayCB with correct data when Next button is clicked', () => {
+      levelEndScene.isLastLevel = false; // Ensure it’s not the last level
+      levelEndScene.renderButtonsHTML();
+      const nextButton = document.getElementById('levelend-next-btn') as HTMLButtonElement;
+      nextButton.click();
+
+      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+        currentLevelData: {
+          levelMeta: {
+            promptFadeOut: 0,
+            letterGroup: 19,
+            levelNumber: 2,
+            protoType: 'Visible',
+            levelType: 'LetterInWord',
+          },
+          puzzles: [],
+          levelNumber: 2,
+        },
+        selectedLevelNumber: 2,
       });
+    });
 
-      it('it should call switchToLevelSelectionCB when Map button is clicked', () => {
-        renderButtonsHTML(true);
-        const mapButton = document.getElementById(
-          'levelend-map-btn',
-        ) as HTMLButtonElement;
-        mapButton.click();
-        expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
-      });
+    it('should not render NextButtonHtml if isLastLevel is true', () => {
+      levelEndScene.isLastLevel = true; // Simulate last level scenario
+      levelEndScene.renderButtonsHTML();
 
-      it('it should render RetryButtonHtml', () => {
-        renderButtonsHTML(false);
-        expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
-      });
-
-      it('it should call switchToGameplayCB with correct data when Retry button is clicked', () => {
-        renderButtonsHTML(true);
-        const retryButton = document.getElementById(
-          'levelend-retry-btn',
-        ) as HTMLButtonElement;
-        retryButton.click();
-
-        expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-          currentLevelData: {...mockData.levels[1], levelNumber: 1},
-          selectedLevelNumber: 1,
-        });
-      });
-
-      it('it should render NextButtonHtml if isLastLevel is false', () => {
-        renderButtonsHTML(false);
-        expect(document.getElementById('levelend-next-btn')).not.toBeNull();
-      });
-
-      it('it should call switchToGameplayCB with correct data if isLastLevel is false when Next Button is clicked', () => {
-        renderButtonsHTML(false);
-        const nextButton = document.getElementById(
-          'levelend-next-btn',
-        ) as HTMLButtonElement;
-        nextButton.click();
-
-        expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
-          currentLevelData: {...mockData.levels[2], levelNumber: 2},
-          selectedLevelNumber: 2,
-        });
-      });
-
-      it('should not render NextButtonHtml if isLastLevel is true', () => {
-        renderButtonsHTML(true); // Pass true to simulate the last level
-
-        const nextButton = document.getElementById('levelend-next-btn');
-        console.log(nextButton);
-        expect(nextButton).toBeNull(); // Confirm the button does not exist
-      });
+      const nextButton = document.getElementById('levelend-next-btn');
+      expect(nextButton).toBeNull(); // Confirm the button does not exist
     });
   });
 });

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,0 +1,114 @@
+import {MapButton, RetryButtonHtml, NextButtonHtml} from '@components/buttons';
+
+describe('LevelEndScene Buttons', () => {
+  let mockSwitchToGameplayCB: jest.Mock;
+  let mockSwitchToLevelSelectionCB: jest.Mock;
+  let mockData: any;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mockSwitchToGameplayCB = jest.fn();
+    mockSwitchToLevelSelectionCB = jest.fn();
+    mockData = {
+      levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
+    };
+
+    const buttonsContainer = document.createElement('div');
+    buttonsContainer.id = 'buttons-container';
+    document.body.appendChild(buttonsContainer);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function renderButton(
+    id: string,
+    ButtonClass:
+      | typeof MapButton
+      | typeof RetryButtonHtml
+      | typeof NextButtonHtml,
+    onClick: () => void,
+  ) {
+    const button = new ButtonClass({targetId: 'buttons-container', id});
+    button.onClick(onClick);
+  }
+
+  function renderButtonsHTML(isLastLevel: boolean) {
+    renderButton('levelend-map-btn', MapButton, mockSwitchToLevelSelectionCB);
+    renderButton('levelend-retry-btn', RetryButtonHtml, () => {
+      mockSwitchToGameplayCB({
+        currentLevelData: {...mockData.levels[1], levelNumber: 1},
+        selectedLevelNumber: 1,
+      });
+    });
+
+    if (!isLastLevel) {
+      renderButton('levelend-next-btn', NextButtonHtml, () => {
+        const nextLevel = 2;
+        mockSwitchToGameplayCB({
+          currentLevelData: {
+            ...mockData.levels[nextLevel],
+            levelNumber: nextLevel,
+          },
+          selectedLevelNumber: nextLevel,
+        });
+      });
+    }
+  }
+
+  describe('Button Rendering', () => {
+    it('should render MapButton and RetryButtonHtml by default', () => {
+      renderButtonsHTML(true);
+      expect(document.getElementById('levelend-map-btn')).not.toBeNull();
+      expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
+    });
+
+    it('should render NextButtonHtml only if isLastLevel is false', () => {
+      renderButtonsHTML(false);
+      expect(document.getElementById('levelend-next-btn')).not.toBeNull();
+    });
+
+    it('should not render NextButtonHtml if isLastLevel is true', () => {
+      renderButtonsHTML(true);
+      expect(document.getElementById('levelend-next-btn')).toBeNull();
+    });
+  });
+
+  describe('Button Click Callbacks', () => {
+    it('should call switchToLevelSelectionCB when MapButton is clicked', () => {
+      renderButtonsHTML(true);
+      const mapButton = document.getElementById(
+        'levelend-map-btn',
+      ) as HTMLButtonElement;
+      mapButton.click();
+      expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
+    });
+
+    it('should call switchToGameplayCB with correct data when RetryButtonHtml is clicked', () => {
+      renderButtonsHTML(true);
+      const retryButton = document.getElementById(
+        'levelend-retry-btn',
+      ) as HTMLButtonElement;
+      retryButton.click();
+
+      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+        currentLevelData: {...mockData.levels[1], levelNumber: 1},
+        selectedLevelNumber: 1,
+      });
+    });
+
+    it('should call switchToGameplayCB with correct data when NextButtonHtml is clicked if isLastLevel is false', () => {
+      renderButtonsHTML(false);
+      const nextButton = document.getElementById(
+        'levelend-next-btn',
+      ) as HTMLButtonElement;
+      nextButton.click();
+
+      expect(mockSwitchToGameplayCB).toHaveBeenCalledWith({
+        currentLevelData: {...mockData.levels[2], levelNumber: 2},
+        selectedLevelNumber: 2,
+      });
+    });
+  });
+});

--- a/src/scenes/levelend-scene/levelend-scene.spec.ts
+++ b/src/scenes/levelend-scene/levelend-scene.spec.ts
@@ -1,157 +1,102 @@
 import {MapButton, RetryButtonHtml, NextButtonHtml} from '@components/buttons';
 import {LevelEndScene} from './levelend-scene';
 
-// Mock the getContext method on HTMLCanvasElement to avoid "not implemented" errors
-beforeAll(() => {
-  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-    value: () => ({
-      fillRect: jest.fn(),
-      clearRect: jest.fn(),
-      getImageData: jest.fn(),
-      putImageData: jest.fn(),
-      createImageData: jest.fn(),
-      setTransform: jest.fn(),
-      drawImage: jest.fn(),
-      save: jest.fn(),
-      fillText: jest.fn(),
-      restore: jest.fn(),
-      beginPath: jest.fn(),
-      moveTo: jest.fn(),
-      lineTo: jest.fn(),
-      closePath: jest.fn(),
-      stroke: jest.fn(),
-      translate: jest.fn(),
-      scale: jest.fn(),
-      rotate: jest.fn(),
-      arc: jest.fn(),
-      fill: jest.fn(),
-      measureText: jest.fn(() => ({width: 0})),
-      transform: jest.fn(),
-      rect: jest.fn(),
-      clip: jest.fn(),
-    }),
-  });
-});
-
 describe('LevelEndScreen', () => {
   let mockSwitchToGameplayCB: jest.Mock;
   let mockSwitchToLevelSelectionCB: jest.Mock;
   let mockData: any;
   let levelEndScene: LevelEndScene;
 
-  beforeEach(() => {
-    document.body.innerHTML = '';
-    mockSwitchToGameplayCB = jest.fn();
-    mockSwitchToLevelSelectionCB = jest.fn();
-    mockData = {
-      levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
-    };
+  describe('Given Default', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+      mockSwitchToGameplayCB = jest.fn();
+      mockSwitchToLevelSelectionCB = jest.fn();
+      mockData = {
+        levels: [{levelMeta: {levelNumber: 1}}, {levelMeta: {levelNumber: 2}}],
+      };
 
-    const buttonsContainer = document.createElement('div');
-    buttonsContainer.id = 'levelEndButtons';
-    document.body.appendChild(buttonsContainer);
+      const buttonsContainer = document.createElement('div');
+      buttonsContainer.id = 'levelEndButtons';
+      document.body.appendChild(buttonsContainer);
 
-    const starsContainer = document.createElement('div');
-    starsContainer.className = 'stars-container';
-    document.body.appendChild(starsContainer);
+      const starsContainer = document.createElement('div');
+      starsContainer.className = 'stars-container';
+      document.body.appendChild(starsContainer);
 
-    const levelEndElement = document.createElement('div');
-    levelEndElement.id = 'levelEnd';
-    document.body.appendChild(levelEndElement);
+      const levelEndElement = document.createElement('div');
+      levelEndElement.id = 'levelEnd';
+      document.body.appendChild(levelEndElement);
 
-    const gameControlElement = document.createElement('div');
-    gameControlElement.id = 'game-control';
-    document.body.appendChild(gameControlElement);
-
-    const mockCanvas = document.createElement('canvas');
-    mockCanvas.id = 'canvas';
-    document.body.appendChild(mockCanvas);
-    const mockContext = mockCanvas.getContext('2d');
-
-    levelEndScene = new LevelEndScene(
-      mockCanvas,
-      600, // height
-      800, // width
-      mockContext,
-      3, // starCount
-      1, // currentLevel
-      mockSwitchToGameplayCB,
-      mockSwitchToLevelSelectionCB,
-      mockData,
-      1, // monsterPhaseNumber
-    );
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = '';
-  });
-
-  function renderButton(
-    id: string,
-    ButtonClass:
-      | typeof MapButton
-      | typeof RetryButtonHtml
-      | typeof NextButtonHtml,
-    onClick: () => void,
-  ) {
-    const button = new ButtonClass({targetId: 'levelEndButtons', id});
-    button.onClick(onClick);
-  }
-
-  function renderButtonsHTML(isLastLevel: boolean) {
-    renderButton('levelend-map-btn', MapButton, mockSwitchToLevelSelectionCB);
-    renderButton('levelend-retry-btn', RetryButtonHtml, () => {
-      mockSwitchToGameplayCB({
-        currentLevelData: { ...mockData.levels[1], levelNumber: 1 },
-        selectedLevelNumber: 1,
-      });
+      const gameControlElement = document.createElement('div');
+      gameControlElement.id = 'game-control';
+      document.body.appendChild(gameControlElement);
     });
-  
-    if (!isLastLevel) {
-      renderButton('levelend-next-btn', NextButtonHtml, () => {
-        const nextLevel = 2;
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    function renderButton(
+      id: string,
+      ButtonClass:
+        | typeof MapButton
+        | typeof RetryButtonHtml
+        | typeof NextButtonHtml,
+      onClick: () => void,
+    ) {
+      const button = new ButtonClass({targetId: 'levelEndButtons', id});
+      button.onClick(onClick);
+    }
+
+    function renderButtonsHTML(isLastLevel: boolean) {
+      renderButton('levelend-map-btn', MapButton, mockSwitchToLevelSelectionCB);
+      renderButton('levelend-retry-btn', RetryButtonHtml, () => {
         mockSwitchToGameplayCB({
-          currentLevelData: {
-            ...mockData.levels[nextLevel],
-            levelNumber: nextLevel,
-          },
-          selectedLevelNumber: nextLevel,
+          currentLevelData: {...mockData.levels[1], levelNumber: 1},
+          selectedLevelNumber: 1,
         });
       });
-    } else {
-      document.getElementById('levelend-next-btn').remove();
-    }
-  }
-  
 
-  describe('Given Default parameters', () => {
-    describe('When LevelEndScene renders', () => {
+      if (!isLastLevel) {
+        renderButton('levelend-next-btn', NextButtonHtml, () => {
+          const nextLevel = 2;
+          mockSwitchToGameplayCB({
+            currentLevelData: {
+              ...mockData.levels[nextLevel],
+              levelNumber: nextLevel,
+            },
+            selectedLevelNumber: nextLevel,
+          });
+        });
+      }
+    }
+
+    describe('When instantiated', () => {
+      it('should call showLevelEndScreen', () => {
+        const initSpy = jest.spyOn(LevelEndScene.prototype, 'showLevelEndScreen');
+        levelEndScene = new LevelEndScene(
+          600, // height
+          800, // width
+          3, // starCount
+          1, // currentLevel
+          mockSwitchToGameplayCB,
+          mockSwitchToLevelSelectionCB,
+          mockData,
+          1, // monsterPhaseNumber
+        );
+        jest.runAllTimers();
+        expect(initSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('Levelend buttons should be now HTML', () => {
       it('it should render MapButton', () => {
         renderButtonsHTML(false);
         expect(document.getElementById('levelend-map-btn')).not.toBeNull();
       });
 
-      it('it should render RetryButtonHtml', () => {
-        renderButtonsHTML(false);
-        expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
-      });
-
-      it('it should render NextButtonHtml if isLastLevel is false', () => {
-        renderButtonsHTML(false);
-        expect(document.getElementById('levelend-next-btn')).not.toBeNull();
-      });
-
-      it('should not render NextButtonHtml if isLastLevel is true', () => {
-        renderButtonsHTML(true); // Pass true to simulate the last level
-      
-        const nextButton = document.getElementById('levelend-next-btn');
-        console.log(nextButton);
-        expect(nextButton).toBeNull(); // Confirm the button does not exist
-      });
-    });
-
-    describe('When clicking MapButton', () => {
-      it('it should call switchToLevelSelectionCB', () => {
+      it('it should call switchToLevelSelectionCB when Map button is clicked', () => {
         renderButtonsHTML(true);
         const mapButton = document.getElementById(
           'levelend-map-btn',
@@ -159,10 +104,13 @@ describe('LevelEndScreen', () => {
         mapButton.click();
         expect(mockSwitchToLevelSelectionCB).toHaveBeenCalled();
       });
-    });
 
-    describe('When clicking RetryButtonHtml', () => {
-      it('it should call switchToGameplayCB with correct data', () => {
+      it('it should render RetryButtonHtml', () => {
+        renderButtonsHTML(false);
+        expect(document.getElementById('levelend-retry-btn')).not.toBeNull();
+      });
+
+      it('it should call switchToGameplayCB with correct data when Retry button is clicked', () => {
         renderButtonsHTML(true);
         const retryButton = document.getElementById(
           'levelend-retry-btn',
@@ -174,10 +122,13 @@ describe('LevelEndScreen', () => {
           selectedLevelNumber: 1,
         });
       });
-    });
 
-    describe('When clicking NextButtonHtml', () => {
-      it('it should call switchToGameplayCB with correct data if isLastLevel is false', () => {
+      it('it should render NextButtonHtml if isLastLevel is false', () => {
+        renderButtonsHTML(false);
+        expect(document.getElementById('levelend-next-btn')).not.toBeNull();
+      });
+
+      it('it should call switchToGameplayCB with correct data if isLastLevel is false when Next Button is clicked', () => {
         renderButtonsHTML(false);
         const nextButton = document.getElementById(
           'levelend-next-btn',
@@ -188,6 +139,14 @@ describe('LevelEndScreen', () => {
           currentLevelData: {...mockData.levels[2], levelNumber: 2},
           selectedLevelNumber: 2,
         });
+      });
+
+      it('should not render NextButtonHtml if isLastLevel is true', () => {
+        renderButtonsHTML(true); // Pass true to simulate the last level
+
+        const nextButton = document.getElementById('levelend-next-btn');
+        console.log(nextButton);
+        expect(nextButton).toBeNull(); // Confirm the button does not exist
       });
     });
   });

--- a/src/scenes/levelend-scene/levelend-scene.ts
+++ b/src/scenes/levelend-scene/levelend-scene.ts
@@ -134,13 +134,18 @@ export class LevelEndScene {
     });
   };
 
-  retryAndNextButtonCB(level: number) {
-    const gamePlayData = {
-      currentLevelData: { ...this.data.levels[level], levelNumber: level },
-      selectedLevelNumber: level,
-    };
-    this.handlePublishEvent(true, gamePlayData);
-    this.switchToGameplayCB();
+  buttonCallbackFn(level: number | null, action: 'map' | 'retry' | 'next') {
+    if (action === 'map') {
+      this.handlePublishEvent(true);
+      this.switchToLevelSelectionCB();
+    } else {
+      const gamePlayData = {
+        currentLevelData: { ...this.data.levels[level], levelNumber: level },
+        selectedLevelNumber: level,
+      };
+      this.handlePublishEvent(true, gamePlayData);
+      this.switchToGameplayCB();
+    }
   }
 
   renderButtonsHTML() {
@@ -150,15 +155,14 @@ export class LevelEndScene {
         ButtonClass: MapButton,
         id: 'levelend-map-btn',
         onClick: () => {
-          this.handlePublishEvent(true);
-          this.switchToLevelSelectionCB();
+          this.buttonCallbackFn(null, 'map');
         },
       },
       {
         ButtonClass: RetryButtonHtml,
         id: 'levelend-retry-btn',
         onClick: () => {
-          this.retryAndNextButtonCB(this.currentLevel);
+          this.buttonCallbackFn(this.currentLevel, 'retry');
         },
       },
       {
@@ -167,7 +171,7 @@ export class LevelEndScene {
         showButton: this.isLastLevel,
         onClick: () => {
           const nextLevel = this.currentLevel + 1;
-          this.retryAndNextButtonCB(nextLevel);
+          this.buttonCallbackFn(nextLevel, 'next');
         },
       },
     ];

--- a/src/scenes/levelend-scene/levelend-scene.ts
+++ b/src/scenes/levelend-scene/levelend-scene.ts
@@ -67,6 +67,7 @@ export class LevelEndScene {
   toggleLevelEndBackground = (shouldShow: boolean) => {
     if (this.levelEndElement) {
       this.levelEndElement.style.display = shouldShow ? 'block' : 'none';
+      // this is to ensure that the level end scene is the top element when level end is active
       this.levelEndElement.style.zIndex = "11";
     }
   };
@@ -93,9 +94,6 @@ export class LevelEndScene {
       // this.monster.changeToEatAnimation();  //Commenting to handle interactive animation
     }
   };
-
-  draw() {
-  }
 
   renderStarsHTML() {
     const starsContainer = document.querySelector(".stars-container");
@@ -128,11 +126,22 @@ export class LevelEndScene {
     const button = new ButtonClass({ targetId: buttonsContainerId, id });
     const gameControl = document.getElementById("game-control") as HTMLCanvasElement;
     button.onClick(() => {
+      // this is to revert back the level end element to original z indev value 7
       this.levelEndElement.style.zIndex = '7';
+      // making sure this moves at the back since we dont need pause button in the levelend scene bnut this code might be remove when working on the destroy function in FM-329
       gameControl.style.zIndex = "-1";
       onClickCallback();
     });
   };
+
+  retryAndNextButtonCB(level: number) {
+    const gamePlayData = {
+      currentLevelData: { ...this.data.levels[level], levelNumber: level },
+      selectedLevelNumber: level,
+    };
+    this.handlePublishEvent(true, gamePlayData);
+    this.switchToGameplayCB();
+  }
 
   renderButtonsHTML() {
     // Define configurations for each button
@@ -149,36 +158,23 @@ export class LevelEndScene {
         ButtonClass: RetryButtonHtml,
         id: 'levelend-retry-btn',
         onClick: () => {
-          const gamePlayData = {
-            currentLevelData: {
-              ...this.data.levels[this.currentLevel],
-              levelNumber: this.currentLevel,
-            },
-            selectedLevelNumber: this.currentLevel,
-          };
-          this.handlePublishEvent(true, gamePlayData);
-          this.switchToGameplayCB();
+          this.retryAndNextButtonCB(this.currentLevel);
         },
       },
       {
         ButtonClass: NextButtonHtml,
         id: 'levelend-next-btn',
-        condition: this.isLastLevel,
+        showButton: this.isLastLevel,
         onClick: () => {
           const nextLevel = this.currentLevel + 1;
-          const gamePlayData = {
-            currentLevelData: { ...this.data.levels[nextLevel], levelNumber: nextLevel },
-            selectedLevelNumber: nextLevel,
-          };
-          this.handlePublishEvent(true, gamePlayData);
-          this.switchToGameplayCB();
+          this.retryAndNextButtonCB(nextLevel);
         },
       },
     ];
   
     // Create buttons based on configuration
-    buttonConfigs.forEach(({ ButtonClass, id, onClick, condition = true }) => {
-      if (condition) this.createButton(ButtonClass, id, onClick);
+    buttonConfigs.forEach(({ ButtonClass, id, onClick, showButton = true }) => {
+      if (showButton) this.createButton(ButtonClass, id, onClick);
     });
   }  
 

--- a/src/scenes/levelend-scene/levelend-scene.ts
+++ b/src/scenes/levelend-scene/levelend-scene.ts
@@ -123,7 +123,7 @@ export class LevelEndScene {
     id: string,
     onClickCallback: () => void
   ) {
-    const buttonsContainerId = 'buttons-container';
+    const buttonsContainerId = 'levelEndButtons';
 
     const button = new ButtonClass({ targetId: buttonsContainerId, id });
     const gameControl = document.getElementById("game-control") as HTMLCanvasElement;

--- a/src/scenes/levelend-scene/levelend-scene.ts
+++ b/src/scenes/levelend-scene/levelend-scene.ts
@@ -13,10 +13,8 @@ import gameStateService from '@gameStateService';
 import './levelend-scene.scss';
 
 export class LevelEndScene {
-  public canvas: HTMLCanvasElement;
   public height: number;
   public width: number;
-  public context: CanvasRenderingContext2D;
   public starCount: number;
   public currentLevel: number;
   public switchToGameplayCB: Function;
@@ -25,11 +23,10 @@ export class LevelEndScene {
   public audioPlayer: AudioPlayer;
   public isLastLevel: boolean;
   public levelEndElement = document.getElementById("levelEnd");
+  
   constructor(
-    canvas: any,
     height: number,
     width: number,
-    context: CanvasRenderingContext2D,
     starCount: number,
     currentLevel: number,
     switchToGameplayCB,
@@ -37,14 +34,11 @@ export class LevelEndScene {
     data,
     monsterPhaseNumber: number
   ) {
-    this.canvas = canvas;
     this.height = height;
     this.width = width;
-    this.context = context;
     this.switchToGameplayCB = switchToGameplayCB;
     this.switchToLevelSelectionCB = switchToLevelSelectionCB;
     this.data = data;
-    this.canvas.style.zIndex = "8";
     this.audioPlayer = new AudioPlayer();
     this.starCount = starCount;
     this.currentLevel = currentLevel;
@@ -183,9 +177,6 @@ export class LevelEndScene {
   }  
 
   addEventListener() {
-    document
-      .getElementById("canvas")
-      .addEventListener(CLICK, this.handleMouseClick, false);
     document.addEventListener("visibilitychange", this.pauseAudios, false);
   }
 


### PR DESCRIPTION
# Changes
- Use HTML buttons into level end screen
- Move levelend-scene.ts to src/scenes/levelend-scene/levelend-scene.ts
- Created next button component

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select any level to play
- Finish the game
- Make sure the buttons are html and working properly

Ref: [FM-328](https://curiouslearning.atlassian.net/browse/FM-328)


[FM-328]: https://curiouslearning.atlassian.net/browse/FM-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ