### PR TITLE
feat: Move Feedback Audio players from stone-handler to game puzzles class and create a reusable component for Feedback audio. (FM-468)

### DIFF
--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -215,65 +215,10 @@ export default class StoneHandler extends EventManager {
     this.unregisterEventListener();
   }
 
-  public isStoneLetterDropCorrect(
-    droppedStone: string,
-    feedBackIndex: number,
-    isWord: boolean = false
-  ): boolean {
-    /*
-     * To Do: Need to refactor or revome this completely and place something
-     * that is tailored to single letter puzzle since word puzzle no longer uses this.
-     * Will leave this for now to avoid messing witht the single letter puzzle.
-    */
-    const isLetterDropCorrect = isWord
-      ? droppedStone == this.correctTargetStone.substring(0, droppedStone.length)
-      : droppedStone == this.correctTargetStone;
-
-    this.processLetterDropFeedbackAudio(
-      feedBackIndex,
-      isLetterDropCorrect,
-      isWord,
-      droppedStone
-    );
-
-    return isLetterDropCorrect
-  }
-
-  public processLetterDropFeedbackAudio(
-    feedBackIndex: number,
-    isLetterDropCorrect: boolean,
-    isWord: boolean,
-    droppedStone: string,
-  ) {
-    if (isLetterDropCorrect) {
-      const condition = isWord
-        ? droppedStone === this.getCorrectTargetStone() // condition for word puzzle
-        : isLetterDropCorrect // for letter and letter for word puzzle
-
-      if (condition) {
-        this.playCorrectAnswerFeedbackSound(feedBackIndex);
-      } else {
-        this.audioPlayer.playFeedbackAudios(
-          false,
-          AUDIO_PATH_EATS,
-          AUDIO_PATH_CHEERING_FUNC(2),
-        );
-      }
-    } else {
-      this.audioPlayer.playFeedbackAudios(
-        false,
-        AUDIO_PATH_EATS,
-      );
-      setTimeout(() => {
-        this.audioPlayer.playFeedbackAudios(
-          false,
-          AUDIO_PATH_MONSTER_SPIT,
-          Math.round(Math.random()) > 0 ? AUDIO_PATH_MONSTER_DISSAPOINTED : null
-        );
-      }, 1700); //1000 time is tailored to handleStoneDropEnd 1000 delay of isSpit animation.
-    }
-  }
-
+  /**
+   * Gets the correct target stone/word
+   * @returns string - The correct target stone/word
+   */
   public getCorrectTargetStone(): string {
     return this.correctTargetStone;
   }
@@ -327,32 +272,6 @@ export default class StoneHandler extends EventManager {
       feedbackAudios["great"],
       feedbackAudios["amazing"]
     ];
-  }
-
-  /**
-   * Performance optimization: Parallel audio playback
-   * Disposes stones immediately while playing audio in parallel
-   */
-  async playCorrectAnswerFeedbackSound(feedBackIndex: number) {
-    try {
-      // Dispose stones immediately - don't wait for audio
-      this.disposeStones();
-
-      // Play feedback audio in parallel for better performance
-      const randomNumber = Utils.getRandomNumber(1, 3).toString();
-      await Promise.allSettled([
-        this.correctStoneAudio.play(),
-        this.audioPlayer.playFeedbackAudios(
-          false,
-          AUDIO_PATH_EATS,
-          AUDIO_PATH_CHEERING_FUNC(randomNumber),
-          AUDIO_PATH_POINTS_ADD,
-          Utils.getConvertedDevProdURL(this.feedbackAudios[feedBackIndex])
-        )
-      ]);
-    } catch (error) {
-      console.warn('Audio playback failed:', error);
-    }
   }
 
   cleanup() {
@@ -500,7 +419,7 @@ export default class StoneHandler extends EventManager {
       [[setCoordinateFactor(3, 2.4), 2.1], 1.42],  //Right stone 3
     ];
 
-    // Separate coordinate factors for egg monster due to different dimensionse
+    // Separate coordinate factors for egg monster due to different dimensions
     const eggMonsterCoordinateFactors = [
       [6.2, 1.8], //Left stone 2nd - upper
       [7.5, 1.5], //Left stone in 3rd

--- a/src/gamepuzzles/basePuzzleLogic/basePuzzleLogic.spec.ts
+++ b/src/gamepuzzles/basePuzzleLogic/basePuzzleLogic.spec.ts
@@ -1,0 +1,105 @@
+import BasePuzzleLogic from './basePuzzleLogic';
+
+// Create a concrete implementation of BasePuzzleLogic for testing
+class TestPuzzleLogic extends BasePuzzleLogic {
+  isLetterDropCorrect(droppedStone: string, isWord?: boolean): boolean {
+    return droppedStone === this.getCorrectTargetStone();
+  }
+
+  getCorrectTargetStone(): string {
+    return this.getTargetText();
+  }
+
+  validatePuzzleCompletion(): boolean {
+    return true;
+  }
+}
+
+describe('BasePuzzleLogic', () => {
+  let puzzleLogic: TestPuzzleLogic;
+  const mockLevelData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: 'Word',
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['a', 'b', 'c'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'abc'
+        },
+        segmentNumber: 1,
+        targetStones: ['a', 'b', 'c']
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    puzzleLogic = new TestPuzzleLogic(mockLevelData, 0);
+  });
+
+  test('should correctly initialize with level data and puzzle number', () => {
+    expect(puzzleLogic['levelData']).toEqual(mockLevelData);
+    expect(puzzleLogic['puzzleNumber']).toBe(0);
+  });
+
+  test('should update puzzle level correctly', () => {
+    puzzleLogic.updatePuzzleLevel(1);
+    expect(puzzleLogic['puzzleNumber']).toBe(1);
+  });
+
+  test('should get puzzle type correctly', () => {
+    expect(puzzleLogic.getPuzzleType()).toBe('Word');
+  });
+
+  test('should check if puzzle is a word puzzle correctly', () => {
+    expect(puzzleLogic.checkIsWordPuzzle()).toBe(true);
+    
+    // Change level type and test again
+    const newMockLevelData = { ...mockLevelData };
+    newMockLevelData.levelMeta.levelType = 'LetterOnly';
+    const newPuzzleLogic = new TestPuzzleLogic(newMockLevelData, 0);
+    expect(newPuzzleLogic.checkIsWordPuzzle()).toBe(false);
+  });
+
+  test('should get default values correctly', () => {
+    const values = puzzleLogic.getValues();
+    expect(values).toEqual({
+      groupedLetters: '',
+      droppedLetters: '',
+      groupedObj: {},
+      droppedHistory: {},
+      hideListObj: {}
+    });
+  });
+
+  test('should validate if stone letter should be hidden correctly', () => {
+    expect(puzzleLogic.validateShouldHideLetter(0)).toBe(true);
+  });
+
+  test('should handle check hovered stone correctly', () => {
+    expect(puzzleLogic.handleCheckHoveredStone('a', 0)).toBe(false);
+  });
+
+  test('should validate fed letters correctly', () => {
+    expect(puzzleLogic.validateFedLetters()).toBe(false);
+  });
+
+  test('should validate word puzzle correctly', () => {
+    expect(puzzleLogic.validateWordPuzzle()).toBe(true);
+  });
+
+  test('should get correct target stone correctly', () => {
+    expect(puzzleLogic.getCorrectTargetStone()).toBe('abc');
+  });
+
+  test('should check if letter drop is correct', () => {
+    expect(puzzleLogic.isLetterDropCorrect('abc')).toBe(true);
+    expect(puzzleLogic.isLetterDropCorrect('def')).toBe(false);
+  });
+});

--- a/src/gamepuzzles/basePuzzleLogic/basePuzzleLogic.ts
+++ b/src/gamepuzzles/basePuzzleLogic/basePuzzleLogic.ts
@@ -1,0 +1,164 @@
+/**
+ * Base class for all game puzzle logic
+ * Provides common functionality and interface for different puzzle types
+ */
+export default abstract class BasePuzzleLogic {
+  protected levelData: {
+    levelNumber: number;
+    levelMeta: {
+      letterGroup: number;
+      levelNumber: number;
+      levelType: string;
+      promptFadeOut: number;
+      protoType: string;
+    };
+    puzzles: [
+      {
+        foilStones: string[];
+        prompt: {
+          promptAudio: string;
+          promptText: string;
+        };
+        segmentNumber: number;
+        targetStones: string[];
+      }
+    ];
+  };
+  protected puzzleNumber: number;
+
+  constructor(levelData, puzzleNumber) {
+    this.levelData = levelData;
+    this.puzzleNumber = puzzleNumber;
+  }
+
+  /**
+   * Updates the current puzzle level
+   * @param puzzleNumber - The new puzzle number
+   */
+  updatePuzzleLevel(puzzleNumber: number): void {
+    this.puzzleNumber = puzzleNumber;
+  }
+
+  /**
+   * Gets the target text for the current puzzle
+   * @returns The target text
+   */
+  protected getTargetText(): string {
+    return this.levelData.puzzles[this.puzzleNumber]?.prompt?.promptText;
+  }
+
+  /**
+   * Gets the puzzle type
+   * @returns The puzzle type (e.g., "Word", "LetterOnly")
+   */
+  getPuzzleType(): string {
+    return this.levelData?.levelMeta?.levelType;
+  }
+
+  /**
+   * Checks if the puzzle is a word puzzle
+   * @returns boolean indicating if this is a word puzzle
+   */
+  checkIsWordPuzzle(): boolean {
+    return this.getPuzzleType() === 'Word';
+  }
+
+  /**
+   * Gets values needed for rendering and game logic
+   * Default implementation returns empty objects
+   * Override in subclasses as needed
+   */
+  getValues(): any {
+    return {
+      groupedLetters: '',
+      droppedLetters: '',
+      groupedObj: {},
+      droppedHistory: {},
+      hideListObj: {}
+    };
+  }
+
+  /**
+   * Validates if a stone letter should be hidden
+   * @param foilStoneIndex - The index of the foil stone
+   * @returns boolean indicating if the stone should be hidden
+   */
+  validateShouldHideLetter(foilStoneIndex: number): boolean {
+    return true; // Default implementation shows all stones
+  }
+
+  /**
+   * Handles checking if a hovered stone should be added to the group
+   * @param foilStoneText - The text of the hovered stone
+   * @param foilStoneIndex - The index of the hovered stone
+   * @returns boolean indicating if the stone should be added to the group
+   */
+  handleCheckHoveredStone(foilStoneText: string, foilStoneIndex: number): boolean {
+    return false; // Default implementation doesn't allow hovering
+  }
+
+  /**
+   * Sets a picked up letter
+   * Default implementation does nothing
+   * Override in subclasses as needed
+   */
+  setPickUpLetter(letter: string, arrFoilStoneIndex: number): void {
+    // Default implementation does nothing
+  }
+
+  /**
+   * Clears picked up letters
+   * Default implementation does nothing
+   * Override in subclasses as needed
+   */
+  clearPickedUp(): void {
+    // Default implementation does nothing
+  }
+
+  /**
+   * Sets grouped letters to dropped
+   * Default implementation does nothing
+   * Override in subclasses as needed
+   */
+  setGroupToDropped(): void {
+    // Default implementation does nothing
+  }
+
+  /**
+   * Validates if fed letters are correct
+   * Default implementation returns false
+   * Override in subclasses as needed
+   */
+  validateFedLetters(): boolean {
+    return false;
+  }
+
+  /**
+   * Validates if word puzzle is completed
+   * Default implementation returns false
+   * Override in subclasses as needed
+   */
+  validateWordPuzzle(): boolean {
+    return this.validatePuzzleCompletion();
+  }
+
+  /**
+   * Checks if the dropped stone letter is correct
+   * @param droppedStone - The letter or word that was dropped
+   * @param isWord - Whether this is a word puzzle
+   * @returns boolean indicating if the dropped letter/word is correct
+   */
+  abstract isLetterDropCorrect(droppedStone: string, isWord?: boolean): boolean;
+
+  /**
+   * Gets the correct target stone/word
+   * @returns string - The correct target stone/word
+   */
+  abstract getCorrectTargetStone(): string;
+
+  /**
+   * Checks if the puzzle is completed
+   * @returns boolean indicating if the puzzle is completed
+   */
+  abstract validatePuzzleCompletion(): boolean;
+}

--- a/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.spec.ts
+++ b/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.spec.ts
@@ -1,0 +1,132 @@
+import FeedbackAudioHandler, { FeedbackType } from './feedbackAudioHandler';
+import { AudioPlayer } from "@components";
+
+// Mock the AudioPlayer class
+jest.mock('@components', () => ({
+  AudioPlayer: jest.fn().mockImplementation(() => ({
+    playFeedbackAudios: jest.fn(),
+    stopAllAudios: jest.fn()
+  }))
+}));
+
+// Mock the Audio class
+global.Audio = jest.fn().mockImplementation(() => ({
+  play: jest.fn().mockResolvedValue(undefined),
+  pause: jest.fn(),
+  loop: false
+}));
+
+// Mock the Utils functions
+jest.mock('@common', () => ({
+  Utils: {
+    getRandomNumber: jest.fn().mockReturnValue(2),
+    getConvertedDevProdURL: jest.fn(url => url)
+  }
+}));
+
+// Mock the constants
+jest.mock('@constants', () => ({
+  AUDIO_PATH_EATS: 'eats.mp3',
+  AUDIO_PATH_MONSTER_SPIT: 'spit.mp3',
+  AUDIO_PATH_MONSTER_DISSAPOINTED: 'disappointed.mp3',
+  AUDIO_PATH_POINTS_ADD: 'points.mp3',
+  AUDIO_PATH_CHEERING_FUNC: jest.fn(num => `cheering${num}.mp3`),
+  AUDIO_PATH_CORRECT_STONE: 'correct.mp3'
+}));
+
+describe('FeedbackAudioHandler', () => {
+  let feedbackAudioHandler: FeedbackAudioHandler;
+  let originalMathRound;
+  const mockFeedbackAudios = {
+    fantastic: 'fantastic.mp3',
+    great: 'great.mp3',
+    amazing: 'amazing.mp3'
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Store original Math.round
+    originalMathRound = Math.round;
+    // Mock Math.round to always return 0 for predictable test results
+    Math.round = jest.fn().mockReturnValue(0);
+    feedbackAudioHandler = new FeedbackAudioHandler(mockFeedbackAudios);
+  });
+
+  afterEach(() => {
+    // Restore Math.round
+    Math.round = originalMathRound;
+  });
+
+  test('should initialize with correct audio files', () => {
+    expect(feedbackAudioHandler['feedbackAudios']).toEqual([
+      'fantastic.mp3',
+      'great.mp3',
+      'amazing.mp3'
+    ]);
+    expect(global.Audio).toHaveBeenCalledWith('correct.mp3');
+  });
+
+  test('should play correct answer feedback', () => {
+    feedbackAudioHandler.playFeedback(FeedbackType.CORRECT_ANSWER, 0);
+    
+    // Check that the correct audio was played
+    expect(feedbackAudioHandler['correctStoneAudio'].play).toHaveBeenCalled();
+    expect(feedbackAudioHandler['audioPlayer'].playFeedbackAudios).toHaveBeenCalledWith(
+      false,
+      'eats.mp3',
+      'cheering2.mp3',
+      'points.mp3',
+      'fantastic.mp3'
+    );
+  });
+
+  test('should play partial correct feedback', () => {
+    feedbackAudioHandler.playFeedback(FeedbackType.PARTIAL_CORRECT, 0);
+    
+    // Check that the correct audio was played
+    expect(feedbackAudioHandler['audioPlayer'].playFeedbackAudios).toHaveBeenCalledWith(
+      false,
+      'eats.mp3',
+      'cheering2.mp3'
+    );
+  });
+
+  test('should play incorrect feedback', () => {
+    jest.useFakeTimers();
+    feedbackAudioHandler.playFeedback(FeedbackType.INCORRECT, 0);
+    
+    // Check that the first audio was played
+    expect(feedbackAudioHandler['audioPlayer'].playFeedbackAudios).toHaveBeenCalledWith(
+      false,
+      'eats.mp3'
+    );
+    
+    // Advance timers to trigger the setTimeout callback
+    jest.advanceTimersByTime(1700);
+    
+    // Since Math.round is mocked to return 0, which is <= 0,
+    // the third parameter should be null
+    expect(feedbackAudioHandler['audioPlayer'].playFeedbackAudios).toHaveBeenCalledWith(
+      false,
+      'spit.mp3',
+      null
+    );
+    
+    jest.useRealTimers();
+  });
+
+  test('should stop all audio', () => {
+    feedbackAudioHandler.stopAllAudio();
+    
+    expect(feedbackAudioHandler['audioPlayer'].stopAllAudios).toHaveBeenCalled();
+    expect(feedbackAudioHandler['correctStoneAudio'].pause).toHaveBeenCalled();
+  });
+
+  test('should dispose resources', () => {
+    feedbackAudioHandler.dispose();
+    
+    expect(feedbackAudioHandler['audioPlayer'].stopAllAudios).toHaveBeenCalled();
+    expect(feedbackAudioHandler['correctStoneAudio'].pause).toHaveBeenCalled();
+    expect(feedbackAudioHandler['correctStoneAudio'].src).toBe('');
+  });
+});

--- a/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.ts
+++ b/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.ts
@@ -1,0 +1,141 @@
+import { AudioPlayer } from "@components";
+import {
+  AUDIO_PATH_EATS,
+  AUDIO_PATH_MONSTER_SPIT,
+  AUDIO_PATH_MONSTER_DISSAPOINTED,
+  AUDIO_PATH_POINTS_ADD,
+  AUDIO_PATH_CHEERING_FUNC,
+  AUDIO_PATH_CORRECT_STONE
+} from '@constants';
+import { Utils } from '@common';
+
+/**
+ * Feedback type enum for different feedback scenarios
+ */
+export enum FeedbackType {
+  CORRECT_ANSWER = 'correct_answer',
+  PARTIAL_CORRECT = 'partial_correct',
+  INCORRECT = 'incorrect'
+}
+
+/**
+ * Handles feedback audio for game puzzles
+ * Centralizes all audio feedback logic related to correct/incorrect letter drops
+ */
+export default class FeedbackAudioHandler {
+  private audioPlayer: AudioPlayer;
+  private feedbackAudios: string[];
+  private correctStoneAudio: HTMLAudioElement;
+
+  constructor(feedbackAudios: any) {
+    this.audioPlayer = new AudioPlayer();
+    this.feedbackAudios = this.convertFeedBackAudiosToList(feedbackAudios);
+    this.correctStoneAudio = new Audio(AUDIO_PATH_CORRECT_STONE);
+    this.correctStoneAudio.loop = false;
+  }
+
+  /**
+   * Plays feedback audio based on the feedback type
+   * @param feedbackType - The type of feedback to play
+   * @param feedBackIndex - Index for feedback audio selection
+   */
+  public playFeedback(feedbackType: FeedbackType, feedBackIndex: number): void {
+    switch (feedbackType) {
+      case FeedbackType.CORRECT_ANSWER:
+        this.playCorrectAnswerFeedbackSound(feedBackIndex);
+        break;
+      case FeedbackType.PARTIAL_CORRECT:
+        this.playPartialCorrectFeedbackSound();
+        break;
+      case FeedbackType.INCORRECT:
+        this.playIncorrectFeedbackSound();
+        break;
+    }
+  }
+
+  /**
+   * Plays audio for a partially correct answer (e.g., correct letter in a word puzzle)
+   */
+  private playPartialCorrectFeedbackSound(): void {
+    this.audioPlayer.playFeedbackAudios(
+      false,
+      AUDIO_PATH_EATS,
+      AUDIO_PATH_CHEERING_FUNC(2)
+    );
+  }
+
+  /**
+   * Plays audio for an incorrect answer
+   */
+  private playIncorrectFeedbackSound(): void {
+    this.audioPlayer.playFeedbackAudios(
+      false,
+      AUDIO_PATH_EATS
+    );
+    
+    setTimeout(() => {
+      this.audioPlayer.playFeedbackAudios(
+        false,
+        AUDIO_PATH_MONSTER_SPIT,
+        Math.round(Math.random()) > 0 ? AUDIO_PATH_MONSTER_DISSAPOINTED : null
+      );
+    }, 1700); // 1700ms is tailored to handleStoneDropEnd 1000 delay of isSpit animation
+  }
+
+  /**
+   * Plays the correct answer feedback sounds
+   * @param feedBackIndex - Index for feedback audio selection
+   */
+  private async playCorrectAnswerFeedbackSound(feedBackIndex: number): Promise<void> {
+    try {
+      // Play feedback audio in parallel for better performance
+      const randomNumber = Utils.getRandomNumber(1, 3).toString();
+      await Promise.allSettled([
+        this.correctStoneAudio.play(),
+        this.audioPlayer.playFeedbackAudios(
+          false,
+          AUDIO_PATH_EATS,
+          AUDIO_PATH_CHEERING_FUNC(randomNumber),
+          AUDIO_PATH_POINTS_ADD,
+          Utils.getConvertedDevProdURL(this.feedbackAudios[feedBackIndex])
+        )
+      ]);
+    } catch (error) {
+      console.warn('Audio playback failed:', error);
+    }
+  }
+
+  /**
+   * Stops all feedback audio
+   */
+  public stopAllAudio(): void {
+    this.audioPlayer.stopAllAudios();
+    if (this.correctStoneAudio) {
+      this.correctStoneAudio.pause();
+    }
+  }
+
+  /**
+   * Converts feedback audios to a list format
+   * @param feedbackAudios - The feedback audios object
+   * @returns Array of feedback audio paths
+   */
+  private convertFeedBackAudiosToList(feedbackAudios): string[] {
+    return [
+      feedbackAudios["fantastic"],
+      feedbackAudios["great"],
+      feedbackAudios["amazing"]
+    ];
+  }
+
+  /**
+   * Cleans up resources
+   */
+  public dispose(): void {
+    this.audioPlayer.stopAllAudios();
+    if (this.correctStoneAudio) {
+      this.correctStoneAudio.pause();
+      this.correctStoneAudio.src = '';
+    }
+  }
+}

--- a/src/gamepuzzles/index.ts
+++ b/src/gamepuzzles/index.ts
@@ -1,4 +1,16 @@
-import WordPuzzleLogic from './wordPuzzleLogic';
-//import here for single letter puzzle or other game puzzle logic.
+import WordPuzzleLogic from './wordPuzzleLogic/wordPuzzleLogic';
+import LetterPuzzleLogic from './letterPuzzleLogic/letterPuzzleLogic';
+import SoundWordPuzzleLogic from './soundWordPuzzleLogic/soundWordPuzzleLogic';
+import BasePuzzleLogic from './basePuzzleLogic/basePuzzleLogic';
+import FeedbackAudioHandler, { FeedbackType } from './feedbackAudioHandler/feedbackAudioHandler';
+import PuzzleFactory from './puzzleFactory/puzzleFactory';
 
-export { WordPuzzleLogic };
+export { 
+  WordPuzzleLogic, 
+  LetterPuzzleLogic, 
+  SoundWordPuzzleLogic, 
+  BasePuzzleLogic, 
+  FeedbackAudioHandler, 
+  FeedbackType,
+  PuzzleFactory 
+};

--- a/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.spec.ts
+++ b/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.spec.ts
@@ -1,0 +1,117 @@
+import LetterPuzzleLogic from './letterPuzzleLogic';
+
+describe('LetterPuzzleLogic', () => {
+  let letterPuzzleLogic: LetterPuzzleLogic;
+  
+  // Mock level data for LetterOnly puzzle
+  const mockLetterOnlyData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: 'LetterOnly',
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['a', 'b', 'c', 'd', 'e'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'a'
+        },
+        segmentNumber: 1,
+        targetStones: ['a']
+      }
+    ]
+  };
+
+  // Mock level data for LetterInWord puzzle
+  const mockLetterInWordData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: 'LetterInWord',
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['c', 'a', 't', 'd', 'o', 'g'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'c'
+        },
+        segmentNumber: 1,
+        targetStones: ['c']
+      }
+    ]
+  };
+
+  describe('LetterOnly puzzle', () => {
+    beforeEach(() => {
+      letterPuzzleLogic = new LetterPuzzleLogic(mockLetterOnlyData, 0);
+    });
+
+    test('should correctly identify as a letter puzzle', () => {
+      expect(letterPuzzleLogic.isLetterPuzzle()).toBe(true);
+      expect(letterPuzzleLogic.checkIsWordPuzzle()).toBe(false);
+    });
+
+    test('should correctly get the target letter', () => {
+      expect(letterPuzzleLogic.getCorrectTargetStone()).toBe('a');
+    });
+
+    test('should correctly check if letter drop is correct', () => {
+      expect(letterPuzzleLogic.isLetterDropCorrect('a')).toBe(true);
+      expect(letterPuzzleLogic.isLetterDropCorrect('b')).toBe(false);
+    });
+
+    test('should set and get current letter correctly', () => {
+      letterPuzzleLogic.setCurrentLetter('a');
+      expect(letterPuzzleLogic.getCurrentLetter()).toBe('a');
+    });
+
+    test('should clear current letter correctly', () => {
+      letterPuzzleLogic.setCurrentLetter('a');
+      letterPuzzleLogic.clearCurrentLetter();
+      expect(letterPuzzleLogic.getCurrentLetter()).toBe('');
+    });
+
+    test('should validate puzzle completion correctly', () => {
+      letterPuzzleLogic.setCurrentLetter('a');
+      expect(letterPuzzleLogic.validatePuzzleCompletion()).toBe(true);
+      
+      letterPuzzleLogic.setCurrentLetter('b');
+      expect(letterPuzzleLogic.validatePuzzleCompletion()).toBe(false);
+    });
+
+    test('should update puzzle level and clear current letter', () => {
+      letterPuzzleLogic.setCurrentLetter('a');
+      letterPuzzleLogic.updatePuzzleLevel(1);
+      expect(letterPuzzleLogic.getCurrentLetter()).toBe('');
+      expect(letterPuzzleLogic['puzzleNumber']).toBe(1);
+    });
+  });
+
+  describe('LetterInWord puzzle', () => {
+    beforeEach(() => {
+      letterPuzzleLogic = new LetterPuzzleLogic(mockLetterInWordData, 0);
+    });
+
+    test('should correctly identify as a letter puzzle', () => {
+      expect(letterPuzzleLogic.isLetterPuzzle()).toBe(true);
+      expect(letterPuzzleLogic.checkIsWordPuzzle()).toBe(false);
+    });
+
+    test('should correctly get the target letter', () => {
+      expect(letterPuzzleLogic.getCorrectTargetStone()).toBe('c');
+    });
+
+    test('should correctly check if letter drop is correct', () => {
+      expect(letterPuzzleLogic.isLetterDropCorrect('c')).toBe(true);
+      expect(letterPuzzleLogic.isLetterDropCorrect('a')).toBe(false);
+    });
+  });
+});

--- a/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.ts
+++ b/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.ts
@@ -1,0 +1,89 @@
+import BasePuzzleLogic from '../basePuzzleLogic/basePuzzleLogic';
+
+/**
+ * Handles logic for Letter Only and Letter In Word puzzles
+ */
+export default class LetterPuzzleLogic extends BasePuzzleLogic {
+  private currentLetter: string = '';
+
+  constructor(levelData, puzzleNumber) {
+    super(levelData, puzzleNumber);
+  }
+
+  /**
+   * Checks if the dropped stone letter is correct
+   * @param droppedStone - The letter that was dropped
+   * @returns boolean indicating if the dropped letter is correct
+   */
+  override isLetterDropCorrect(droppedStone: string): boolean {
+    const targetLetter = this.getCorrectTargetStone();
+    return droppedStone === targetLetter;
+  }
+
+  /**
+   * Gets the correct target letter
+   * @returns string - The correct target letter
+   */
+  override getCorrectTargetStone(): string {
+    // For LetterOnly and LetterInWord puzzles, the target is a single letter
+    // In the case of LetterInWord, the prompt text might be a word, but we're
+    // only interested in a single letter at a time
+    if (this.getPuzzleType() === 'LetterOnly') {
+      // For LetterOnly, the target is directly in the targetStones array
+      return this.levelData.puzzles[this.puzzleNumber]?.targetStones[0] || '';
+    } else {
+      // For LetterInWord, we need to extract the current letter from the prompt text
+      return this.getTargetText();
+    }
+  }
+
+  /**
+   * Checks if the puzzle is completed
+   * @returns boolean indicating if the puzzle is completed
+   */
+  override validatePuzzleCompletion(): boolean {
+    // For letter puzzles, completion is determined by a single correct letter drop
+    return this.currentLetter === this.getCorrectTargetStone();
+  }
+
+  /**
+   * Sets the current letter that was dropped
+   * @param letter - The letter that was dropped
+   */
+  setCurrentLetter(letter: string): void {
+    this.currentLetter = letter;
+  }
+
+  /**
+   * Clears the current letter
+   */
+  clearCurrentLetter(): void {
+    this.currentLetter = '';
+  }
+
+  /**
+   * Gets the current letter
+   * @returns The current letter
+   */
+  getCurrentLetter(): string {
+    return this.currentLetter;
+  }
+
+  /**
+   * Checks if this is a letter puzzle (LetterOnly or LetterInWord)
+   * @returns boolean indicating if this is a letter puzzle
+   */
+  isLetterPuzzle(): boolean {
+    const puzzleType = this.getPuzzleType();
+    return puzzleType === 'LetterOnly' || puzzleType === 'LetterInWord';
+  }
+
+  /**
+   * Updates the puzzle level
+   * @param puzzleNumber - The new puzzle number
+   */
+  override updatePuzzleLevel(puzzleNumber: number): void {
+    super.updatePuzzleLevel(puzzleNumber);
+    this.clearCurrentLetter();
+  }
+}

--- a/src/gamepuzzles/puzzleFactory/puzzleFactory.spec.ts
+++ b/src/gamepuzzles/puzzleFactory/puzzleFactory.spec.ts
@@ -1,0 +1,93 @@
+import PuzzleFactory from './puzzleFactory';
+import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
+import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
+import SoundWordPuzzleLogic from '../soundWordPuzzleLogic/soundWordPuzzleLogic';
+
+// Mock the console.warn to avoid polluting test output
+console.warn = jest.fn();
+
+describe('PuzzleFactory', () => {
+  const mockLevelData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: '', // Will be set in each test
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['a', 'b', 'c'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'abc'
+        },
+        segmentNumber: 1,
+        targetStones: ['a', 'b', 'c']
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should create WordPuzzleLogic for Word level type', () => {
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = 'Word';
+    
+    const puzzleLogic = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    
+    expect(puzzleLogic).toBeInstanceOf(WordPuzzleLogic);
+  });
+
+  test('should create LetterPuzzleLogic for LetterOnly level type', () => {
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = 'LetterOnly';
+    
+    const puzzleLogic = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    
+    expect(puzzleLogic).toBeInstanceOf(LetterPuzzleLogic);
+  });
+
+  test('should create LetterPuzzleLogic for LetterInWord level type', () => {
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = 'LetterInWord';
+    
+    const puzzleLogic = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    
+    expect(puzzleLogic).toBeInstanceOf(LetterPuzzleLogic);
+  });
+
+  test('should create SoundWordPuzzleLogic for SoundWord level type', () => {
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = 'SoundWord';
+    
+    const puzzleLogic = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    
+    expect(puzzleLogic).toBeInstanceOf(SoundWordPuzzleLogic);
+  });
+
+  test('should default to WordPuzzleLogic for unknown level type', () => {
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = 'UnknownType';
+    
+    const puzzleLogic = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    
+    expect(puzzleLogic).toBeInstanceOf(WordPuzzleLogic);
+    expect(console.warn).toHaveBeenCalledWith('Unknown level type: UnknownType. Defaulting to WordPuzzleLogic.');
+  });
+
+  test('should handle null or undefined level data gracefully', () => {
+    // Test with null level data
+    const puzzleLogic1 = PuzzleFactory.createPuzzleLogic(null, 0);
+    expect(puzzleLogic1).toBeInstanceOf(WordPuzzleLogic);
+    
+    // Test with undefined level type
+    const levelData = { ...mockLevelData };
+    levelData.levelMeta.levelType = undefined;
+    const puzzleLogic2 = PuzzleFactory.createPuzzleLogic(levelData, 0);
+    expect(puzzleLogic2).toBeInstanceOf(WordPuzzleLogic);
+  });
+});

--- a/src/gamepuzzles/puzzleFactory/puzzleFactory.ts
+++ b/src/gamepuzzles/puzzleFactory/puzzleFactory.ts
@@ -1,0 +1,33 @@
+import BasePuzzleLogic from '../basePuzzleLogic/basePuzzleLogic';
+import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
+import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
+import SoundWordPuzzleLogic from '../soundWordPuzzleLogic/soundWordPuzzleLogic';
+
+/**
+ * Factory class to create the appropriate puzzle logic based on level type
+ */
+export default class PuzzleFactory {
+  /**
+   * Creates a puzzle logic instance based on the level type
+   * @param levelData - The level data
+   * @param puzzleNumber - The puzzle number
+   * @returns The appropriate puzzle logic instance
+   */
+  static createPuzzleLogic(levelData: any, puzzleNumber: number): BasePuzzleLogic {
+    const levelType = levelData?.levelMeta?.levelType;
+
+    switch (levelType) {
+      case 'Word':
+        return new WordPuzzleLogic(levelData, puzzleNumber);
+      case 'LetterOnly':
+      case 'LetterInWord':
+        return new LetterPuzzleLogic(levelData, puzzleNumber);
+      case 'SoundWord':
+        return new SoundWordPuzzleLogic(levelData, puzzleNumber);
+      default:
+        // Default to WordPuzzleLogic if level type is unknown
+        console.warn(`Unknown level type: ${levelType}. Defaulting to WordPuzzleLogic.`);
+        return new WordPuzzleLogic(levelData, puzzleNumber);
+    }
+  }
+}

--- a/src/gamepuzzles/soundWordPuzzleLogic/soundWordPuzzleLogic.spec.ts
+++ b/src/gamepuzzles/soundWordPuzzleLogic/soundWordPuzzleLogic.spec.ts
@@ -1,0 +1,91 @@
+import SoundWordPuzzleLogic from './soundWordPuzzleLogic';
+
+describe('SoundWordPuzzleLogic', () => {
+  let soundWordPuzzleLogic: SoundWordPuzzleLogic;
+  const mockLevelData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: 'SoundWord',
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['d', 'o', 'g', 'c', 'a', 't'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'dog'
+        },
+        segmentNumber: 1,
+        targetStones: ['d', 'o', 'g']
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    soundWordPuzzleLogic = new SoundWordPuzzleLogic(mockLevelData, 0);
+  });
+
+  test('should correctly identify as a sound word puzzle', () => {
+    expect(soundWordPuzzleLogic.isSoundWordPuzzle()).toBe(true);
+    expect(soundWordPuzzleLogic.checkIsWordPuzzle()).toBe(false);
+  });
+
+  test('should correctly get the target word', () => {
+    expect(soundWordPuzzleLogic.getCorrectTargetStone()).toBe('dog');
+  });
+
+  test('should correctly check if letter drop is correct', () => {
+    // For partial words
+    expect(soundWordPuzzleLogic.isLetterDropCorrect('d')).toBe(true);
+    expect(soundWordPuzzleLogic.isLetterDropCorrect('do')).toBe(true);
+    expect(soundWordPuzzleLogic.isLetterDropCorrect('dog')).toBe(true);
+    
+    // For incorrect words
+    expect(soundWordPuzzleLogic.isLetterDropCorrect('c')).toBe(false);
+    expect(soundWordPuzzleLogic.isLetterDropCorrect('cat')).toBe(false);
+  });
+
+  test('should set and get dropped letters correctly', () => {
+    soundWordPuzzleLogic.setDroppedLetters('d');
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('d');
+    
+    soundWordPuzzleLogic.setDroppedLetters('dog');
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('dog');
+  });
+
+  test('should append dropped letters correctly', () => {
+    soundWordPuzzleLogic.setDroppedLetters('d');
+    soundWordPuzzleLogic.appendDroppedLetters('o');
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('do');
+    
+    soundWordPuzzleLogic.appendDroppedLetters('g');
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('dog');
+  });
+
+  test('should clear dropped letters correctly', () => {
+    soundWordPuzzleLogic.setDroppedLetters('dog');
+    soundWordPuzzleLogic.clearDroppedLetters();
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('');
+  });
+
+  test('should validate puzzle completion correctly', () => {
+    soundWordPuzzleLogic.setDroppedLetters('d');
+    expect(soundWordPuzzleLogic.validatePuzzleCompletion()).toBe(false);
+    
+    soundWordPuzzleLogic.setDroppedLetters('do');
+    expect(soundWordPuzzleLogic.validatePuzzleCompletion()).toBe(false);
+    
+    soundWordPuzzleLogic.setDroppedLetters('dog');
+    expect(soundWordPuzzleLogic.validatePuzzleCompletion()).toBe(true);
+  });
+
+  test('should update puzzle level and clear dropped letters', () => {
+    soundWordPuzzleLogic.setDroppedLetters('dog');
+    soundWordPuzzleLogic.updatePuzzleLevel(1);
+    expect(soundWordPuzzleLogic.getDroppedLetters()).toBe('');
+    expect(soundWordPuzzleLogic['puzzleNumber']).toBe(1);
+  });
+});

--- a/src/gamepuzzles/soundWordPuzzleLogic/soundWordPuzzleLogic.ts
+++ b/src/gamepuzzles/soundWordPuzzleLogic/soundWordPuzzleLogic.ts
@@ -1,0 +1,89 @@
+import BasePuzzleLogic from '../basePuzzleLogic/basePuzzleLogic';
+
+/**
+ * Handles logic for Sound Word puzzles
+ * Similar to Word puzzles but with sound-based interactions
+ */
+export default class SoundWordPuzzleLogic extends BasePuzzleLogic {
+  private droppedLetters: string = '';
+
+  constructor(levelData, puzzleNumber) {
+    super(levelData, puzzleNumber);
+  }
+
+  /**
+   * Checks if the dropped stone letter is correct
+   * @param droppedStone - The letter or word that was dropped
+   * @param isWord - Whether this is a complete word
+   * @returns boolean indicating if the dropped letter/word is correct
+   */
+  override isLetterDropCorrect(droppedStone: string, isWord: boolean = true): boolean {
+    const targetWord = this.getTargetText();
+    // For sound word puzzles, we check if the dropped stone matches the target word
+    return droppedStone === targetWord.substring(0, droppedStone.length);
+  }
+
+  /**
+   * Gets the correct target word
+   * @returns string - The correct target word
+   */
+  override getCorrectTargetStone(): string {
+    return this.getTargetText();
+  }
+
+  /**
+   * Checks if the puzzle is completed
+   * @returns boolean indicating if the puzzle is completed
+   */
+  override validatePuzzleCompletion(): boolean {
+    return this.droppedLetters === this.getTargetText();
+  }
+
+  /**
+   * Sets the dropped letters
+   * @param letters - The letters that were dropped
+   */
+  setDroppedLetters(letters: string): void {
+    this.droppedLetters = letters;
+  }
+
+  /**
+   * Appends letters to the dropped letters
+   * @param letters - The letters to append
+   */
+  appendDroppedLetters(letters: string): void {
+    this.droppedLetters += letters;
+  }
+
+  /**
+   * Gets the dropped letters
+   * @returns The dropped letters
+   */
+  getDroppedLetters(): string {
+    return this.droppedLetters;
+  }
+
+  /**
+   * Clears the dropped letters
+   */
+  clearDroppedLetters(): void {
+    this.droppedLetters = '';
+  }
+
+  /**
+   * Checks if this is a sound word puzzle
+   * @returns boolean indicating if this is a sound word puzzle
+   */
+  isSoundWordPuzzle(): boolean {
+    return this.getPuzzleType() === 'SoundWord';
+  }
+
+  /**
+   * Updates the puzzle level
+   * @param puzzleNumber - The new puzzle number
+   */
+  override updatePuzzleLevel(puzzleNumber: number): void {
+    super.updatePuzzleLevel(puzzleNumber);
+    this.clearDroppedLetters();
+  }
+}

--- a/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.spec.ts
+++ b/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.spec.ts
@@ -1,0 +1,167 @@
+import WordPuzzleLogic from './wordPuzzleLogic';
+
+describe('WordPuzzleLogic', () => {
+  let wordPuzzleLogic: WordPuzzleLogic;
+  const mockLevelData = {
+    levelNumber: 1,
+    levelMeta: {
+      letterGroup: 1,
+      levelNumber: 1,
+      levelType: 'Word',
+      promptFadeOut: 1,
+      protoType: 'test'
+    },
+    puzzles: [
+      {
+        foilStones: ['c', 'a', 't', 'd', 'o', 'g'],
+        prompt: {
+          promptAudio: 'audio.mp3',
+          promptText: 'cat'
+        },
+        segmentNumber: 1,
+        targetStones: ['c', 'a', 't']
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    wordPuzzleLogic = new WordPuzzleLogic(mockLevelData, 0);
+  });
+
+  test('should initialize with empty values', () => {
+    const values = wordPuzzleLogic.getValues();
+    expect(values.groupedLetters).toBe('');
+    expect(values.droppedLetters).toBe('');
+    expect(values.groupedObj).toEqual({});
+    expect(values.droppedHistory).toEqual({});
+    expect(values.hideListObj).toEqual({});
+  });
+
+  test('should correctly identify as a word puzzle', () => {
+    expect(wordPuzzleLogic.checkIsWordPuzzle()).toBe(true);
+  });
+
+  test('should correctly get the target word', () => {
+    expect(wordPuzzleLogic.getCorrectTargetStone()).toBe('cat');
+  });
+
+  test('should correctly check if letter drop is correct', () => {
+    // For a single letter (isWord = false)
+    expect(wordPuzzleLogic.isLetterDropCorrect('cat', false)).toBe(true);
+    expect(wordPuzzleLogic.isLetterDropCorrect('dog', false)).toBe(false);
+
+    // For a partial word (isWord = true)
+    expect(wordPuzzleLogic.isLetterDropCorrect('c', true)).toBe(true);
+    expect(wordPuzzleLogic.isLetterDropCorrect('ca', true)).toBe(true);
+    expect(wordPuzzleLogic.isLetterDropCorrect('cat', true)).toBe(true);
+    expect(wordPuzzleLogic.isLetterDropCorrect('d', true)).toBe(false);
+  });
+
+  test('should handle picking up letters correctly', () => {
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    
+    let values = wordPuzzleLogic.getValues();
+    expect(values.groupedLetters).toBe('c');
+    expect(values.groupedObj[0]).toBe('c');
+    
+    wordPuzzleLogic.setPickUpLetter('a', 1);
+    
+    values = wordPuzzleLogic.getValues();
+    expect(values.groupedLetters).toBe('ca');
+    expect(values.groupedObj[1]).toBe('a');
+  });
+
+  test('should handle setting grouped letters to dropped correctly', () => {
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    wordPuzzleLogic.setPickUpLetter('a', 1);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    const values = wordPuzzleLogic.getValues();
+    expect(values.droppedLetters).toBe('ca');
+    expect(values.droppedHistory[0]).toBe('c');
+    expect(values.droppedHistory[1]).toBe('a');
+  });
+
+  test('should validate fed letters correctly', () => {
+    // Create a spy on the validateFedLetters method to see what's happening
+    const validateFedLettersSpy = jest.spyOn(wordPuzzleLogic, 'validateFedLetters');
+    
+    // Set the first letter
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    // Check the droppedLetters value
+    const values1 = wordPuzzleLogic.getValues();
+    expect(values1.droppedLetters).toBe('c');
+    expect(wordPuzzleLogic.validateFedLetters()).toBe(true);
+    
+    // Set the second letter
+    wordPuzzleLogic.setPickUpLetter('a', 1);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    // Check the droppedLetters value
+    const values2 = wordPuzzleLogic.getValues();
+    expect(values2.droppedLetters).toBe('ca');
+    expect(wordPuzzleLogic.validateFedLetters()).toBe(true);
+    
+    // Create a new instance with incorrect letters
+    const newWordPuzzleLogic = new WordPuzzleLogic(mockLevelData, 0);
+    newWordPuzzleLogic.setPickUpLetter('d', 3);
+    newWordPuzzleLogic.setGroupToDropped();
+    expect(newWordPuzzleLogic.validateFedLetters()).toBe(false);
+  });
+
+  test('should validate puzzle completion correctly', () => {
+    // Set the first letter
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    // Check the droppedLetters value
+    const values1 = wordPuzzleLogic.getValues();
+    expect(values1.droppedLetters).toBe('c');
+    expect(wordPuzzleLogic.validatePuzzleCompletion()).toBe(false);
+    
+    // Set the second letter
+    wordPuzzleLogic.setPickUpLetter('a', 1);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    // Check the droppedLetters value
+    const values2 = wordPuzzleLogic.getValues();
+    expect(values2.droppedLetters).toBe('ca');
+    expect(wordPuzzleLogic.validatePuzzleCompletion()).toBe(false);
+    
+    // Set the third letter
+    wordPuzzleLogic.setPickUpLetter('t', 2);
+    wordPuzzleLogic.setGroupToDropped();
+    
+    // Check the droppedLetters value
+    const values3 = wordPuzzleLogic.getValues();
+    expect(values3.droppedLetters).toBe('cat');
+    expect(wordPuzzleLogic.validatePuzzleCompletion()).toBe(true);
+  });
+
+  test('should clear picked up letters correctly', () => {
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    wordPuzzleLogic.setPickUpLetter('a', 1);
+    
+    wordPuzzleLogic.clearPickedUp();
+    
+    const values = wordPuzzleLogic.getValues();
+    expect(values.groupedLetters).toBe('');
+    expect(values.groupedObj).toEqual({});
+  });
+
+  test('should validate if stone should be hidden correctly', () => {
+    // Initially no stones should be hidden
+    expect(wordPuzzleLogic.validateShouldHideLetter(0)).toBe(true);
+    
+    // After picking up a letter, it should be hidden
+    wordPuzzleLogic.setPickUpLetter('c', 0);
+    expect(wordPuzzleLogic.validateShouldHideLetter(0)).toBe(true);
+    
+    // After clearing picked up letters, the letter should still be hidden
+    // because it's in the hideListObj
+    wordPuzzleLogic.clearPickedUp();
+    expect(wordPuzzleLogic.validateShouldHideLetter(0)).toBe(true);
+  });
+});

--- a/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.ts
+++ b/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.ts
@@ -1,4 +1,6 @@
-export default class WordPuzzleLogic {
+import BasePuzzleLogic from '../basePuzzleLogic/basePuzzleLogic';
+
+export default class WordPuzzleLogic extends BasePuzzleLogic {
     /**
         puzzleNumber - Puzzle stage level of current (Up to 5 stage levels) game level.
         groupedLetters - String sequence of letters when performing the multi-letter seleciton.
@@ -9,28 +11,6 @@ export default class WordPuzzleLogic {
         hideListObj - Object with key properties of stone letter index.
                     Used to hide stones that is part of the group or stones that was already fed to the monster.
     **/
-    private levelData: {
-        levelNumber: number;
-        levelMeta: {
-            letterGroup: number;
-            levelNumber: number;
-            levelType: string;
-            promptFadeOut: number;
-            protoType: string;
-        };
-        puzzles: [
-            {
-                foilStones: string[];
-                prompt: {
-                    promptAudio: string;
-                    promptText: string;
-                };
-                segmentNumber: number;
-                targetStones: string[];
-            }
-        ];
-    }
-    private puzzleNumber: number;
     private groupedLetters: string;
     private droppedLetters: string;
     private groupedObj: {} | { [key:number]: string };
@@ -38,8 +18,7 @@ export default class WordPuzzleLogic {
     private hideListObj: {} | { [key:number]: string };
 
     constructor(levelData, puzzleNumber) {
-        this.levelData = levelData;
-        this.puzzleNumber = puzzleNumber;
+        super(levelData, puzzleNumber);
         this.groupedLetters = '';
         this.droppedLetters = '';
         this.groupedObj = {};
@@ -47,11 +26,7 @@ export default class WordPuzzleLogic {
         this.hideListObj = {};
     }
 
-    private getTargetWord():string {
-        return this.levelData.puzzles[this.puzzleNumber]?.prompt?.promptText;
-    }
-
-    getValues(): {
+    override getValues(): {
         groupedLetters: string;
         droppedLetters: string;
         groupedObj: { [key:number]: string },
@@ -67,16 +42,12 @@ export default class WordPuzzleLogic {
         }
     }
 
-    checkIsWordPuzzle():boolean {
-        return this.levelData?.levelMeta?.levelType === 'Word';
-    }
-
-    updatePuzzleLevel(puzzleNumber: number):void {
+    override updatePuzzleLevel(puzzleNumber: number):void {
         this.clearAllValues();
-        this.puzzleNumber = puzzleNumber;
+        super.updatePuzzleLevel(puzzleNumber);
     }
 
-    clearPickedUp():void {
+    override clearPickedUp():void {
         this.groupedLetters = '';
         this.groupedObj = {};
         this.hideListObj = { ...this.droppedHistory };
@@ -88,17 +59,16 @@ export default class WordPuzzleLogic {
         this.groupedObj = {};
         this.droppedHistory = {};
         this.hideListObj = {};
-        this.puzzleNumber = 0;
     }
 
-    validateShouldHideLetter(foilStoneIndex):boolean {
+    override validateShouldHideLetter(foilStoneIndex):boolean {
         //If stone key index is listed in hideListObj it should not be drawn.
-        return !this.hideListObj[foilStoneIndex];
+        return this.hideListObj[foilStoneIndex] === undefined;
     }
 
-    handleCheckHoveredStone(foilStoneText:string, foilStoneIndex:number):boolean {
+    override handleCheckHoveredStone(foilStoneText:string, foilStoneIndex:number):boolean {
         const combinedLetters = this.groupedLetters;
-        const targetWord = this.getTargetWord();
+        const targetWord = this.getTargetText();
 
         /* Goes inside here if there are no previous letter(s) were dropped
         and grouping of letters starts in a incorrect letter. */
@@ -118,29 +88,60 @@ export default class WordPuzzleLogic {
     }
 
     validateFedLetters():boolean {
-        const targetWord = this.getTargetWord();
-        return this.droppedLetters === targetWord.substring(0, this.droppedLetters.length);
+        const targetWord = this.getTargetText();
+        return targetWord.startsWith(this.droppedLetters);
     }
 
-    validateWordPuzzle():boolean {
-        const targetWord = this.getTargetWord();
+    override validatePuzzleCompletion():boolean {
+        const targetWord = this.getTargetText();
         return this.droppedLetters === targetWord;
     }
 
-    setGroupToDropped():void {
-        this.droppedLetters = `${this.droppedLetters}${this.groupedLetters}`;
+    override setGroupToDropped():void {
+        // Update dropped letters with the current grouped letters
+        this.droppedLetters += this.groupedLetters;
+        
+        // Update dropped history with the current grouped object
         this.droppedHistory = {
             ...this.droppedHistory,
             ...this.groupedObj
         };
+        
+        // Clear the grouped letters after dropping
+        this.groupedLetters = '';
+        this.groupedObj = {};
     }
 
-    setPickUpLetter(letter: string, arrFoilStoneIndex: number):void {
+    override setPickUpLetter(letter: string, arrFoilStoneIndex: number):void {
         this.hideListObj = {
             ...this.hideListObj,
             ...this.groupedObj
         }; //Hide the previous letters except the new one.
         this.groupedLetters = `${this.groupedLetters}${letter}`;
         this.groupedObj[arrFoilStoneIndex] = letter;
+    }
+
+    /**
+     * Checks if the dropped stone letter is correct
+     * @param droppedStone - The letter or word that was dropped
+     * @param isWord - Whether this is a word puzzle
+     * @returns boolean indicating if the dropped letter/word is correct
+     */
+    override isLetterDropCorrect(droppedStone: string, isWord: boolean = false): boolean {
+        const targetWord = this.getTargetText();
+        if (isWord) {
+            return droppedStone === targetWord.substring(0, droppedStone.length);
+        } else {
+            // For single letter puzzles - not typically used in Word puzzles
+            return targetWord.includes(droppedStone);
+        }
+    }
+
+    /**
+     * Gets the correct target stone/word
+     * @returns string - The correct target stone/word
+     */
+    override getCorrectTargetStone(): string {
+        return this.getTargetText();
     }
 }


### PR DESCRIPTION
# Changes
- Refactored puzzle logic into a modular, extensible architecture with separate components for different puzzle types and audio feedback, improving maintainability and testability.

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select any level and play
- make sure audio is still working as before

Ref: [FM-468](https://curiouslearning.atlassian.net/browse/FM-468)


[FM-468]: https://curiouslearning.atlassian.net/browse/FM-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ