### PR TITLE
fix: rtl spacing fix (Fm-463)

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -98,8 +98,3 @@
 .text-red {
   color: red;
 }
-
-// Letter spacing
-.letter-spacing {
-  margin-left: 5px;
-}

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -216,7 +216,7 @@ export class PromptText extends BaseHTML {
                         ? "text-black" 
                         : "text-red";
                     
-                    html += `<span class="${letterClass} letter-spacing">${this.targetStones[i]}</span>`;
+                    html += `<span class="${letterClass}">${this.targetStones[i]}</span>`;
                 }
                 
                 wrapper.innerHTML = html;


### PR DESCRIPTION
# Changes
- Fixed the extra spacing in RTL languages

# How to test
- Run any RTL languages
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select and play the word game
- Make sure there's no extra spaces in the word

Ref: [Fm-463](https://curiouslearning.atlassian.net/browse/Fm-463)
