### PR TITLE
fix: Updated handling on scene-handler for gameplay and retry scene handling (FM-532)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -172,6 +172,7 @@ export enum MonsterState {
 export const SCENE_NAME_START = "StartScene";
 export const SCENE_NAME_LEVEL_SELECT = "LevelSelection";
 export const SCENE_NAME_GAME_PLAY = "GamePlay";
+export const SCENE_NAME_GAME_PLAY_REPLAY = "GamePlay_Replay";
 export const SCENE_NAME_LEVEL_END = "LevelEnd";
 
 //Levels

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -11,6 +11,7 @@ import {
   SCENE_NAME_START,
   SCENE_NAME_LEVEL_SELECT,
   SCENE_NAME_GAME_PLAY,
+  SCENE_NAME_GAME_PLAY_REPLAY,
   SCENE_NAME_LEVEL_END,
   PWAInstallStatus,
   PreviousPlayedLevel,
@@ -53,7 +54,7 @@ export class SceneHandler {
           this.currentScene = sceneName;
           this.handleSwitchScene(sceneName);
         }
-         }
+      }
     );
   }
 
@@ -143,6 +144,7 @@ export class SceneHandler {
       case SCENE_NAME_LEVEL_SELECT:
         return new LevelSelectionScreen();
       case SCENE_NAME_GAME_PLAY:
+      case SCENE_NAME_GAME_PLAY_REPLAY:
         return new GameplayScene();
       case SCENE_NAME_LEVEL_END:
         return new LevelEndScene();

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -37,6 +37,7 @@ import { FirebaseIntegration } from "../../Firebase/firebase-integration";
 import {
   SCENE_NAME_LEVEL_SELECT,
   SCENE_NAME_GAME_PLAY,
+  SCENE_NAME_GAME_PLAY_REPLAY,
   SCENE_NAME_LEVEL_END,
   PreviousPlayedLevel,
   MONSTER_PHASES
@@ -147,7 +148,7 @@ export class GameplayScene {
             currentLevelData: this.levelData,
             selectedLevelNumber: this.levelNumber,
           });
-          gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_GAME_PLAY);
+          gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_GAME_PLAY_REPLAY);
           break;
         case PAUSE_POPUP_EVENT_DATA.SELECT_LEVEL:
           gameStateService.publish(gameStateService.EVENTS.GAME_PAUSE_STATUS_EVENT, false);


### PR DESCRIPTION
# Changes
- Added handling on scene handling for gameplay and game repeat to make sure it will work on the logic for preventing redundant scene initialization.

# How to test
- FTM redirection should work.
- App should not break on stress testing.

Ref: [FM-532](https://curiouslearning.atlassian.net/browse/FM-532)


[FM-532]: https://curiouslearning.atlassian.net/browse/FM-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ