### PR TITLE
fixes: Fixed dev button not disappearing when play button is pressed and timer HTML duplication issue. (FM-288 & FM-347)

### DIFF
--- a/src/components/timer-ticking.ts
+++ b/src/components/timer-ticking.ts
@@ -16,7 +16,6 @@ export default class TimerTicking extends EventManager {
     public isTimerStarted: boolean;
     public isTimerEnded: boolean;
     public isTimerRunningOut: boolean;
-    public timeTickerElement: HTMLElement;
     public timer_full: HTMLImageElement;
     public pauseButtonClicked: boolean;
     public images: Object;
@@ -40,7 +39,6 @@ export default class TimerTicking extends EventManager {
         this.height = height;
         this.widthToClear = this.width / 3.4;
         this.callback = callback;
-        this.timeTickerElement = document.getElementById("timer-ticking");
         this.timer = 0;
         this.isTimerStarted = false;
         this.isTimerEnded = false;
@@ -120,6 +118,7 @@ export default class TimerTicking extends EventManager {
 
     public destroy(): void {
         this.stopTimer();
+        this.timerHtmlComponent?.destroy();
     }
 
 

--- a/src/components/timerHtml/timerHtml.spec.ts
+++ b/src/components/timerHtml/timerHtml.spec.ts
@@ -5,7 +5,14 @@ import TimerHTMLComponent from './timerHtml';
 import { AudioPlayer } from '@components';
 
 // Mock dependencies
-jest.mock('./timerHtml');
+jest.mock('./timerHtml', () => {
+  // Return a mock class with the 'destroy' method
+  return jest.fn().mockImplementation(() => {
+    return {
+      destroy: jest.fn(),  // Mock the 'destroy' method
+    };
+  });
+});
 jest.mock('@components', () => ({
   AudioPlayer: jest.fn(() => ({
     playAudio: jest.fn(),
@@ -28,6 +35,7 @@ describe('TimerTicking', () => {
 
     // Initialize TimerTicking instance
     timerTicking = new TimerTicking(800, 600, mockCallback);
+
   });
 
   afterEach(() => {
@@ -125,4 +133,25 @@ describe('TimerTicking', () => {
     // Assert that stopTimer was called
     expect(stopTimerSpy).toHaveBeenCalled();
   });
+
+  test('should destroy timer HTML when destroy timerTicking method is called. ', () => {
+    //Create an instance of TimerHTML with a mock destroy method
+    const mockDestroy = jest.fn();
+
+    // Mock TimerHTML class constructor to return an object with destroy as mockDestroy
+    (TimerHTMLComponent as jest.Mock).mockImplementationOnce(() => {
+      return {
+        destroy: mockDestroy,  // Mock the destroy method for this instance
+      };
+    });
+
+    //Initialize timer HTML
+    timerTicking.timerHtmlComponent = new TimerHTMLComponent('timer-ticking');
+
+    //Call the destroy method
+    timerTicking.destroy();
+
+    // Check that the destroy method was called
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  })
 });

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -556,7 +556,7 @@ export class GameplayScene {
     if (this.timerTicking) {
       this.timerTicking.destroy();
       this.timerTicking = null;
-  }
+    }
     this.trailParticles.clearTrailSubscription();
     this.unsubscribeEvent();
     this.isDisposing = true;

--- a/src/scenes/start-scene/start-scene.spec.ts
+++ b/src/scenes/start-scene/start-scene.spec.ts
@@ -170,6 +170,17 @@ describe('Start Scene Test', () => {
       // Check if sendTappedStartEvent was called
       expect(mockFirebase.sendTappedStartEvent).toHaveBeenCalledTimes(1); // Assuming mockFirebase is correctly set
     });
+
+    it('Should remove the dev button.', () => {
+      // Trigger the onClick callback directly by calling the mock callback
+      if (mockOnClickCallback) {
+        mockOnClickCallback(); // Simulate the button click
+      }
+
+      const devBtn = document.getElementById('toggle-btn');
+
+      expect(devBtn.style.display).toEqual('none');
+    })
   });
 
 });

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -113,6 +113,7 @@ export class StartScene {
   createPlayButton() {
     this.playButton = new PlayButtonHtml({ targetId: 'background' });
     this.playButton.onClick(() => {
+      this.toggleBtn.style.display = "none";
       this.logTappedStartFirebaseEvent();
       this.audioPlayer.playButtonClickSound();
       gameStateService.publish(gameStateService.EVENTS.SCENE_LOADING_EVENT, true);


### PR DESCRIPTION
# Changes
- Updated logic on play button, adding the hiding of toggle button.
- Updated timer-ticking destroy method by adding this.timerHtmlComponent?.destroy(); as part of its logic so HTML element can be removed properly.
- Updated test cases for start-scene and timer-ticking.

# How to test
- For FM-288, on start screen, pressing play button should make the dev button disappear.
- For FM-347, there should be no duplicate timer HTML whenever the game restarts. Press F12 and see if element 'timer-ticking' is under background HTML, it should only be one.

Ref: [FM-288](https://curiouslearning.atlassian.net/browse/FM-288)
Ref: [FM-347](https://curiouslearning.atlassian.net/browse/FM-347)


[FM-288]: https://curiouslearning.atlassian.net/browse/FM-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FM-347]: https://curiouslearning.atlassian.net/browse/FM-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ