### PR TITLE
fixed: Some of the letter audios will not auto-play while playing the game (FM-576).

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -2,23 +2,6 @@ import { Debugger } from "@common";
 import { TestServer } from "@constants";
 import { languageFontMapping } from "@data/i18-font-mapping";
 export class Utils {
-  /**
-   * Returns the correct prompt audio URL for the given puzzle data.
-   * Handles dev/prod URL conversion.
-   */
-  public static getPromptAudioUrl(currentPuzzleData: any): string {
-      return Utils.getConvertedDevProdURL(currentPuzzleData.prompt.promptAudio);
-  }
-
-  /**
-   * Plays the prompt audio using the provided AudioPlayer instance, if app is in foreground.
-   */
-  public static playPromptSound(audioPlayer: any, currentPuzzleData: any, isAppForeground: boolean) {
-      if (isAppForeground) {
-          audioPlayer.playPromptAudio(Utils.getPromptAudioUrl(currentPuzzleData));
-      }
-  }
-
   public static UrlSubstring: string = "/feedthemonster";
   public static subdomain: string = "https://feedthemonster.curiouscontent.org";
 

--- a/src/components/prompt-text/prompt-text.spec.ts
+++ b/src/components/prompt-text/prompt-text.spec.ts
@@ -1,4 +1,4 @@
-import { PromptText } from './prompt-text';
+import { PromptText, DEFAULT_SELECTORS } from './prompt-text';
 import { AudioPlayer } from '@components';
 import { EventManager } from '@events';
 import { Utils } from '@common';
@@ -239,7 +239,10 @@ describe('PromptText', () => {
       mockHeight,
       mockPuzzleData,
       mockLevelData,
-      mockRightToLeft
+      mockRightToLeft,
+      'prompt-container',  // id parameter (string)
+      { selectors: DEFAULT_SELECTORS },
+      false
     );
   });
   

--- a/src/gameSettingsService/gameSettingsService.ts
+++ b/src/gameSettingsService/gameSettingsService.ts
@@ -45,4 +45,5 @@ export class GameSettingsService extends PubSub{
   public getDevicePixelRatioValue() {
     return this.devicePixelRatio;
   }
+
 }

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -217,8 +217,8 @@ export class GameplayScene {
       this.rightToLeft,
       'prompt-container',  // id parameter (string)
       { selectors: DEFAULT_SELECTORS },  // options parameter
+      gamePlayData?.tutorialOn && this.counter === 0,
       onClickCallback,
-      this.tutorial.shouldPlayTutorialPromptAudio
     );
     this.levelIndicators = new LevelIndicators();
     this.levelIndicators.setIndicators(this.counter);

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -256,20 +256,6 @@ export default class TutorialHandler {
     }
   }
 
-  public shouldPlayTutorialPromptAudio(promptTextInstance: any): boolean {
-    if (!promptTextInstance || !promptTextInstance.levelData || !promptTextInstance.currentPuzzleData) return false;
-    const gameTypesList = gameStateService.getGameTypeList();
-    const { isMatchSound, gameTypeName, gameType } = TutorialHandler.getPromptTextContext(promptTextInstance.levelData, gameTypesList);
-    const isValidGameType = gameType && !gameType.isCleared && gameType.levelNumber === promptTextInstance.levelData.levelMeta.levelNumber;
-    let triggerStart = 1910, triggerEnd = 1926;
-    if (isMatchSound && isValidGameType) {
-      triggerStart = 3000;
-      triggerEnd = 3016;
-    }
-
-    return Math.floor(promptTextInstance.time) >= triggerStart && Math.floor(promptTextInstance.time) <= triggerEnd;
-  }
-
   dispose() {
     //Clear canvas tutorials and reset values;
     if (this.hasEstablishedSubscriptions) {


### PR DESCRIPTION
# Changes
- Removed shouldPlayTutorialPromptAudio in tutorial-handler.
- Removed duplicated audio player in utils.
- Removed nested callbacks for shouldPlayTutorialPromptAudio.
- Reverted back the original condition on playing the initial audio play in prompt-text.ts
- Introduced patch fixes like variables this.triggerStart and this.triggerEnd for determining the trigger time,and this.hasInitialAudioPlayed for proper flagging the audio.
- Introduced a method setPromptInitialAudioDelayValues to preserve the needed time trigger introduced in FM-484.
- Added comments for clarity on the implementation of this bug fix.

# How to test
- Run FTM app.
- Play any game level.
- Whenever the game starts there should always be a auto audio play for the letter or word.

Ref: [FM-576](https://curiouslearning.atlassian.net/browse/FM-576)
