### PR TITLE
fix: move the timerStartSFXPlayed flag from loadpuzzle to initnewpuzzle (FM-560)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -589,7 +589,6 @@ export class GameplayScene {
     this.counter += 1; //increment Puzzle
     this.isGameStarted = false;
     this.tutorial.resetTutorialTimer();
-    this.timerStartSFXPlayed = false; // make sure when loading new puzzle, timer start sfx will set to false.
     // Reset the 6-second tutorial delay timer each time a new puzzle is loaded
     this.tutorial.resetQuickStartTutorialDelay();
     if (this.counter === this.levelData.puzzles.length) {
@@ -648,6 +647,7 @@ export class GameplayScene {
     if (this.monster) {
       this.monster.dispose();
     }
+    this.timerStartSFXPlayed = false; // move this flag from loadpuzzle to initnewpuzzle to make sure when loading new puzzle, timer start sfx will set to false.
     this.stoneHandler.stonesHasLoaded = false;
     this.monster = this.initializeRiveMonster();
     this.removeEventListeners();


### PR DESCRIPTION
# Changes
- move the timerStartSFXPlayed flag from loadpuzzle to initnewpuzzle to make sure when initializing new puzzle, timer start sfx will set to false. because putting in loadpuzzle causes the sfx start to play twice after feeding when user is not interacting.

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- tap on level 4 or any level that has tutorial
- don't interact or or tap the monster to avoid quick start. wait the stone to drop
- feed the correct stone to the monster 
- carefully listen at the end or feedback make sure the sfx don't play twice.

Ref: [FM-560](https://curiouslearning.atlassian.net/browse/FM-560)


[FM-560]: https://curiouslearning.atlassian.net/browse/FM-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ