### PR TITLE
fix: Allowed retry scene name to be re-instance (FM-554).

### DIFF
--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -50,7 +50,11 @@ export class SceneHandler {
     this.unsubscribeEvent = gameStateService.subscribe(
       gameStateService.EVENTS.SWITCH_SCENE_EVENT,
       (sceneName: string) => {
-        if (!this.currentScene || this.currentScene !== sceneName) {
+        if (
+          !this.currentScene ||
+          this.currentScene !== sceneName || //Prevents the double instance of the same scene (fix from FM-532 issue).
+          sceneName === SCENE_NAME_GAME_PLAY_REPLAY //If the scene AGAIN is reply, always allow it as Reply is manual and user triggered.
+        ) {
           this.currentScene = sceneName;
           this.handleSwitchScene(sceneName);
         }


### PR DESCRIPTION
# Changes
- Allowed Replay Scene Flag to be reinitialized even if the scene name is already Replay-Scene.

# How to test
- Run FTM App
- Select any game level
- At the game start perform the retry button.
- As the game starts again, retry for the second time.
- App should still reply the game level.

Ref: [FM-554](https://curiouslearning.atlassian.net/browse/FM-554)
