### PR TITLE
fix: Fm 267 Animation issues fixed on gameplay screen

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -291,7 +291,7 @@ export class GameplayScene {
         this.pickedStone.y = this.pickedStoneObject.origy;
         // Trigger animations
         this.triggerMonsterAnimation('isMouthClosed');
-        this.triggerMonsterAnimation('backToIdle', 1300);
+        this.triggerMonsterAnimation('backToIdle', 350);
 
       }
 
@@ -325,9 +325,6 @@ export class GameplayScene {
           this.pickedStoneObject = sc;
           this.pickedStone = sc;
           this.stoneHandler.playDragAudioIfNecessary(sc);
-
-          // Trigger open mouth animation
-          this.triggerMonsterAnimation('isMouthOpen');
           break;
         }
       }
@@ -359,8 +356,7 @@ export class GameplayScene {
     }
   }
 
-  handleMouseMove = (event) => {
-    // const isMouthOpened = triggerInputs.find(input => input.name === 'isMouthOpen'); //drag
+  handleMouseMove = (event) => {    
     if (this.pickedStone && this.pickedStone.frame <= 99) {
       return; // Prevent dragging if the stone is animating
     }
@@ -411,16 +407,15 @@ export class GameplayScene {
               this.pickedStone,
               this.pickedStoneObject
             );
-            
+
             //After resetting its original position replace it with the new letter.
             this.pickedStoneObject = newStoneLetter;
             this.pickedStone = newStoneLetter;
           }
         }
       }
-
       // Trigger open mouth animation
-    this.triggerMonsterAnimation('isMouthOpen');
+      this.triggerMonsterAnimation('isMouthOpen');
     }
     this.trailParticles?.addTrailParticlesOnMove(
       trailX,
@@ -646,7 +641,7 @@ export class GameplayScene {
   }
 
   public wordPuzzle(droppedStoneInstance: StoneConfig) {
-   
+
     if (droppedStoneInstance.frame <= 99) {
       return; // Prevent dragging if the stone is animating
     }
@@ -666,7 +661,7 @@ export class GameplayScene {
     );
 
     if (isCorrect) {
-      if (this.wordPuzzleLogic.validateWordPuzzle()) { 
+      if (this.wordPuzzleLogic.validateWordPuzzle()) {
         this.handleCorrectStoneDrop(feedBackIndex);
         this.handleStoneDropEnd(isCorrect, "Word");
         this.stonesCount = 1;
@@ -705,10 +700,10 @@ export class GameplayScene {
     }
     if (isCorrect) {
       this.triggerMonsterAnimation('isChewing');
-      this.triggerMonsterAnimation('isHappy',1700);
+      this.triggerMonsterAnimation('isHappy', 1700);
     } else {
       this.triggerMonsterAnimation('isSpit');
-      this.triggerMonsterAnimation('isSad',1030);
+      this.triggerMonsterAnimation('isSad', 1030);
     }
 
     this.logPuzzleEndFirebaseEvent(isCorrect, puzzleType);


### PR DESCRIPTION
# How to test
- When the stones appear if we select one stone and we don't drop it to the monster and if we try to drop a different stone then the reaction animations are not playing.
- If we click on the stone multiple times the monster mouth open animation plays and it will be in that stage even if we don't hold the stone and until we drop a stone.
- If we click on the stone position the monster mouth open animation plays.
- If we give fast inputs to the monster sometimes the reaction animation gets stuck.

Ref: [FM-267](https://curiouslearning.atlassian.net/browse/FM-267)


[FM-267]: https://curiouslearning.atlassian.net/browse/FM-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ