### PR TITLE
Feat: Updated Tutorial Drag Drop Point and Added Clear Tutorial Feature (FM-510 & FM-542).

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -8,6 +8,7 @@ import {
   isDocumentVisible,
   toggleDebugMode,
   hideElement,
+  getGameTypeName
 } from "./utils";
 import { Debugger, lang, font, pseudoId, Window, source, campaign_id } from "./global-variables";
 import {
@@ -49,5 +50,6 @@ export {
   isClickInsideButton,
   isDocumentVisible,
   toggleDebugMode,
-  hideElement
+  hideElement,
+  getGameTypeName
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -192,3 +192,8 @@ export const hideElement = (isHide: boolean = false, element: HTMLElement) => {
     element.classList.add("show");
   }
 };
+
+export const getGameTypeName = (protoType: string, levelType: string) => {
+  //If prototype is Visible it means its not an audio puzzle.
+  return protoType === 'Visible' ? levelType : `Sound${levelType}`;
+}

--- a/src/components/riveMonster/rive-monster-component.spec.ts
+++ b/src/components/riveMonster/rive-monster-component.spec.ts
@@ -1,6 +1,7 @@
 import { Rive, Layout, Fit, Alignment } from '@rive-app/canvas';
 import { MONSTER_PHASES } from '@constants';
 import { RiveMonsterComponent } from './rive-monster-component';
+import gameStateService from '@gameStateService';
 
 jest.mock('@gameSettingsService', () => ({
   __esModule: true,
@@ -59,6 +60,13 @@ jest.mock('@rive-app/canvas', () => {
     Alignment: { Center: 'Center' }
   };
 });
+
+jest.mock('@gameStateService', () => ({
+  __esModule: true,
+  default: {
+    saveHitBoxRanges: jest.fn()
+  }
+}));
 
 describe('RiveMonsterComponent', () => {
   let canvas, gameCanvas, component;

--- a/src/components/riveMonster/rive-monster-component.ts
+++ b/src/components/riveMonster/rive-monster-component.ts
@@ -1,6 +1,7 @@
 import { MONSTER_PHASES, CACHED_RIVE_WASM } from '@constants';
 import { Rive, Layout, Fit, Alignment, RuntimeLoader } from '@rive-app/canvas';
 import gameSettingsService from '@gameSettingsService';
+import gameStateService from '@gameStateService';
 
 RuntimeLoader.setWasmUrl(CACHED_RIVE_WASM);
 export interface RiveMonsterComponentProps {
@@ -129,6 +130,8 @@ export class RiveMonsterComponent {
       from: monsterTopY + hitboxPaddingY + hitboxOffsetY,
       to: monsterBottomY - hitboxPaddingY + hitboxOffsetY,
     };
+
+    gameStateService.saveHitBoxRanges({ hitboxRangeX: this.hitboxRangeX, hitboxRangeY: this.hitboxRangeY });
   }
 
   // do not delete to check hitbox overlay

--- a/src/gameStateService/gameStateService.ts
+++ b/src/gameStateService/gameStateService.ts
@@ -2,6 +2,17 @@ import { PubSub } from '../events/pub-sub-events';
 import { DataModal, GameScore } from "@data";
 import { getGameTypeName } from '@common';
 
+export interface hitboxRangeType {
+    hitboxRangeX: {
+        from: number,
+        to: number
+    },
+    hitboxRangeY: {
+        from: number,
+        to: number
+    }
+}
+
 /*
  * GameStateService.ts
  * The GameStateService class is reponsible to managing the current state of the game (ts).
@@ -74,6 +85,7 @@ export class GameStateService extends PubSub {
     public isLastLevel: boolean;
     public currentMonsterPhase: number;
     public tutorialOn: boolean = false;
+    public hitboxRanges: null | hitboxRangeType;
 
     constructor() {
         super();
@@ -259,5 +271,13 @@ export class GameStateService extends PubSub {
 
     public updateMonsterPhaseState(newMonsterPhaseNum: number) {
         this.monsterPhaseNumber = newMonsterPhaseNum;
+    }
+
+    public saveHitBoxRanges(hitboxRangeXandY: hitboxRangeType) {
+        this.hitboxRanges = hitboxRangeXandY;
+    }
+
+    public getHitBoxRanges() {
+        return this.hitboxRanges;
     }
 };

--- a/src/scenes/gameplay-scene/gameplay-scene.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.spec.ts
@@ -120,7 +120,8 @@ jest.mock('@gameStateService', () => ({
       GAMEPLAY_DATA_EVENT: 'GAMEPLAY_DATA_EVENT',
       SWITCH_SCENE_EVENT: 'SWITCH_SCENE_EVENT',
     },
-    getGameTypeList: jest.fn()
+    getGameTypeList: jest.fn(),
+    saveHitBoxRanges: jest.fn()
   }
 }));
 

--- a/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
+++ b/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
@@ -17,7 +17,7 @@ export default class MatchLetterPuzzleTutorial extends TutorialComponent {
     this.height = height;
     this.frame = 0;
     this.animationStartTime = 0;
-    this.stonePosDetailsType = this.updateTargetStonePositions(stonePosVal, this.width, this.height);
+    this.stonePosDetailsType = this.updateTargetStonePositions(stonePosVal);
     this.stoneImg = stoneImg
     this.animateImagePosVal = this.stonePosDetailsType.animateImagePosVal;
     this.x = this.animateImagePosVal.x;

--- a/src/tutorials/base-tutorial/base-tutorial-component.ts
+++ b/src/tutorials/base-tutorial/base-tutorial-component.ts
@@ -1,4 +1,5 @@
 import { TUTORIAL_HAND } from "@constants";
+import gameStateService from '@gameStateService';
 export interface AnimStoneImagePosValTypes {
   x: number,
   y: number,
@@ -135,18 +136,44 @@ export default class TutorialComponent {
     return { x, y, dx, dy, absdx, absdy };
   }
 
+  private getHitboxPosition() {
+    const hitboxRanges: {
+      hitboxRangeX: {
+        from: number,
+        to: number
+      },
+      hitboxRangeY: {
+        from: number,
+        to: number
+      }
+  } = gameStateService.getHitBoxRanges();
+    const getRangeCenter = (hitBoxFromPos: number, hitBoxToPos: number) => {
+      return (hitBoxFromPos + hitBoxToPos) / 2;
+    }
+
+    return {
+      endX: getRangeCenter(
+        hitboxRanges.hitboxRangeX.from,
+        hitboxRanges.hitboxRangeX.to
+      ),
+      endY: getRangeCenter(
+        hitboxRanges.hitboxRangeY.from,
+        hitboxRanges.hitboxRangeY.to
+      )
+    }
+  }
+
   /**
    * Method name is same similar to original from tutorial.ts
    * @param targetStonePosition array [x and y ] position of the stone we want to animate in tutorial.
-   * @param width width of screen
-   * @param height height of screen
    */
-  public updateTargetStonePositions(targetStonePosition: number[], width: number, height: number): StonePosDetailsType {
+  public updateTargetStonePositions(targetStonePosition: number[]): StonePosDetailsType {
     //To Do - This will be the original for now and will need to be updated once we have a clear goal on the rest of the tutorial flow.
     const startX = targetStonePosition[0] - 22;
     const startY = targetStonePosition[1] - 50;
-    const endX = width / 2;
-    const endY = height / 2;
+    const { endX, endY } = this.getHitboxPosition();
+
+    //Monster Stone Difference is the target where the stone will be dropped for the tutorial.
     const monsterStoneDifference = Math.sqrt((startX - endX) * (startX - endX) + (startY - endY) * (startY - endY));
     const animateImagePosVal = this.animateImage({
       startX,

--- a/src/tutorials/tutorial-handler.spec.ts
+++ b/src/tutorials/tutorial-handler.spec.ts
@@ -35,7 +35,7 @@ describe('TutorialHandler', () => {
       shouldHaveTutorial: true // <-- Important
     });
 
-    expect(gameStateService.subscribe).toHaveBeenCalledTimes(2);
+    expect(gameStateService.subscribe).toHaveBeenCalledTimes(3);
     expect(gameStateService.getGameTypeList).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Changes
- Added clear tutorial logic using gameStateService and GameScore getAllGameLevelInfo.
- Added a level-end subscription for Tutorial Handler to flag the tutorial as cleared.
- Updated the logic on how the tutorial drag computes for the drop location.

# How to test
- Start FTM app.
- Play on level 1, segment 1 of the puzzle.
- Tutorial should show up.
- The drag tutorial should drag where the hitbox is and it is close to the Rive monster.
- After clearing the level 1 game, when we repeat the level. The tutorial should not show up.

Ref: [FM-542](https://curiouslearning.atlassian.net/browse/FM-542)
Ref: [FM-510](https://curiouslearning.atlassian.net/browse/FM-510)


[FM-542]: https://curiouslearning.atlassian.net/browse/FM-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FM-510]: https://curiouslearning.atlassian.net/browse/FM-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ