### PR TITLE
Feat: Add screen transition (routing) analytics and event handling on the Start Scene (FM-291).

### DIFF
--- a/src/components/buttons/play-button/play-button.scss
+++ b/src/components/buttons/play-button/play-button.scss
@@ -1,9 +1,10 @@
 .game-scene {
   #play-button {
-      position: absolute;
-      top: 23vh;
-      left: 50%;
-      transform: translate(-50%, -50%);
+    position: relative;
+    top: 14vh;
+    display: block;
+    margin: 0 auto;
+    z-index: 5;
   }
 }
 

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -18,7 +18,6 @@ import {
 } from "@constants";
 import gameStateService from '@gameStateService';
 
-
 export class StartScene {
   public canvas: HTMLCanvasElement;
   public data: any;
@@ -115,6 +114,9 @@ export class StartScene {
     this.playButton = new PlayButtonHtml({ targetId: 'background' });
     this.playButton.onClick(() => {
       this.logTappedStartFirebaseEvent();
+      this.audioPlayer.playButtonClickSound();
+      gameStateService.publish(gameStateService.EVENTS.SCENE_LOADING_EVENT, true);
+      this.switchSceneToLevelSelection();
     });
     document.addEventListener("selectstart", function (e) {
       e.preventDefault();


### PR DESCRIPTION
# Changes
- Updated the CSS implementation of Play Button so it will be on top of the canvas and pressable.
- Added routing logic to the Play Button.
- Updated the test cases for the start-scene press play scenario.

# How to test
- Start the FTM.
- On the Start Scene, the play button should be pressable now as it will animate a press down.
- It should also play an audio as you press it.
- It should switch to level selection properly.

Ref: [FM-291](https://curiouslearning.atlassian.net/browse/FM-291)


[FM-291]: https://curiouslearning.atlassian.net/browse/FM-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ