### PR TITLE
Fix: Fixed the left stones from adjusting their original X position (FM-331).

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import("ts-jest").JestConfigWithTsJest} **/
 module.exports = {
+  preset: "ts-jest",
   collectCoverage: true,
   collectCoverageFrom: [
     "<rootDir>/src/**/*.ts"
@@ -19,7 +20,8 @@ module.exports = {
     "@constants/*": "<rootDir>/src/constants/index.ts",
     "@data/*": "<rootDir>/src/data/$1",
     "@events": ["<rootDir>/src/events", "<rootDir>/src/events/$1"],
-    "@gameStateService/*": ["<rootDir>/src/gameStateService/$1"]
+    "@gameStateService/*": ["<rootDir>/src/gameStateService/$1"],
+    "^lodash-es$": "<rootDir>/node_modules/lodash/index.js"
   },
   roots: [
     "<rootDir>/src/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@capacitor/cli": "^4.4.0",
         "@types/howler": "^2.2.7",
         "@types/jest": "^29.5.14",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.7.5",
         "compression-webpack-plugin": "^11.1.0",
         "cross-env": "^7.0.3",
@@ -5595,6 +5596,21 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
+      "dev": true
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@capacitor/cli": "^4.4.0",
     "@types/howler": "^2.2.7",
     "@types/jest": "^29.5.14",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.7.5",
     "compression-webpack-plugin": "^11.1.0",
     "cross-env": "^7.0.3",

--- a/src/components/popups/pause-popup/pause-popup-component.ts
+++ b/src/components/popups/pause-popup/pause-popup-component.ts
@@ -5,7 +5,7 @@ import { AudioPlayer } from '@components';
 import { lang } from '@common';
 import { AUDIO_ARE_YOU_SURE } from '@constants';
 import { ConfirmPopupComponent } from '@components/popups/confirm-popup/confirm-popup-component';
-import debounce from 'lodash-es/debounce';
+import { debounce } from 'lodash-es';
 
 export const PAUSE_POPUP_EVENT_DATA = {
   SELECT_LEVEL: 'select-level',

--- a/src/gameStateService/data-access-objects.ts
+++ b/src/gameStateService/data-access-objects.ts
@@ -72,30 +72,34 @@ export const createStonePositionsDAO = ({
 		*/
 		return deviceWidth > widthVal ? smallerVal : defaultVal;
 	}
+
   //Coordinates with comments are the ones near to the monster.
 	const staticCoordinateFactors = [
-		[5, 1.9],
-		[setCoordinateFactor(2, 1.3), 1.07], //This stone is located right below the monster.
-		[[setCoordinateFactor(2.8, 2.5), 2], 1.2], //Lower right 1.
-		[setCoordinateFactor(4.3, 4.5), 1.28], //lower left side 2.
-		[7, 1.5],
-		[[2.3, 2.1],  1.9],
-		[[setCoordinateFactor(3, 2.4), 2.1], 1.42],  //Lower right 2, above lower right 1.
-		[6.4, 1.1]
+		[5, 1.9], //Left stone 1 - upper
+		[7, 1.5], //Left stone 2
+		[setCoordinateFactor(4.3, 4.5), 1.28], //Left stone 3
+		[6.4, 1.1], //Left stone 4 - very bottom
+		[setCoordinateFactor(2, 1.3), 1.07], //Middle stone that is located right below the monster.
+		[[2.3, 2.1], 1.9], //Right stone 1 - upper
+		[[setCoordinateFactor(2.8, 2.5), 2], 1.2], //Right stone 2
+		[[setCoordinateFactor(3, 2.4), 2.1], 1.42],  //Right stone 3
 	];
 
 	const randomizedStonePositions = staticCoordinateFactors.map(
-	(coordinatesFactors: [number[] | number, number]) => {
+	(coordinatesFactors: [number[] | number, number], index) => {
 		const factorX = coordinatesFactors[0];
 		const factorY = coordinatesFactors[1];
 		let coordinateX = Array.isArray(factorX)
 			? ((widthVal / factorX[0]) + (widthVal / factorX[1]))
 			: (widthVal / factorX);
 		let coordinateY = heightVal / factorY;
+		const offsetXAdjustment = index < 4 ? 25 : 0; //Only use +25 on stones on the left side.
+		const posX = coordinateX - offsetCoordinateValue;
+		const posY = coordinateY - offsetCoordinateValue;
 
 		return [
-				coordinateX - offsetCoordinateValue,
-				coordinateY - offsetCoordinateValue,
+			posX + offsetXAdjustment,
+			posY,
 		]
 	}
 	).sort(() => Math.random() - 0.5);

--- a/src/scenes/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene.ts
@@ -253,6 +253,7 @@ export class GameplayScene {
       /*
         Note: TO DO: Should use stone-handler.ts method resetStonePosition.
       */
+
       if (
         this.pickedStone &&
         this.pickedStoneObject &&
@@ -260,16 +261,11 @@ export class GameplayScene {
         typeof this.pickedStoneObject.origx === "number" &&
         typeof this.pickedStoneObject.origy === "number"
       ) {
-        const xLimit = 50;
-        const halfWidth = this.width / 2;
-        this.pickedStone.x =
-          this.pickedStone.text.length <= 3 &&
-            this.pickedStoneObject.origx < xLimit &&
-            this.pickedStoneObject.origx < halfWidth
-            ? this.pickedStoneObject.origx + 25
-            : this.pickedStoneObject.origx;
+        //Resets stones to original position after dragging.
+        this.pickedStone.x = this.pickedStoneObject.origx;
         this.pickedStone.y = this.pickedStoneObject.origy;
       }
+
     }
     this.pickedStone = null;
     this.wordPuzzleLogic.clearPickedUp();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "es2022",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "esModuleInterop":true,                /* Makes cleaner and more consistent imports across your codebase*/
+    "esModuleInterop": true,                /* Makes cleaner and more consistent imports across your codebase*/
     "lib": [
       "es2022",
       "dom",


### PR DESCRIPTION
# Changes
- Refactor the gameplay-scene - handleMouseUp method on resetting and adjusting the stone X position.
- Moved the + 25 offset adjustment to staticCoordinateFactors so the offset will be added upon creation.

# How to test
- Start the FTM app and press play on start screen.
- Select any level on level selection.
- During the game play, the stones on the left should not adjust their original position and should return to how they are originally displayed.

Ref: [FM-331](https://curiouslearning.atlassian.net/browse/FM-331)


[FM-331]: https://curiouslearning.atlassian.net/browse/FM-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ