### PR TITLE
Adding time since sessions start in FTM download events

### DIFF
--- a/feedTheMonster.ts
+++ b/feedTheMonster.ts
@@ -121,10 +121,11 @@ class App {
       json_version_number: this.majVersion && this.minVersion
         ? `${this.majVersion}.${this.minVersion}`
         : "",
-      timestamps: Date.now(),
+        ms_since_session_start: Date.now()-this.startSessionTime,
     };
     switch (percentage) {
       case 25:
+        
         this.firebaseIntegration.sendDownload25PercentCompletedEvent(downloadCompleteData);
         break;
       case 50:
@@ -420,6 +421,7 @@ class App {
       profile_number: 0,
       version_number: this.versionInfoElement.innerHTML,
       json_version_number: this.getJsonVersionNumber(),
+      ms_since_session_start: Date.now()-this.startSessionTime,
     };
     this.firebaseIntegration.sendDownloadCompletedEvent(downloadCompleted);
   }

--- a/src/Firebase/firebase-event-interface.ts
+++ b/src/Firebase/firebase-event-interface.ts
@@ -13,13 +13,14 @@ export interface SessionEnd extends CommonEventProperties{
 }
 
 export interface DowloadPercentCompleted extends CommonEventProperties{
-       timestamps:Number;
+    ms_since_session_start:Number;
    }
 
 export interface TappedStart extends CommonEventProperties{
    
 }
 export interface DownloadCompleted extends CommonEventProperties{
+    ms_since_session_start:Number;
    
 }
 export interface SelectedLevel extends CommonEventProperties{


### PR DESCRIPTION
# Changes
- Adding time since sessions start in FTM download events

# How to test
 - In Firebase console events section we can see download_25 , download_50, download_75 and download_complete event!
- In Big-querry after filtering the data we can see ms_since_session_start param in the data!

Ref: [AJ-269](https://curiouslearning.atlassian.net/browse/aj-269)
