### PR TITLE
fix: The intro audio plays in the background in Gameplay screen and other screen. (FM-504)

### DIFF
--- a/src/components/evolutionAnimation/evolution-animation.ts
+++ b/src/components/evolutionAnimation/evolution-animation.ts
@@ -144,11 +144,18 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
     // Set flag to indicate we're playing intro audio due to visibility change
     this.isPlayingIntroFromVisibilityChange = true;
     
-    // Play both audio files simultaneously if the document is visible
+    // Play both audio files with a 1-second delay between them if the document is visible
     if (isDocumentVisible()) {
-      // Play both audio files simultaneously instead of in sequence this is to follow the levelend scene behavior
+      // Play the first audio immediately
       this.audioPlayer.playAudio(AUDIO_MONSTER_EVOLVE);
-      this.audioPlayer.playAudio(AUDIO_INTRO);
+      
+      // Play the second audio after a 1-second delay
+      setTimeout(() => {
+        // Double-check visibility before playing the delayed audio
+        if (isDocumentVisible()) {
+          this.audioPlayer.playAudio(AUDIO_INTRO);
+        }
+      }, 1000);
     } else {
       this.isPlayingIntroFromVisibilityChange = false;
     }
@@ -206,22 +213,24 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
 
   // Play audio sequence after evolution animation completes
   private playEvolutionCompletionAudios() {
-    // If intro audio is already playing from visibility change, skip playing evolution audio
-    if (this.isPlayingIntroFromVisibilityChange) {
-      return;
-    }
-
     // First stop any currently playing audio
     this.audioPlayer.stopAllAudios();
 
-    // Only proceed if the tab is visible to avoid unnecessary audio loading
+    // Only proceed if the tab is visible to avoid unnecessary audio playback
     if (!isDocumentVisible()) {
       return;
     }
 
-    // Play both audio files simultaneously instead of in sequence
+    // Play the first audio immediately
     this.audioPlayer.playAudio(AUDIO_MONSTER_EVOLVE);
-    this.audioPlayer.playAudio(AUDIO_INTRO);
+    
+    // Play the second audio after a 1-second delay
+    setTimeout(() => {
+      // Double-check visibility before playing the delayed audio
+      if (isDocumentVisible()) {
+        this.audioPlayer.playAudio(AUDIO_INTRO);
+      }
+    }, 1000);
   }
 
   public startAnimation() {

--- a/src/components/evolutionAnimation/evolution-animation.ts
+++ b/src/components/evolutionAnimation/evolution-animation.ts
@@ -63,6 +63,10 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
     this.audioPlayer = new AudioPlayer();
     this.initialize();
     this.addEventListener();
+    
+    // Preload audio files during initialization to avoid delays later
+    this.preloadAudioFiles();
+    
     this.startAnimation();
   }
 
@@ -119,25 +123,35 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
   };
 
   /**
+   * Preloads all audio files needed for the evolution animation
+   * This ensures audio plays without delay when needed
+   */
+  private preloadAudioFiles() {
+    // Preload intro audio and evolution audio during initialization
+    this.audioPlayer.preloadGameAudio(AUDIO_INTRO);
+    this.audioPlayer.preloadGameAudio(AUDIO_MONSTER_EVOLVE);
+    
+    // Preload evolution sound effects
+    if (EVOLUTION_AUDIOS.EVOL_1 && EVOLUTION_AUDIOS.EVOL_1[0]) {
+      this.audioPlayer.preloadGameAudio(EVOLUTION_AUDIOS.EVOL_1[0]);
+    }
+  }
+
+  /**
    * Plays the intro audio when returning to the tab
    */
   private playIntroAudio() {
     // Set flag to indicate we're playing intro audio due to visibility change
     this.isPlayingIntroFromVisibilityChange = true;
     
-    // Preload and play the intro audio
-    this.audioPlayer.preloadGameAudio(AUDIO_INTRO)
-      .then(() => {
-        // Double-check visibility before playing to avoid unnecessary audio playback
-        if (isDocumentVisible()) {
-          this.audioPlayer.playAudioQueue(false, AUDIO_INTRO);
-        } else {
-          this.isPlayingIntroFromVisibilityChange = false;
-        }
-      })
-      .catch(() => {
-        this.isPlayingIntroFromVisibilityChange = false;
-      });
+    // Play both audio files simultaneously if the document is visible
+    if (isDocumentVisible()) {
+      // Play both audio files simultaneously instead of in sequence this is to follow the levelend scene behavior
+      this.audioPlayer.playAudio(AUDIO_MONSTER_EVOLVE);
+      this.audioPlayer.playAudio(AUDIO_INTRO);
+    } else {
+      this.isPlayingIntroFromVisibilityChange = false;
+    }
   }
 
   /**
@@ -205,23 +219,9 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
       return;
     }
 
-    // Preload all audio files to ensure they're ready to play
-    Promise.all([
-      this.audioPlayer.preloadGameAudio(AUDIO_MONSTER_EVOLVE),
-      this.audioPlayer.preloadGameAudio(AUDIO_INTRO)
-    ]).then(() => {
-      // Double-check visibility before playing
-      if (isDocumentVisible() && !this.isPlayingIntroFromVisibilityChange) {
-        // Play audio sequence in order using the playAudioQueue method
-        this.audioPlayer.playAudioQueue(
-          false, 
-          AUDIO_MONSTER_EVOLVE,
-          AUDIO_INTRO
-        );
-      }
-    }).catch(() => {
-      // Silent error handling
-    });
+    // Play both audio files simultaneously instead of in sequence
+    this.audioPlayer.playAudio(AUDIO_MONSTER_EVOLVE);
+    this.audioPlayer.playAudio(AUDIO_INTRO);
   }
 
   public startAnimation() {

--- a/src/components/evolutionAnimation/evolution-animation.ts
+++ b/src/components/evolutionAnimation/evolution-animation.ts
@@ -130,11 +130,6 @@ export class EvolutionAnimationComponent extends RiveMonsterComponent {
     // Preload intro audio and evolution audio during initialization
     this.audioPlayer.preloadGameAudio(AUDIO_INTRO);
     this.audioPlayer.preloadGameAudio(AUDIO_MONSTER_EVOLVE);
-    
-    // Preload evolution sound effects
-    if (EVOLUTION_AUDIOS.EVOL_1 && EVOLUTION_AUDIOS.EVOL_1[0]) {
-      this.audioPlayer.preloadGameAudio(EVOLUTION_AUDIOS.EVOL_1[0]);
-    }
   }
 
   /**


### PR DESCRIPTION
# Changes
-  preload audios plays and minimize delay in the evolution screen

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen

Ref: [FM-504](https://curiouslearning.atlassian.net/browse/FM-504)


[FM-504]: https://curiouslearning.atlassian.net/browse/FM-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ