### PR TITLE
fix: the issue on sfx playing when tapping the monster and the delay start of the start timer sfx in low end devices (FM-650)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.spec.ts
@@ -61,7 +61,8 @@ jest.mock('@components', () => {
       sourceNode: {} as AudioBufferSourceNode,
       audioQueue: [],
       promptAudioBuffer: null,
-      playBackgroundMusic: jest.fn()
+      playBackgroundMusic: jest.fn(),
+      preloadGameAudio: jest.fn()
     })),
     TrailEffectsHandler: jest.fn().mockImplementation(() => ({
       dispose: jest.fn(),
@@ -175,7 +176,8 @@ jest.mock('@components', () => {
       sourceNode: {} as AudioBufferSourceNode,
       audioQueue: [],
       promptAudioBuffer: null,
-      playBackgroundMusic: jest.fn()
+      playBackgroundMusic: jest.fn(),
+      preloadGameAudio: jest.fn()
     })),
     TrailEffectsHandler: jest.fn().mockImplementation(() => ({
       dispose: jest.fn(),

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -102,7 +102,6 @@ export class GameplayScene {
   public loadPuzzleDelay: 3000 | 4500;
   private puzzleHandler: any;
   private timerStartSFXPlayed: boolean;
-  public isMonsterClicked: boolean = false;
   // Define animation delays as an array where index 0 = phase 0, index 1 = phase 1, index 2 = phase 2
   private animationDelays = [
     { backToIdle: 350, isChewing: 0, isHappy: 1700, isSpit: 1500, isSad: 3000 }, // Phase 1

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -52,7 +52,6 @@ import PuzzleHandler from "@gamepuzzles/puzzleHandler/puzzleHandler";
 import { DEFAULT_SELECTORS } from '@components/prompt-text/prompt-text';
 
 export class GameplayScene {
-  private justClickedMonster: boolean = false;
   public width: number;
   public height: number;
   public monster: RiveMonsterComponent;
@@ -464,11 +463,6 @@ export class GameplayScene {
     const y = event.clientY - rect.top;
 
     if (this.monster.onClick(x, y)) {
-      // Only set justClickedMonster if not in tutorial intro/hand-pointer state
-      console.log('this.tutorial?.shouldShowTutorialAnimation', this.tutorial?.shouldShowTutorialAnimation)
-      if (this.tutorial?.shouldShowTutorialAnimation) {
-        this.justClickedMonster = false;
-      }
       this.setGameToStart();
       this.tutorial?.activeTutorial?.removeHandPointer();
     }
@@ -544,11 +538,7 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
-        console.log('this.justClickedMonster', this.justClickedMonster)
-        if (!this.justClickedMonster && this.timerStartSFXPlayed) {
-          this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
-        }
-        this.justClickedMonster = false; // Always reset after check
+        this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
         this.timerStartSFXPlayed = false; // to ensure it wont run again in the current level.
       }
     }

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -487,7 +487,7 @@ export class GameplayScene {
     this.handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
   };
 
-  private setGameToStart() {
+  private setGameToStart() { 
     this.isGameStarted = true;
     this.time = 0;
     this.trailEffectHandler.setGameHasStarted(true);

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -487,7 +487,7 @@ export class GameplayScene {
     this.handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
   };
 
-  private setGameToStart() { 
+  private setGameToStart() {
     this.isGameStarted = true;
     this.time = 0;
     this.trailEffectHandler.setGameHasStarted(true);

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -165,6 +165,7 @@ export class GameplayScene {
     //this.setupBg(); //Temporary disabled to try evolution background.
     this.setupMonsterPhaseBg();
     this.timerStartSFXPlayed = false;
+    this.audioPlayer.preloadGameAudio(AUDIO_PATH_POINTS_ADD); // to preload the PointsAdd.wav
   }
 
   private initializeRiveMonster(): RiveMonsterComponent {
@@ -464,7 +465,6 @@ export class GameplayScene {
     const y = event.clientY - rect.top;
 
     if (this.monster.onClick(x, y)) {
-      this.isMonsterClicked = true;
       this.setGameToStart();
       this.tutorial?.activeTutorial?.removeHandPointer();
     }
@@ -493,9 +493,6 @@ export class GameplayScene {
     this.isGameStarted = true;
     this.time = 0;
     this.trailEffectHandler.setGameHasStarted(true);
-    this.audioPlayer.preloadGameAudio(AUDIO_PATH_POINTS_ADD); // to preload the PointsAdd.wav
-    if(!this.isMonsterClicked) return;
-    this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.
   }
 
   draw(deltaTime: number) {
@@ -534,7 +531,6 @@ export class GameplayScene {
   }
 
   private handleTimerUpdate(deltaTime: number) {
-    console.log('handleTimerUpdate')
     // Update timer only once animation is complete and game is not paused.
     if (this.stoneHandler.stonesHasLoaded && !this.isPauseButtonClicked) {
       const hasTutorial = this.tutorial.shouldShowTutorialAnimation;
@@ -542,13 +538,10 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
-        console.log('this.isMonsterClicked ', this.isMonsterClicked, this.timerStartSFXPlayed)
-        !this.isMonsterClicked && !this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
-        this.isMonsterClicked && this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
-        if(this.isMonsterClicked) {
-          this.isMonsterClicked = false;
-        } 
-        this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.
+        if (!this.timerStartSFXPlayed && deltaTime > 1 && deltaTime <= 100) {
+          this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
+          this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.
+        }
       }
     }
   }

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -538,6 +538,7 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
+        // added delta time checking to ensure that the timer starts sfx will only trigger once.
         if (!this.timerStartSFXPlayed && deltaTime > 1 && deltaTime <= 100) {
           this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
           this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -589,6 +589,7 @@ export class GameplayScene {
     this.counter += 1; //increment Puzzle
     this.isGameStarted = false;
     this.tutorial.resetTutorialTimer();
+    this.timerStartSFXPlayed = false; // make sure when loading new puzzle, timer start sfx will set to false.
     // Reset the 6-second tutorial delay timer each time a new puzzle is loaded
     this.tutorial.resetQuickStartTutorialDelay();
     if (this.counter === this.levelData.puzzles.length) {

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -537,7 +537,7 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
-        // added delta time checking to ensure that the timer starts sfx will only trigger once.
+        // added delta time checking to ensure that the timer starts sfx will only trigger once at the beginning of the timer countdown.
         if (!this.timerStartSFXPlayed && deltaTime > 1 && deltaTime <= 100) {
           this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
           this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -52,6 +52,7 @@ import PuzzleHandler from "@gamepuzzles/puzzleHandler/puzzleHandler";
 import { DEFAULT_SELECTORS } from '@components/prompt-text/prompt-text';
 
 export class GameplayScene {
+  private justClickedMonster: boolean = false;
   public width: number;
   public height: number;
   public monster: RiveMonsterComponent;
@@ -463,6 +464,11 @@ export class GameplayScene {
     const y = event.clientY - rect.top;
 
     if (this.monster.onClick(x, y)) {
+      // Only set justClickedMonster if not in tutorial intro/hand-pointer state
+      console.log('this.tutorial?.shouldShowTutorialAnimation', this.tutorial?.shouldShowTutorialAnimation)
+      if (this.tutorial?.shouldShowTutorialAnimation) {
+        this.justClickedMonster = false;
+      }
       this.setGameToStart();
       this.tutorial?.activeTutorial?.removeHandPointer();
     }
@@ -538,7 +544,11 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
-        this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
+        console.log('this.justClickedMonster', this.justClickedMonster)
+        if (!this.justClickedMonster && this.timerStartSFXPlayed) {
+          this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
+        }
+        this.justClickedMonster = false; // Always reset after check
         this.timerStartSFXPlayed = false; // to ensure it wont run again in the current level.
       }
     }

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -102,6 +102,7 @@ export class GameplayScene {
   public loadPuzzleDelay: 3000 | 4500;
   private puzzleHandler: any;
   private timerStartSFXPlayed: boolean;
+  public isMonsterClicked: boolean = false;
   // Define animation delays as an array where index 0 = phase 0, index 1 = phase 1, index 2 = phase 2
   private animationDelays = [
     { backToIdle: 350, isChewing: 0, isHappy: 1700, isSpit: 1500, isSad: 3000 }, // Phase 1
@@ -463,6 +464,7 @@ export class GameplayScene {
     const y = event.clientY - rect.top;
 
     if (this.monster.onClick(x, y)) {
+      this.isMonsterClicked = true;
       this.setGameToStart();
       this.tutorial?.activeTutorial?.removeHandPointer();
     }
@@ -492,6 +494,7 @@ export class GameplayScene {
     this.time = 0;
     this.trailEffectHandler.setGameHasStarted(true);
     this.audioPlayer.preloadGameAudio(AUDIO_PATH_POINTS_ADD); // to preload the PointsAdd.wav
+    if(!this.isMonsterClicked) return;
     this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.
   }
 
@@ -531,6 +534,7 @@ export class GameplayScene {
   }
 
   private handleTimerUpdate(deltaTime: number) {
+    console.log('handleTimerUpdate')
     // Update timer only once animation is complete and game is not paused.
     if (this.stoneHandler.stonesHasLoaded && !this.isPauseButtonClicked) {
       const hasTutorial = this.tutorial.shouldShowTutorialAnimation;
@@ -538,8 +542,13 @@ export class GameplayScene {
       if (!hasTutorial || (shouldStartTimer && hasTutorial)) { 
         // After 12s, start timer updates
         this.timerTicking.update(deltaTime);
-        this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
-        this.timerStartSFXPlayed = false; // to ensure it wont run again in the current level.
+        console.log('this.isMonsterClicked ', this.isMonsterClicked, this.timerStartSFXPlayed)
+        !this.isMonsterClicked && !this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
+        this.isMonsterClicked && this.timerStartSFXPlayed && this.audioPlayer.playAudio(AUDIO_PATH_POINTS_ADD);
+        if(this.isMonsterClicked) {
+          this.isMonsterClicked = false;
+        } 
+        this.timerStartSFXPlayed = true; // This flag needed to ensure that the timer starts sfx will only trigger once.
       }
     }
   }

--- a/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
+++ b/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
@@ -37,7 +37,7 @@ export default class MatchLetterPuzzleTutorial extends TutorialComponent {
     if (this.stonePosDetailsType && this.frame >= 100) {
       const { dx, absdx, dy, absdy } = this.animateImagePosVal;
       const { startX, startY, endX, endY, monsterStoneDifference } = this.stonePosDetailsType;
-      console.log('drawTutorial for debugging:', {'startX': startX, 'startY': startY, 'endX': endX, 'endY': endY, 'monsterStoneDifference':monsterStoneDifference});
+
       this.x = dx >= 0
         ? this.x + absdx * deltaTime
         : this.x - absdx * deltaTime;

--- a/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
+++ b/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
@@ -37,7 +37,7 @@ export default class MatchLetterPuzzleTutorial extends TutorialComponent {
     if (this.stonePosDetailsType && this.frame >= 100) {
       const { dx, absdx, dy, absdy } = this.animateImagePosVal;
       const { startX, startY, endX, endY, monsterStoneDifference } = this.stonePosDetailsType;
-
+      console.log('drawTutorial for debugging:', {'startX': startX, 'startY': startY, 'endX': endX, 'endY': endY, 'monsterStoneDifference':monsterStoneDifference});
       this.x = dx >= 0
         ? this.x + absdx * deltaTime
         : this.x - absdx * deltaTime;

--- a/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
+++ b/src/tutorials/MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial.ts
@@ -37,7 +37,6 @@ export default class MatchLetterPuzzleTutorial extends TutorialComponent {
     if (this.stonePosDetailsType && this.frame >= 100) {
       const { dx, absdx, dy, absdy } = this.animateImagePosVal;
       const { startX, startY, endX, endY, monsterStoneDifference } = this.stonePosDetailsType;
-      console.log('drawTutorial for debugging:', {'startX': startX, 'startY': startY, 'endX': endX, 'endY': endY, 'monsterStoneDifference':monsterStoneDifference});
       this.x = dx >= 0
         ? this.x + absdx * deltaTime
         : this.x - absdx * deltaTime;


### PR DESCRIPTION
# Changes
- Added delta time to ensure that the SFX plays only at the start of the timer.

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select any level to play
- In gameplay scene make sure the start sfx will play when the timer starts
- Make sure the sfx timer starts dont play when tapping the monster

Ref: [FM-650](https://curiouslearning.atlassian.net/browse/FM-650)
