### PR TITLE
fix: FM-489 Feedback audios are not playing in Australian English test build.

### DIFF
--- a/lang/australianenglish/ftm_australianenglish.json
+++ b/lang/australianenglish/ftm_australianenglish.json
@@ -10,9 +10,9 @@
   "minversion": 29,
   "langname": "AUSTRALIANENGLISH",
   "FeedbackAudios": [
-    "https://feedthemonster.curiouscontent.org/lang/austrailianenglish/audios/fantastic.mp3",
-    "https://feedthemonster.curiouscontent.org/lang/austrailianenglish/audios/great.mp3",
-    "https://feedthemonster.curiouscontent.org/lang/austrailianenglish/audios/amazing.mp3"
+    "https://feedthemonster.curiouscontent.org/lang/australianenglish/audios/fantastic.mp3",
+    "https://feedthemonster.curiouscontent.org/lang/australianenglish/audios/great.mp3",
+    "https://feedthemonster.curiouscontent.org/lang/australianenglish/audios/amazing.mp3"
   ],
   "OtherAudios": {
     "Select your player": "https://feedthemonster.curiouscontent.org/lang/australianenglish/audios/Select-your-player.mp3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedthemonsterjs",
-  "version": "1.1.0",
+  "version": "1.0.40",
   "description": "education app",
   "main": "feedTheMonster.js",
   "scripts": {


### PR DESCRIPTION
# Changes
- Feedback audios are not playing in Australian English test build.
- Fixed the typo in Australian English json file

Ref: [FM-489](https://curiouslearning.atlassian.net/browse/Fm-489)


[FM-489]: https://curiouslearning.atlassian.net/browse/FM-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ