### PR TITLE
optimized: Removed Timer from Stone-handler (FM-557).

### DIFF
--- a/src/common/stone-config/stone-config.spec.ts
+++ b/src/common/stone-config/stone-config.spec.ts
@@ -1,10 +1,8 @@
 import { StoneConfig } from './stone-config';
-import { TimerTicking } from '@components';
 
 describe('StoneConfig', () => {
   let stoneConfig: StoneConfig;
   let mockContext: CanvasRenderingContext2D;
-  let mockTimerTicking: TimerTicking;
   let mockImage: HTMLImageElement;
   let now: number;
 
@@ -30,10 +28,6 @@ describe('StoneConfig', () => {
       }
     } as unknown as CanvasRenderingContext2D;
 
-    mockTimerTicking = {
-      update: jest.fn()
-    } as unknown as TimerTicking;
-
     mockImage = new Image();
     Object.defineProperties(mockImage, {
       width: { value: 100 },
@@ -50,8 +44,7 @@ describe('StoneConfig', () => {
       'A',
       100,
       100,
-      mockImage,
-      mockTimerTicking
+      mockImage
     );
   });
 
@@ -76,8 +69,7 @@ describe('StoneConfig', () => {
         'A',
         targetX,
         100,
-        mockImage,
-        mockTimerTicking
+        mockImage
       );
 
       // Initialize animation
@@ -110,8 +102,7 @@ describe('StoneConfig', () => {
         'A',
         100,
         targetY,
-        mockImage,
-        mockTimerTicking
+        mockImage
       );
 
       // Initialize animation

--- a/src/common/stone-config/stone-config.ts
+++ b/src/common/stone-config/stone-config.ts
@@ -1,5 +1,4 @@
 import { font } from "@common";
-import { TimerTicking } from "@components";
 import gameSettingsService from '@gameSettingsService';
 
 /**
@@ -20,14 +19,13 @@ export class StoneConfig {
     public imageCenterOffsetX: number;
     public imageCenterOffsetY: number;
     public context: CanvasRenderingContext2D;
-    public timerTickingInstance: TimerTicking;
     public frame: number = 0;
     public isDisposed: boolean = false;
     // Performance optimization: Use time-based animation for smoother movement
     private animationStartTime: number = 0;
     private animationDuration: number = 1500; // 1.5 second animation
     public scale = gameSettingsService.getDevicePixelRatioValue();
-    constructor(context, canvasWidth, canvasHeight, stoneLetter, xPos, yPos, img, timerTickingInstance) {
+    constructor(context, canvasWidth, canvasHeight, stoneLetter, xPos, yPos, img) {
         this.x = xPos;
         this.y = yPos;
         this.origx = xPos;
@@ -40,7 +38,6 @@ export class StoneConfig {
         this.calculateImageAndFontSize();
         this.imageCenterOffsetX = this.imageSize / 2.3;
         this.imageCenterOffsetY = this.imageSize / 1.5;
-        this.timerTickingInstance = timerTickingInstance;
     }
 
     public initialize() {
@@ -107,7 +104,7 @@ export class StoneConfig {
             const elapsed = performance.now() - this.animationStartTime;
             this.frame = Math.min(100, (elapsed / this.animationDuration) * 100);
         }
-
+        //shouldResize is used when stone letters are grouped together when playing word puzzle game types.
         const x = this.getX() - (shouldResize ? this.imageCenterOffsetX * 1.25 : this.imageCenterOffsetX);
         const y = this.getY() - (shouldResize ? this.imageCenterOffsetY * 1.25 : this.imageCenterOffsetY);
         const size = shouldResize ? this.imageSize * 1.25 : this.imageSize;
@@ -140,7 +137,6 @@ export class StoneConfig {
         this.isDisposed = true;
         this.img = null;
         this.context = null;
-        this.timerTickingInstance = null;
         this.frame = 0;
     }
 

--- a/src/components/stone-handler/stone-handler.spec.ts
+++ b/src/components/stone-handler/stone-handler.spec.ts
@@ -1,7 +1,7 @@
 // Import dependencies
 import StoneHandler from './stone-handler'; // Adjust path as necessary
 import { StoneConfig } from '@common';
-import { AudioPlayer, TimerTicking } from '@components';
+import { AudioPlayer } from '@components';
 import { AUDIO_PATH_ON_DRAG } from '@constants'; // Import the constant
 
 jest.mock('@components', () => ({
@@ -36,7 +36,6 @@ describe('StoneHandler - playDragAudioIfNecessary', () => {
       mockCanvas,
       0, // Puzzle number
       mockLevelData, // Pass the mocked levelData
-      mockTimerTickingInstance
     );
 
     stoneHandler.audioPlayer = mockAudioPlayer;
@@ -59,7 +58,6 @@ describe('StoneHandler - Latest Optimizations', () => {
   let stoneHandler: StoneHandler;
   let mockContext: CanvasRenderingContext2D;
   let mockCanvas: HTMLCanvasElement;
-  let mockTimerTicking: TimerTicking;
 
   beforeEach(() => {
     mockContext = {
@@ -82,10 +80,6 @@ describe('StoneHandler - Latest Optimizations', () => {
       })
     } as unknown as HTMLCanvasElement;
 
-    mockTimerTicking = {
-      update: jest.fn()
-    } as unknown as TimerTicking;
-
     const mockLevelData = {
       puzzles: [{
         targetStones: ['A', 'B'],
@@ -97,8 +91,7 @@ describe('StoneHandler - Latest Optimizations', () => {
       mockContext,
       mockCanvas,
       0,
-      mockLevelData,
-      mockTimerTicking
+      mockLevelData
     );
   });
 
@@ -149,14 +142,14 @@ describe('StoneHandler - Latest Optimizations', () => {
   describe('Performance Improvements', () => {
     it('should skip disposed stones in draw loop', () => {
       const mockStones = [
-        { frame: 50, draw: jest.fn(), isDisposed: true },
-        { frame: 100, draw: jest.fn(), isDisposed: false }
+        { frame: 150, draw: jest.fn(), isDisposed: true },
+        { frame: 50, draw: jest.fn(), isDisposed: false }
       ];
       stoneHandler.foilStones = mockStones as any[];
-      
-      stoneHandler.draw(16);
-      
-      expect(mockStones[0].draw).not.toHaveBeenCalled();
+
+      stoneHandler.draw();
+      //If the last stone is still below 100 frame, it means the stones hasn't fully loaded yet.
+      expect(stoneHandler.stonesHasLoaded).toEqual(false);
     });
 
     it('should handle animation completion efficiently', () => {
@@ -165,32 +158,15 @@ describe('StoneHandler - Latest Optimizations', () => {
         { frame: 90, draw: jest.fn(), isDisposed: false }
       ];
       stoneHandler.foilStones = mockStones as any[];
-      stoneHandler.isGamePaused = false;
-      
-      stoneHandler.draw(16);
-      
-      // Timer should not update since not all stones are at frame 100
-      expect(mockTimerTicking.update).not.toHaveBeenCalled();
-      
+
+      stoneHandler.draw();
+
       // Update second stone to complete animation
       mockStones[1].frame = 100;
-      stoneHandler.draw(16);
-      
-      // Now timer should update
-      expect(mockTimerTicking.update).toHaveBeenCalledWith(16);
+      stoneHandler.draw();
+
     });
 
-    it('should not update timer when game is paused', () => {
-      const mockStones = [
-        { frame: 100, draw: jest.fn(), isDisposed: false },
-        { frame: 100, draw: jest.fn(), isDisposed: false }
-      ];
-      stoneHandler.foilStones = mockStones as any[];
-      stoneHandler.isGamePaused = true;
-      
-      stoneHandler.draw(16);
-      
-      expect(mockTimerTicking.update).not.toHaveBeenCalled();
-    });
+
   });
 });

--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -1,14 +1,12 @@
-import { StoneConfig, VISIBILITY_CHANGE, Utils } from '@common'
+import { StoneConfig, VISIBILITY_CHANGE } from '@common'
 import { EventManager } from "@events";
-import { AudioPlayer, TimerTicking } from "@components"
-import { GameScore } from "@data";
+import { AudioPlayer } from "@components";
 import {
   ASSETS_PATH_STONE_PINK_BG,
   AUDIO_PATH_ON_DRAG
 } from '@constants';
 import gameStateService from '@gameStateService';
 import gameSettingsService from '@gameSettingsService';
-import { FeedbackType } from '@gamepuzzles';
 
 /**
  * StoneHandler is responsible for creating, drawing, and positioning stones.
@@ -28,23 +26,19 @@ export default class StoneHandler extends EventManager {
   public levelData: any;
   public correctAnswer: string;
   public puzzleStartTime: Date;
-  public showTutorial: boolean =
-    GameScore.getDatafromStorage().length == undefined ? true : false;
   correctTargetStone: string;
   stonebg: HTMLImageElement;
   public audioPlayer: AudioPlayer;
-  public timerTickingInstance: TimerTicking;
-  isGamePaused: boolean = false;
   public originalWidth: any;
   public originalHeight:any;
-  private unsubscribeEvent: () => void;
+  public stonesHasLoaded: boolean = false;
+  public activeStones: Array<StoneConfig> = new Array<StoneConfig>();
 
   constructor(
     context: CanvasRenderingContext2D,
     canvas,
     puzzleNumber: number,
     levelData,
-    timerTickingInstance: TimerTicking
   ) {
     super({
       stoneDropCallbackHandler: (event) => this.handleStoneDrop(event),
@@ -63,22 +57,14 @@ export default class StoneHandler extends EventManager {
     this.puzzleStartTime = new Date();
     this.stonebg = new Image();
     this.stonebg.src = ASSETS_PATH_STONE_PINK_BG;
-    this.audioPlayer = new AudioPlayer();
     this.stonebg.onload = (e) => {
       this.createStones(this.stonebg);
     };
     this.audioPlayer = new AudioPlayer();
-    this.timerTickingInstance = timerTickingInstance;
     document.addEventListener(
       VISIBILITY_CHANGE,
       this.handleVisibilityChange,
       false
-    );
-    this.unsubscribeEvent = gameStateService.subscribe(
-      gameStateService.EVENTS.GAME_PAUSE_STATUS_EVENT,
-      (isGamePaused: boolean) => {
-        this.isGamePaused = isGamePaused;
-      }
     );
   }
 
@@ -104,9 +90,6 @@ export default class StoneHandler extends EventManager {
     // Clear existing stones first to prevent memory leaks
     this.disposeStones();
 
-    // Create stone pool for reuse
-    const stonePool = new Map();
-
     const foilStones = this.getFoilStones();
     // Randomize stone positions
     const positions = this.shuffleArray(this.stonePos);
@@ -114,7 +97,7 @@ export default class StoneHandler extends EventManager {
     this.canvas.width = this.canvas.clientWidth * scale;
     this.canvas.height = this.canvas.clientHeight * scale;
     this.context.scale(scale, scale);
-    
+
     for (let i = 0; i < foilStones.length; i++) {
       // Create new stone with all required parameters
       const stone = new StoneConfig(
@@ -124,55 +107,45 @@ export default class StoneHandler extends EventManager {
         foilStones[i],
         positions[i][0],
         positions[i][1],
-        img,
-        this.timerTickingInstance
+        img
       );
 
       // Initialize stone
       stone.initialize();
 
       //Publish stone details, image and level data for stone tutorial only at the first puzzle segment.
-      if (foilStones[i] == this.correctTargetStone && this.currentPuzzleData.segmentNumber === 0) {
-        gameStateService.publish(gameStateService.EVENTS.CORRECT_STONE_POSITION, {
-          stonePosVal: positions[i],
-          img,
-          levelData: this.levelData
-        });
+      if (this.currentPuzzleData.segmentNumber === 0) {
+        if (foilStones[i] == this.correctTargetStone) {
+          gameStateService.publish(gameStateService.EVENTS.CORRECT_STONE_POSITION, {
+            stonePosVal: positions[i],
+            img,
+            levelData: this.levelData
+          });
+        }
+
+        //Add IF Condition here for publishing CORRECT_STONE_POSITION for word puzzle.
       }
 
-      // Store in pool for potential reuse
-      stonePool.set(foilStones[i], stone);
       this.foilStones.push(stone);
     }
+    this.activeStones = this.foilStones.filter(stone => stone && !stone.isDisposed);
   }
 
   /**
    * Performance optimized draw loop
    * Only processes active stones and updates timer efficiently
    */
-  draw(deltaTime: number) {
+  draw() {
     if (this.foilStones.length === 0) return;
 
-    // Only check animation completion once per frame
-    let isAnimationComplete = true;
-    const activeStones = this.foilStones.filter(stone => stone && !stone.isDisposed);
-
-    // Draw only active stones
-    for (const stone of activeStones) {
-      if (stone.frame < 100) {
-        isAnimationComplete = false;
-      }
+    for (const stone of this.foilStones) {
       stone.draw();
     }
 
-    // Update timer only once animation is complete and game is not paused
-    if (isAnimationComplete && !this.isGamePaused) {
-      this.timerTickingInstance.update(deltaTime);
-    }
+    !this.stonesHasLoaded && this.areStonesReadyForPlay();
   }
 
   drawWordPuzzleLetters(
-    deltaTime: number,
     shouldHideStoneChecker: (index: number) => boolean,
     groupedLetters: {} | { [key: number]: string }
   ): void {
@@ -183,9 +156,14 @@ export default class StoneHandler extends EventManager {
         );
       }
     }
+  }
 
-    if (this.foilStones.length > 0 && this.foilStones[this.foilStones.length - 1].frame >= 100 && !this.isGamePaused) {
-      this.timerTickingInstance.update(deltaTime);
+  private areStonesReadyForPlay() {
+    /* if stone frames are above 100, it means it has properly loaded in its default position
+        and ready to be move by the user.
+    */
+    if (this.foilStones[this.foilStones.length - 1].frame >= 100) {
+      this.stonesHasLoaded = true;
     }
   }
 
@@ -208,7 +186,6 @@ export default class StoneHandler extends EventManager {
   public dispose() {
     this.canvas.width = this.originalWidth;
     this.canvas.height = this.originalHeight;
-    this.unsubscribeEvent();
     document.removeEventListener(
       VISIBILITY_CHANGE,
       this.handleVisibilityChange,
@@ -223,9 +200,6 @@ export default class StoneHandler extends EventManager {
 
     // Remove event listeners
     document.removeEventListener(VISIBILITY_CHANGE, this.handleVisibilityChange);
-    if (this.unsubscribeEvent) {
-      this.unsubscribeEvent();
-    }
   }
 
   public getCorrectTargetStone(): string {
@@ -416,16 +390,6 @@ export default class StoneHandler extends EventManager {
     *  use the original canvas width and height instead.
     *  this is the default coordinates
     */
-    const baseCoordinateFactors = [
-      [5, 1.9], //Left stone 1 - upper
-      [7, 1.5], //Left stone 2
-      [setCoordinateFactor(4.3, 4.5), 1.28], //Left stone 3
-      [6.4, 1.1], //Left stone 4 - very bottom
-      [setCoordinateFactor(2, 1.3), 1.07], //Middle stone that is located right below the monster.
-      [[2.3, 2.1], 1.9], //Right stone 1 - upper
-      [[setCoordinateFactor(2.8, 2.5), 2], 1.2], //Right stone 2
-      [[setCoordinateFactor(3, 2.4), 2.1], 1.42],  //Right stone 3
-    ];
 
     // Separate coordinate factors for egg monster due to different dimensionse
     const eggMonsterCoordinateFactors = [

--- a/src/gameStateService/gameStateService.ts
+++ b/src/gameStateService/gameStateService.ts
@@ -68,9 +68,18 @@ export class GameStateService extends PubSub {
             levelNumber: number,
             isCleared: boolean
         };
-        LetterOnly: number;
-        SoundLetterOnly: number;
-        Word: number;
+        LetterOnly: {
+            levelNumber: number,
+            isCleared: boolean
+        };
+        SoundLetterOnly: {
+            levelNumber: number,
+            isCleared: boolean
+        };
+        Word: {
+            levelNumber: number,
+            isCleared: boolean
+        };
     };
     public feedbackAudios: null | {
         amazing: string,
@@ -212,11 +221,13 @@ export class GameStateService extends PubSub {
             : "";
 
         let shouldHaveTutorial = false;
+        let isTutorialCleared : boolean = false;
         const selectedLevelNumber:string | number = this.gamePlayData.selectedLevelNumber;
         const levelNumber = typeof selectedLevelNumber === 'string' ? parseInt(selectedLevelNumber) : selectedLevelNumber;
         //Very small array to iterate.
         Object.values(this.gameTypesFirstInstanceList).every((listedLevelNumber: { levelNumber: number, isCleared: boolean}) => {
             if (listedLevelNumber?.levelNumber === levelNumber) {
+                isTutorialCleared = listedLevelNumber?.isCleared;
                 shouldHaveTutorial = true;
                 return false; //Return false to break every loop.
             }
@@ -233,7 +244,8 @@ export class GameStateService extends PubSub {
             data: this.data,
             isLastLevel: this.isLastLevel,
             monsterPhaseNumber: this.monsterPhaseNumber,
-            tutorialOn: shouldHaveTutorial
+            tutorialOn: shouldHaveTutorial,
+            isTutorialCleared
         };
     }
 

--- a/src/scenes/gameplay-scene/gameplay-scene.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.spec.ts
@@ -2,6 +2,8 @@ import { GameplayScene } from './gameplay-scene';
 import gameStateService from '@gameStateService';
 import gameSettingsService from '@gameSettingsService';
 import { SCENE_NAME_GAME_PLAY } from "@constants";
+import { TimerTicking } from '@components';
+import { update } from 'lodash-es';
 
 // Mocking dependencies
 jest.mock('@components', () => {
@@ -42,6 +44,7 @@ jest.mock('@components', () => {
       startTimer: jest.fn(),
       applyRotation: jest.fn(),
       destroy: jest.fn(),
+      update: jest.fn()
     })),
     StoneHandler: jest.fn().mockImplementation(() => ({
       draw: jest.fn(),
@@ -53,7 +56,6 @@ jest.mock('@components', () => {
       getFoilStones: jest.fn().mockReturnValue(['FoilStone1', 'FoilStone2']),
       stones: [],
       foilStones: [],
-      isGamePaused: false,
       context: {} as CanvasRenderingContext2D,
       canvas: document.createElement('canvas'),
       currentPuzzleData: {},
@@ -90,7 +92,7 @@ jest.mock('@components', () => {
       play: jest.fn(),
       checkHitboxDistance: jest.fn(),
       onClick: jest.fn(),
-    }))
+    })),
   };
 });
 
@@ -121,7 +123,7 @@ jest.mock('@gameStateService', () => ({
       SWITCH_SCENE_EVENT: 'SWITCH_SCENE_EVENT',
     },
     getGameTypeList: jest.fn(),
-    saveHitBoxRanges: jest.fn()
+    saveHitBoxRanges: jest.fn(),
   }
 }));
 
@@ -167,7 +169,8 @@ describe('GameplayScene with BasePopupComponent', () => {
       jsonVersionNumber: '1.0.0',
       data: {},
       feedbackAudios: {},
-      tutorialOn: false
+      tutorialOn: false,
+      isTutorialCleared: false
     });
 
     (gameSettingsService.getCanvasSizeValues as jest.Mock).mockReturnValue({
@@ -449,6 +452,29 @@ describe('GameplayScene with BasePopupComponent', () => {
         gameStateService.EVENTS.SWITCH_SCENE_EVENT,
         expect.any(String)
       );
+    });
+  });
+
+  describe('Timer Update ', () => {
+    it('should call timerTicking.update when stones are loaded and game is not paused', () => {
+      const mockStone = {
+        frame: 100,
+        draw: jest.fn(), // Accepts context
+        isDisposed: false
+      };
+
+      (gameplayScene as any).stoneHandler = {
+        stonesHasLoaded: true,
+        stones: [mockStone],
+        draw: jest.fn(), // stubbed to avoid internal errors
+      };
+
+      (gameplayScene as any).isPauseButtonClicked = false;
+      (gameplayScene as any).isGameStarted = true;
+
+      gameplayScene.draw(16);
+
+      expect(gameplayScene.timerTicking.update).toHaveBeenCalledWith(16);
     });
   });
 });


### PR DESCRIPTION
# Changes
- Removed Timer from Stone-handler.
- Moved Timer draw to gameplay-scene.
- Added a proper flag to properly load Timer in sync with Stone-handler after loading the stones.
- Updated gameStateService to provide the proper tutorial details flag for future tutorial features relating to timer.
- Created a method handleTimerUpdate in gameplay-scene, to handle the logic of the Timer drawing.
- Code clean ups via adding comments and updating test specs on the relating files.

# How to test
- Run FTM app.
- Play the level one, tutorial should show up as is.
- Stone letters should work as is.
- No issues in terms of loading the stones or gameplay.

Ref: [FM-557](https://curiouslearning.atlassian.net/browse/FM-557)


[FM-557]: https://curiouslearning.atlassian.net/browse/FM-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ