### PR TITLE
fix: Cr 286 LetterOnly alignment issue

### DIFF
--- a/src/components/prompt-text.ts
+++ b/src/components/prompt-text.ts
@@ -80,12 +80,12 @@ export class PromptText extends EventManager {
     drawRTLLang() {
         var x = this.width / 2;
         const y = this.height * 0.28;
-        this.context.textAlign = "left";
         var fontSize = this.calculateFont();
         const scaledWidth = this.promptImageWidth;
         const scaledHeight = this.promptImageHeight;
         this.context.font = `${fontSize}px ${font}, monospace`;
         if (this.levelData.levelMeta.levelType == "LetterInWord") {
+            this.context.textAlign = "left";
             if (this.levelData.levelMeta.protoType == "Visible") {
                 var letterInWord = this.currentPromptText.replace(
                     new RegExp(this.currentPuzzleData.targetStones[0],),


### PR DESCRIPTION
# Changes
- src/components/prompt-text.ts

# How to test
- Check for Letteronly levels in RTL

Ref: [CR-286](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-286)


[CR-286]: https://curiouslearning.atlassian.net/browse/CR-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ