### PR TITLE
Renaming "user_clicked" event to "tapped_start"!

### DIFF
--- a/src/Firebase/base-firebase-integration.ts
+++ b/src/Firebase/base-firebase-integration.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from "firebase/app";
-import { getAnalytics, logEvent ,setUserProperties} from "firebase/analytics";
+import { getAnalytics, logEvent, setUserProperties } from "firebase/analytics";
 import { firebaseConfig } from "./firebase-config";
 import { source, campaign_id } from "@common";
 
@@ -8,9 +8,9 @@ export class BaseFirebaseIntegration {
     analytics: any;
     constructor() {
         this.initializeFirebase();
-        console.log(" source : ",source ," and  campaign_id: ",campaign_id);
-        if(source!=null || campaign_id!=null)
-        this.setUserProperty(source ,campaign_id);
+        console.log(" source : ", source, " and  campaign_id: ", campaign_id);
+        if (source != null || campaign_id != null)
+            this.setUserProperty(source, campaign_id);
     }
     protected customEvents(eventName: string, event: object): void {
         try {
@@ -33,7 +33,7 @@ export class BaseFirebaseIntegration {
             setUserProperties(this.analytics, {
                 source: source,
                 campaign_id: campaignId
-            }, { global:true });
+            }, { global: true });
             console.log("User properties set: ", { source, campaignId });
         } catch (error) {
             console.error("Error while setting user properties:", error);

--- a/src/Firebase/firebase-integration.ts
+++ b/src/Firebase/firebase-integration.ts
@@ -33,20 +33,16 @@ export class FirebaseIntegration extends BaseFirebaseIntegration {
     public sendLevelCompletedEvent(data: LevelCompletedEvent): void {
         this.customEvents("level_completed", data);
     }
-
-    public sendUserClickedOnPlayEvent(): void {
-        this.customEvents('tapped_start', { click: 'Click' });
-    }
-
     public sendDownloadCompletedEvent(data: DowloadPercentCompleted): void {
         this.customEvents('download_completed', data);
-    }public sendDownload25PercentCompletedEvent(data:DowloadPercentCompleted): void {
-        this.customEvents('download_25',data);
     }
-    public sendDownload50PercentCompletedEvent(data:DowloadPercentCompleted): void {
-        this.customEvents('download_50',data);
+    public sendDownload25PercentCompletedEvent(data: DowloadPercentCompleted): void {
+        this.customEvents('download_25', data);
     }
-    public sendDownload75PercentCompletedEvent(data:DowloadPercentCompleted): void {
-        this.customEvents('download_75',data);
+    public sendDownload50PercentCompletedEvent(data: DowloadPercentCompleted): void {
+        this.customEvents('download_50', data);
+    }
+    public sendDownload75PercentCompletedEvent(data: DowloadPercentCompleted): void {
+        this.customEvents('download_75', data);
     }
 }

--- a/src/Firebase/firebase-integration.ts
+++ b/src/Firebase/firebase-integration.ts
@@ -35,7 +35,7 @@ export class FirebaseIntegration extends BaseFirebaseIntegration {
     }
 
     public sendUserClickedOnPlayEvent(): void {
-        this.customEvents('user_clicked', { click: 'Click' });
+        this.customEvents('tapped_start', { click: 'Click' });
     }
 
     public sendDownloadCompletedEvent(data: DowloadPercentCompleted): void {

--- a/src/components/buttons/play-button.ts
+++ b/src/components/buttons/play-button.ts
@@ -1,8 +1,5 @@
 import { PLAY_BTN_IMG } from "@constants";
-import { TappedStart } from "../../Firebase/firebase-event-interface";
-import { FirebaseIntegration } from "../../Firebase/firebase-integration";
-import { loadImages, pseudoId, lang } from "@common";
-import { getData } from "@data";
+import { loadImages } from "@common";
 export default class PlayButton {
     public posX: number;
     public posY: number;
@@ -11,9 +8,6 @@ export default class PlayButton {
     public images: Object;
     public loadedImages: any;
     public imagesLoaded: boolean = false;
-    private majVersion:string;
-    private minVersion:string;
-    private firebaseIntegration: FirebaseIntegration;
     constructor(
         context: CanvasRenderingContext2D,
         canvas: HTMLCanvasElement,
@@ -24,7 +18,6 @@ export default class PlayButton {
         this.posY = posY;
         this.context = context;
         this.canvas = canvas;
-        this.firebaseIntegration = new FirebaseIntegration();
         this.init();
         this.images = {
             pause_button_image: PLAY_BTN_IMG
@@ -36,9 +29,7 @@ export default class PlayButton {
         });
     }
     private async init() {
-         const data = await getData();
-         this.majVersion = data.majversion;
-         this.minVersion = data.minversion;
+
     }
 
     draw() {
@@ -60,20 +51,8 @@ export default class PlayButton {
             (yClick - this.posY - this.canvas.width / 6) *
             (yClick - this.posY - this.canvas.width / 6)
         );
-        this.logTappedStartFirebaseEvent();
         if (distance < this.canvas.width / 8) {
             return true;
         }
-    }
-    public logTappedStartFirebaseEvent() {
-        let endTime = Date.now();
-        const tappedStartData: TappedStart = {
-          cr_user_id: pseudoId,
-          ftm_language: lang,
-          profile_number: 0,
-          version_number: document.getElementById("version-info-id").innerHTML,
-          json_version_number:  !!this.majVersion && !!this.minVersion  ? this.majVersion.toString() +"."+this.minVersion.toString() : "",
-        };
-        this.firebaseIntegration.sendTappedStartEvent(tappedStartData);
     }
 }

--- a/src/scenes/start-scene.ts
+++ b/src/scenes/start-scene.ts
@@ -2,6 +2,8 @@ import { Monster, AudioPlayer } from "@components";
 import { PlayButton } from "@buttons";
 import { DataModal } from "@data";
 import {
+  lang,
+  pseudoId,
   StoneConfig,
   toggleDebugMode,
   Utils,
@@ -13,6 +15,7 @@ import {
   PWAInstallStatus,
   DEFAULT_BG_GROUP_IMGS,
 } from "@constants";
+import { TappedStart } from "src/Firebase/firebase-event-interface";
 
 export class StartScene {
   public canvas: HTMLCanvasElement;
@@ -117,7 +120,7 @@ export class StartScene {
       15
     );
     if (!(x < excludeX && y < excludeY)) {
-      FirebaseIntegration.getInstance().sendUserClickedOnPlayEvent();
+      this.logTappedStartFirebaseEvent();
       // @ts-ignore
       fbq("trackCustom", FirebaseUserClicked, {
         event: "click",
@@ -127,7 +130,18 @@ export class StartScene {
       self.switchSceneToLevelSelection("StartScene");
     }
   };
-
+  public logTappedStartFirebaseEvent() {
+    let endTime = Date.now();
+    const tappedStartData: TappedStart = {
+      cr_user_id: pseudoId,
+      ftm_language: lang,
+      profile_number: 0,
+      version_number: document.getElementById("version-info-id").innerHTML,
+      json_version_number: !!this.data.majVersion && !!this.data.minVersion ? this.data.majVersion.toString() + "." + this.data.minVersion.toString() : "",
+    };
+    console.log(">>>>>>>>>>>>>")
+    FirebaseIntegration.getInstance().sendTappedStartEvent(tappedStartData);
+  }
   dispose() {
     this.monster.dispose();
     this.audioPlayer.stopAllAudios();


### PR DESCRIPTION
# Changes
- Renaming "user_clicked" event to "tapped_start"!

# How to test
- in order to test the changes user can open the big-querry, after running querries user can see the event being logged as "tapped_start"!

Ref: [AJ-299](https://curiouslearning.atlassian.net/browse/AJ-299)


[AJ-299]: https://curiouslearning.atlassian.net/browse/AJ-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ