### PR TITLE
fix: CR-391 Letter Highlighting issue fixed for  Matchfirst level in RTL languages 

### DIFF
--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -181,7 +181,14 @@ export class PromptText extends BaseHTML {
                 const targetLetterText = typeof targetStone === 'string' 
                     ? targetStone 
                     : (targetStone as { StoneText: string }).StoneText;
-                const parts = this.currentPromptText.split(targetLetterText);
+                const index = this.currentPromptText.indexOf(targetLetterText);
+                const parts =
+                    index !== -1
+                        ? [
+                            this.currentPromptText.slice(0, index),
+                            this.currentPromptText.slice(index + targetLetterText.length),
+                        ]
+                        : [this.currentPromptText];
                 
                 // Add the text with the highlighted letter
                 if (parts.length > 1) {


### PR DESCRIPTION
# Changes
- src/components/prompt-text/prompt-text.ts

# How to test
- Check the matchfirst levels for RTL languages (eg. - Farsi level 36)

Ref: [CR-391](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-391)


[CR-391]: https://curiouslearning.atlassian.net/browse/CR-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ