### PR TITLE
fix - feedback text overlap in levelend scene (FM-341)

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -306,7 +306,7 @@ img {
 .feedback-text.show {
   -webkit-animation: scale-up-center 0.4s cubic-bezier(0.39, 0.575, 0.565, 1) both;
   animation: scale-up-center 0.4s cubic-bezier(0.39, 0.575, 0.565, 1) both;
-  z-index: 10;
+  z-index: 5;
   opacity: 1;
 }
 


### PR DESCRIPTION
# Changes
- Fix feedback text overlapping in level end scene

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Play any level
- Finish the game
- Make sure the feedback text is not overlapping in the level scene

Ref: [FM-341](https://curiouslearning.atlassian.net/browse/FM-341)


[FM-341]: https://curiouslearning.atlassian.net/browse/FM-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ