### PR TITLE
Fix: Fixed issue on delay loading of assets after initial installation (FM-369).

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -334,54 +334,6 @@ img {
   overflow: hidden;
 }
 
-/* TODO: move to scss */
-/* POPUPS */
-.popup {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-  height: 100%;
-  width: 100%;
-}
-
-.popup.show {
-  display: block;
-}
-
-.popup .popup__overlay {
-  height: 100%;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
-.popup .popup__content-wrapper {
-  position: absolute;
-  top: 20vh;
-  left: 10vw;
-  right: 10vw;
-  padding: 35px 50px;
-  height: 80vw;
-  background-repeat: no-repeat;
-  background-size: contain;
-}
-
-.popup .popup__content-wrapper [data-click='close'] {
-  position: absolute;
-  top: -15px;
-  left: 15px;
-
-  display: block;
-}
-
-.popup .popup__content-wrapper .popup__content-container {
-  padding: 15px;
-  color: #fff;
-}
-
 /* BUTTONS */
 .btn--icon {
   height: calc(100vw * 0.19);

--- a/src/components/popups/base-popup/base-popup-component.scss
+++ b/src/components/popups/base-popup/base-popup-component.scss
@@ -25,7 +25,6 @@
   top: 20vh;
   left: 10vw;
   right: 10vw;
-  padding: 35px 50px;
   height: 80vw;
   background-repeat: no-repeat;
   background-size: contain;
@@ -35,11 +34,11 @@
   position: absolute;
   top: -15px;
   left: 15px;
-
   display: block;
 }
 
 .popup .popup__content-wrapper .popup__content-container {
+  position: absolute;
   padding: 15px;
   color: #fff;
   display: flex;
@@ -57,4 +56,12 @@
     top: 4px;
     left: 24px;
   }
+}
+
+#popup-bg {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
 }

--- a/src/components/popups/base-popup/base-popup-component.ts
+++ b/src/components/popups/base-popup/base-popup-component.ts
@@ -18,7 +18,8 @@ const CSS_SHOW = 'show';
 export const POPUP_LAYOUT = (id: string, content: string, showClose: boolean = true): string => `
   <div id="${id}" class="popup">
     <div class="popup__overlay"></div>
-    <div id="${id}-content-wrapper" class="popup__content-wrapper" style="background-image: url(${POPUP_BG_IMG})">
+    <div id="${id}-content-wrapper" class="popup__content-wrapper" >
+      <img id="popup-bg" src="${POPUP_BG_IMG}" />
       <div id="${id}-content-container" class="popup__content-container">${content}</div>
     </div>
   </div>

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -402,7 +402,6 @@ class App {
   hideLoadingScreen() {
     try {
       localStorage.setItem("version" + this.lang, this.getJsonVersionNumber());
-      this.loadingElement.style.display = "none";
       this.handleResize(this.dataModal);
     } catch (error) {
       console.error("Error hiding loading screen:", error);


### PR DESCRIPTION
# Changes
- Removed `this.loadingElement.style.display = "none";` in FeedTheMonster.ts method `hideLoadingScreen`.
- Changed the Popup background image implementation from CSS style background with now img HTML and styled it as a background.
- Removed duplicate CSS styling.

# How to test
- Clear cache and data for the FTM app.
- Run it locally and the the FTM app to download all the assets.
- As soon as it is about to finish downloading and caching the assets, carefully watch how it changes from loading to start-scene.
- **It should load quickly without any brief black screen in between transition.**
- Now proceed to level selection and select any game level.
- On the game-play, click on the the pause button on upper right.
- **When the popup shows, the background popup should load with the buttons without any delays.**

Ref: [FM-369](https://curiouslearning.atlassian.net/browse/FM-369)


[FM-369]: https://curiouslearning.atlassian.net/browse/FM-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ