### PR TITLE
fix: the dev button in prod env (FM-531)

### DIFF
--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -334,7 +334,7 @@ class App {
   }
 
   private updateVersionInfoElement(dataModal: DataModal): void {
-    const isDevOrTestEnv = this.is_cached.has(this.lang) && (Debugger.TestLink || Debugger.DevelopmentLink);
+    const isDevOrTestEnv = this.is_cached.has(this.lang) && (Debugger.TestLink || Debugger.DevelopmentLink || Debugger.DebugMode);
     
     // Update version info when in development/test environment
     if (isDevOrTestEnv) {
@@ -345,10 +345,10 @@ class App {
       }
     }
     
-    // Set toggle button visibility - only show in development/test environment
+    // Set toggle button visibility - show in development/test environment or when debug mode is enabled
     const toggleBtn = document.getElementById("toggle-btn");
     if (toggleBtn) {
-      toggleBtn.style.display = isDevOrTestEnv ? "block" : "none";
+      toggleBtn.style.display = (isDevOrTestEnv) ? "block" : "none";
     }
   }
 

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -334,13 +334,21 @@ class App {
   }
 
   private updateVersionInfoElement(dataModal: DataModal): void {
-    if (this.is_cached.has(this.lang) && (Debugger.TestLink || Debugger.DevelopmentLink)) {
+    const isDevOrTestEnv = this.is_cached.has(this.lang) && (Debugger.TestLink || Debugger.DevelopmentLink);
+    
+    // Update version info when in development/test environment
+    if (isDevOrTestEnv) {
       if (dataModal.majVersion && dataModal.minVersion) {
         this.versionInfoElement.innerHTML += `/j.v${dataModal.majVersion}.${dataModal.minVersion}`;
       } else if (dataModal.version) {
         this.versionInfoElement.innerHTML += `/j.v${dataModal.version}`;
       }
-      document.getElementById("toggle-btn").style.display = "block";
+    }
+    
+    // Set toggle button visibility - only show in development/test environment
+    const toggleBtn = document.getElementById("toggle-btn");
+    if (toggleBtn) {
+      toggleBtn.style.display = isDevOrTestEnv ? "block" : "none";
     }
   }
 


### PR DESCRIPTION
# Changes
- Fix the prod env dev button appearing

# How to test
- Open the start screen of FTM live or prod
- Make sure the button is not visible in prod

Ref: [FM-531](https://curiouslearning.atlassian.net/browse/FM-531)


[FM-531]: https://curiouslearning.atlassian.net/browse/FM-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ