### PR TITLE
fix: Fixed black screen when start scene renders (FM-348).

### DIFF
--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -183,8 +183,6 @@ class App {
 
   private handleLoadingScreen = () => {
     if (this.is_cached.get(lang)) {
-      this.loadingElement.style.zIndex = "-1";
-      this.loadingElement.style.display = "none";
       this.progressBarContainer.style.display = "none";
       this.progressBar.style.display = "none";
     } else {
@@ -192,6 +190,7 @@ class App {
       this.progressBar.style.display = "flex";
       this.progressBar.style.width = "10%";
     }
+
   };
 
   private async registerWorkbox(): Promise<void> {

--- a/src/scenes/start-scene/start-scene.spec.ts
+++ b/src/scenes/start-scene/start-scene.spec.ts
@@ -36,6 +36,7 @@ describe('Start Scene Test', () => {
       <div>
         <div id="title" class="title" style="font-family: Atma-SemiBold, sans-serif;">Feed the Monster</div>
         <button id="toggle-btn" class="off">Dev</button>
+        <div id="loading-screen" style="display: none; z-index: -1;"></div>
         <div class="game-scene"></div>
         <div id="canvas"></div>
         <canvas id="rivecanvas"></canvas>
@@ -117,6 +118,15 @@ describe('Start Scene Test', () => {
 
     // Create the play button
     startScene.createPlayButton();
+  });
+
+  describe('During start scene initialization.', () => {
+    it('It should hide the initial loading screen once start scene has fully loaded.', () => {
+      const loadingElement = document.getElementById("loading-screen");
+
+      expect(loadingElement.style.zIndex).toEqual("-1");
+      expect(loadingElement.style.display).toEqual("none");
+    });
   });
 
   describe('When Play Button is clicked ', () => {

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -44,6 +44,7 @@ export class StartScene {
   private titleTextElement: HTMLElement | null;
   public riveMonster: RiveMonsterComponent;
   private firebaseIntegration: FirebaseIntegration;
+  private loadingElement: HTMLElement;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -58,6 +59,7 @@ export class StartScene {
     this.canavsElement = document.getElementById("canvas") as HTMLCanvasElement;
     this.context = this.canavsElement.getContext("2d");
     this.toggleBtn = document.getElementById("toggle-btn") as HTMLElement;
+    this.loadingElement = document.getElementById("loading-screen") as HTMLElement;
     this.riveMonster = new RiveMonsterComponent({
       canvas: this.riveMonsterElement,
       autoplay: true,
@@ -81,6 +83,7 @@ export class StartScene {
     this.generateGameTitle();
     this.riveMonsterElement.style.zIndex = '6';
     this.firebaseIntegration = new FirebaseIntegration();
+    this.hideInitialLoading();
   }
 
   private setupBg = async () => {
@@ -94,6 +97,13 @@ export class StartScene {
     // Dynamically update the background based on the selected type
     backgroundGenerator.generateBackground(selectedBackgroundType);
   };
+
+  private hideInitialLoading = () => {
+    setTimeout(() => {
+      this.loadingElement.style.zIndex = "-1";
+      this.loadingElement.style.display = "none";
+    }, 750);
+  }
 
   devToggle = () => {
     this.toggleBtn.addEventListener("click", () =>


### PR DESCRIPTION
# Changes
- Removed setting of loadingElement display to "none", from FeedTheMonster and moved the logic to Start-scene.
- Updated start-scene test case and create a new scenario for start scene initial loading.

# How to test
- Load The FTM.
- During the loading before the start scene, there should be no brief black screen.

Ref: [FM-348](https://curiouslearning.atlassian.net/browse/FM-348)


[FM-348]: https://curiouslearning.atlassian.net/browse/FM-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ