### PR TITLE
fix: images are draggable all over the screen (FM-344)

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -29,6 +29,9 @@ body {
 
 img {
   max-width: 100%;
+  user-drag: none; /* Disables dragging on Chrome, Edge, and Safari */
+  -webkit-user-drag: none; /* Ensures dragging is disabled in Safari */
+  pointer-events: none; /* Prevents mouse events like dragging and clicking on the image */
 }
 
 #discription-text {


### PR DESCRIPTION
# Changes
- fix image can be dragged all over the screen

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select any level to play
- In the Gameplay Scene try dragging all UI elements that we just converted to html recently
- Make sure you cannot drag those UI elements

Ref: [FM-344](https://curiouslearning.atlassian.net/browse/FM-344)


[FM-344]: https://curiouslearning.atlassian.net/browse/FM-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ