### PR TITLE
feat: Updated logic to stone draws on word puzzles (FM-557).

### DIFF
--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -170,6 +170,8 @@ export default class StoneHandler extends EventManager {
         );
       }
     }
+
+    !this.stonesHasLoaded && this.areStonesReadyForPlay();
   }
 
   private areStonesReadyForPlay() {


### PR DESCRIPTION
# Changes
- Update logic on draw word stones in stone-handler.

# How to test
- Run FTM app.
- Play the level one, tutorial should show up as is.
- Stone letters should work as is.
- No issues in terms of loading the stones or gameplay.

Ref: [FM-557](https://curiouslearning.atlassian.net/browse/FM-557)


[FM-557]: https://curiouslearning.atlassian.net/browse/FM-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ