### PR TITLE
feat: integrated feaeture flags (EN-33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@capacitor/android": "^4.4.0",
         "@capacitor/core": "^4.4.0",
+        "@curiouslearning/features": "^1.2.5",
         "@octokit/rest": "^20.0.1",
         "@release-it/conventional-changelog": "^8.0.1",
         "@rive-app/canvas": "^2.25.1",
@@ -2301,6 +2302,14 @@
       "integrity": "sha512-hFgLi1bGmADMmYMFAaitEsVheF3QgoMU4TrHkMgik51NzHwUq3nBdP5+A9oNS9qe3dEDyegoaHF8X9oJc9v8QQ==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@curiouslearning/features": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/features/-/features-1.2.5.tgz",
+      "integrity": "sha512-aDbqoz1gf/oQUJEAk3h0F+jgHfnDQ+Il907XS0ggBQf/C1ydbIJf1BTESSASFdmoHPoYUTltF+o3h0k7xDrmiw==",
+      "dependencies": {
+        "@statsig/js-client": "^3.12.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -5280,6 +5289,19 @@
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.12.1.tgz",
+      "integrity": "sha512-99FOEBq7M3Jnkvk0DWRAklvCE1J26HLmYsFGJAo+LQ7382DYBY3X6fvdZeaNGa5KDSIdyZEpeLQxkHw2PpVpGw=="
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.12.1.tgz",
+      "integrity": "sha512-CCGJqFnKYhOEWZsZgXcMuKQLd/4TEB8PgObDXiyoKw1dszl8de4+hCsg/qa64Y4dy0e91cMS9oTfZZD3TJKkNA==",
+      "dependencies": {
+        "@statsig/client-core": "3.12.1"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@capacitor/android": "^4.4.0",
     "@capacitor/core": "^4.4.0",
+    "@curiouslearning/features": "^1.2.5",
     "@octokit/rest": "^20.0.1",
     "@release-it/conventional-changelog": "^8.0.1",
     "@rive-app/canvas": "^2.25.1",

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -20,6 +20,11 @@ import {
 } from "./Firebase/firebase-event-interface";
 import { URL } from "@data";
 import './styles/main.scss';
+import { FeatureFlagsService } from '@curiouslearning/features';
+
+const featureFlagService = new FeatureFlagsService({
+  metaData: { userId: pseudoId }
+});
 
 declare const window: any;
 
@@ -78,6 +83,7 @@ class App {
     await this.loadAndCacheFont(font, `./assets/fonts/${font}.ttf`);
     await this.loadTitleFeedbackCustomFont();
     await this.preloadGameAudios();
+    await featureFlagService.initialize();
     this.handleLoadingScreen();
     this.setupCanvas();
     const data = await getData();

--- a/src/gameStateService/gameStateService.ts
+++ b/src/gameStateService/gameStateService.ts
@@ -10,6 +10,7 @@ import { DataModal, GameScore } from "@data";
 
 export class GameStateService extends PubSub {
     public EVENTS: {
+        START_GAME: string;
         SWITCH_SCENE_EVENT: string;
         GAMEPLAY_DATA_EVENT: string;
         GAME_PAUSE_STATUS_EVENT: string;
@@ -65,6 +66,7 @@ export class GameStateService extends PubSub {
     constructor() {
         super();
         this.EVENTS = {
+            START_GAME: 'START_GAME',
             SWITCH_SCENE_EVENT: 'SWITCH_SCENE_EVENT',
             GAMEPLAY_DATA_EVENT: 'GAMEPLAY_DATA_EVENT',
             GAME_PAUSE_STATUS_EVENT: 'GAME_PAUSE_STATUS_EVENT',

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -174,7 +174,7 @@ export class StartScene {
       this.toggleBtn.style.display = "none";
       this.logTappedStartFirebaseEvent();
       this.audioPlayer.playButtonClickSound();
-      gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_LEVEL_SELECT);
+      gameStateService.publish(gameStateService.EVENTS.START_GAME, true);
     });
     document.addEventListener("selectstart", function (e) {
       e.preventDefault();

--- a/src/services/features/constants.ts
+++ b/src/services/features/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Quickstart feature allows users to skip level selection screen when click play button from start screen.
+ * 
+ * https://curiouslearning.atlassian.net/browse/EN-33
+ * 
+ * https://console.statsig.com/5lPgCbcrKd2jkN9s3INJJ6/gates/en-33
+ */
+export const FEATURE_QUICK_START = 'en-33';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": "./", // Specifies the root directory of the project
     "paths": {
       "@components/*": ["src/components/*"],


### PR DESCRIPTION
# Changes
- feat: added @curiouslearning/features dependency
- feat: integrated en-33 feature

# How to test
- When no id is present, clicking start should skip level selection and go straight to gameplay (quick start)
- When id is present, clicking start should go through default screens
- When offline, it should retain loaded feature
- When offline without stored feature flags, it should default to false (default behavior)

Ref: [EN-33](https://curiouslearning.atlassian.net/browse/EN-33)

Note: unit tests done separately in features module