### PR TITLE
fixed: Feedback audio overlaps that plays in the level-end screen when we complete the level real quick (FM-581).

### DIFF
--- a/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.spec.ts
+++ b/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.spec.ts
@@ -45,22 +45,4 @@ describe('LetterPuzzleLogic', () => {
     expect(result).toBe(false);
   });
 
-  // Test Case 3: Handle letter drop with correct letter
-  it('should handle a correct letter drop and trigger appropriate callbacks', () => {
-    // Arrange
-    letterPuzzleLogic.setTargetLetter('A');
-    
-    // Act
-    const result = letterPuzzleLogic.handleLetterDrop({
-      droppedText: 'A',
-      ...mockHandlers
-    });
-    
-    // Assert
-    expect(result).toBe(true);
-    expect(mockHandlers.playFeedbackAudio).toHaveBeenCalledWith(0, true, false, 'A');
-    expect(mockHandlers.handleCorrectLetterDrop).toHaveBeenCalledWith(0);
-    expect(mockHandlers.isFeedBackTriggeredSetter).toHaveBeenCalledWith(true);
-    expect(mockHandlers.handleLetterDropEnd).toHaveBeenCalledWith(true, "Letter");
-  });
 });

--- a/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.ts
+++ b/src/gamepuzzles/letterPuzzleLogic/letterPuzzleLogic.ts
@@ -24,43 +24,7 @@ export default class LetterPuzzleLogic {
     if (!this.targetLetter) return false;
     return droppedLetter === this.targetLetter;
   }
-  
-  /**
-   * Handles the logic for a letter puzzle.
-   * Returns whether the drop is correct and triggers feedback.
-   * 
-   * @param params Object containing all necessary parameters for handling letter puzzle
-   * @returns True if the letter drop was correct, false otherwise
-   */
-  handleLetterDrop({
-    droppedText,
-    getRandomInt,
-    handleCorrectLetterDrop,
-    handleLetterDropEnd,
-    isFeedBackTriggeredSetter,
-    playFeedbackAudio
-  }) {
-    // Get a random feedback index
-    const feedBackIndex = getRandomInt(0, 1);
-    
-    // Check if the letter drop is correct
-    const isCorrect = this.validateLetterDrop(droppedText);
-    
-    // Play appropriate audio feedback
-    playFeedbackAudio(feedBackIndex, isCorrect, false, droppedText);
-    
-    // Handle correct letter drop if needed
-    if (isCorrect) {
-      handleCorrectLetterDrop(feedBackIndex);
-    }
-    
-    // Set feedback triggered state and handle letter drop end
-    isFeedBackTriggeredSetter(true);
-    handleLetterDropEnd(isCorrect, "Letter");
-    
-    return isCorrect;
-  }
-  
+
   /**
    * Resets the internal state of the letter puzzle logic
    */

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.spec.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.spec.ts
@@ -1,129 +1,184 @@
 import PuzzleHandler from './puzzleHandler';
 import { FeedbackTextEffects } from '@components/feedback-text';
 import { FeedbackType } from '@gamepuzzles';
+import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
+import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
 
-jest.mock('../letterPuzzleLogic/letterPuzzleLogic');
 jest.mock('../wordPuzzleLogic/wordPuzzleLogic');
+jest.mock('../letterPuzzleLogic/letterPuzzleLogic');
+jest.mock('@components/feedback-text');
+jest.mock('@gamepuzzles', () => ({
+  FeedbackAudioHandler: jest.fn().mockImplementation(() => ({
+    playFeedback: jest.fn(),
+    stopAllAudio: jest.fn(),
+    dispose: jest.fn(),
+  })),
+  FeedbackType: {
+    CORRECT_ANSWER: 'CORRECT_ANSWER',
+    PARTIAL_CORRECT: 'PARTIAL_CORRECT',
+    INCORRECT: 'INCORRECT',
+  },
+}));
 
 describe('PuzzleHandler', () => {
-  let puzzleHandler: PuzzleHandler;
-  let mockLevelData: any;
-  let mockContext: any;
-  let mockFeedbackTextEffects: any;
+  let handler: PuzzleHandler;
+  let ctx: any;
 
   beforeEach(() => {
-    // Mock level data for testing
-    mockLevelData = {
-      levelMeta: {
-        levelType: 'LetterOnly'
-      }
-    };
+    jest.clearAllMocks();
 
-    // Mock context for puzzle creation
-    mockContext = {
+    (LetterPuzzleLogic as jest.Mock).mockImplementation(() => ({
+      setTargetLetter: jest.fn(),
+      validateLetterDrop: jest.fn().mockReturnValue(true),
+    }));
+
+    (WordPuzzleLogic as jest.Mock).mockImplementation(() => ({
+      validateFedLetters: jest.fn().mockReturnValue(true),
+      validateWordPuzzle: jest.fn().mockReturnValue(true),
+      setGroupToDropped: jest.fn(),
+      getValues: jest.fn().mockReturnValue({
+        droppedLetters: 'WORD',
+        groupedObj: {},
+        droppedHistory: { A: true, B: true },
+      }),
+      clearPickedUp: jest.fn(),
+    }));
+
+    (FeedbackTextEffects as jest.Mock).mockImplementation(() => ({
+      wrapText: jest.fn(),
+      hideText: jest.fn(),
+    }));
+
+    ctx = {
       levelType: 'LetterOnly',
-      pickedLetter: {
-        text: 'A',
-        frame: 1
-      },
+      pickedLetter: { text: 'A', frame: 0 },
       targetLetterText: 'A',
-      audioPlayer: {
-        play: jest.fn()
-      },
-      promptText: {
-        droppedLetterIndex: jest.fn()
-      },
-      feedBackTexts: {
-        'feedback1': 'Great job!',
-        'feedback2': 'Well done!'
-      },
-      handleCorrectLetterDrop: jest.fn(),
+      promptText: { droppedLetterIndex: jest.fn() },
+      feedBackTexts: { 0: 'Nice!', 1: 'Great job!' },
       handleLetterDropEnd: jest.fn(),
       triggerMonsterAnimation: jest.fn(),
-      timerTicking: {
-        startTimer: jest.fn()
-      },
-      isFeedBackTriggeredSetter: jest.fn(),
+      timerTicking: { startTimer: jest.fn() },
       lang: 'english',
-      lettersCountRef: { value: 1 }
+      lettersCountRef: { value: 0 }
     };
 
-    mockFeedbackTextEffects = {
-      wrapText: jest.fn(),
-      hideText: jest.fn()
-    };
-
-    // Create PuzzleHandler instance
-    puzzleHandler = new PuzzleHandler(mockLevelData, 0);
-    
-    // Mock setTimeout
-    jest.useFakeTimers();
+    handler = new PuzzleHandler({ levelMeta: { levelType: 'LetterOnly' } }, 0, {});
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.useRealTimers();
-  });
+  describe('handleLetterPuzzle', () => {
+    it('should validate letter drop, play correct audio and call feedback', () => {
+      handler.createPuzzle(ctx);
 
-  // Test Case 1: Initialize with different level types
-  it('should initialize with the correct puzzle logic based on level type', () => {
-    // Test LetterOnly level type
-    const letterHandler = new PuzzleHandler({ levelMeta: { levelType: 'LetterOnly' } }, 0);
-    expect(letterHandler['wordPuzzleLogic']).toBeNull();
-    
-    // Test Word level type
-    const wordHandler = new PuzzleHandler({ levelMeta: { levelType: 'Word' } }, 0);
-    expect(wordHandler['wordPuzzleLogic']).not.toBeNull();
-  });
-
-  // Test Case 2: Test handleCorrectLetterDrop method
-  it('should handle correct letter drop with proper feedback and scoring', () => {
-    // Mock the addScore function
-    const mockAddScore = jest.fn();
-    
-    // Call the method
-    puzzleHandler.handleCorrectLetterDrop(
-      0,
-      mockFeedbackTextEffects as any,
-      mockContext,
-      mockAddScore
-    );
-    
-    // Verify the score was added
-    expect(mockAddScore).toHaveBeenCalledWith(100);
-    
-    // Verify feedback text was displayed
-    expect(mockFeedbackTextEffects.wrapText).toHaveBeenCalled();
-    
-    // Advance timers to verify feedback text is hidden after delay
-    jest.advanceTimersByTime(4500);
-    expect(mockFeedbackTextEffects.hideText).toHaveBeenCalled();
-  });
-
-  // Test Case 3: Test createPuzzle routing to correct handler
-  it('should route to the correct puzzle handler based on level type', () => {
-    // Spy on the private methods
-    const letterPuzzleSpy = jest.spyOn(puzzleHandler as any, 'handleLetterPuzzle');
-    const wordPuzzleSpy = jest.spyOn(puzzleHandler as any, 'handleWordPuzzle');
-    
-    // Test LetterOnly level type
-    puzzleHandler.createPuzzle({
-      ...mockContext,
-      levelType: 'LetterOnly'
+      const mockAudio = (handler as any).feedbackAudioHandler;
+      expect(mockAudio.playFeedback).toHaveBeenCalledWith(FeedbackType.CORRECT_ANSWER, expect.any(Number));
+      expect(ctx.handleLetterDropEnd).toHaveBeenCalledWith(true, 'Letter');
     });
-    expect(letterPuzzleSpy).toHaveBeenCalled();
-    expect(wordPuzzleSpy).not.toHaveBeenCalled();
-    
-    // Reset spies
-    letterPuzzleSpy.mockClear();
-    wordPuzzleSpy.mockClear();
-    
-    // Test Word level type
-    puzzleHandler.createPuzzle({
-      ...mockContext,
-      levelType: 'Word'
+
+    it('should skip feedback text if incorrect', () => {
+      (LetterPuzzleLogic as jest.Mock).mockImplementation(() => ({
+        setTargetLetter: jest.fn(),
+        validateLetterDrop: jest.fn().mockReturnValue(false),
+      }));
+
+      const handlerIncorrect = new PuzzleHandler({ levelMeta: { levelType: 'LetterOnly' } }, 0, {});
+      handlerIncorrect.createPuzzle(ctx);
+
+      expect(ctx.handleLetterDropEnd).toHaveBeenCalledWith(false, 'Letter');
+      expect(FeedbackTextEffects.prototype.wrapText).not.toHaveBeenCalled();
     });
-    expect(wordPuzzleSpy).toHaveBeenCalled();
-    expect(letterPuzzleSpy).not.toHaveBeenCalled();
+  });
+
+  describe('handleWordPuzzle', () => {
+    beforeEach(() => {
+      handler = new PuzzleHandler({ levelMeta: { levelType: 'Word' } }, 0, {});
+      ctx.levelType = 'Word';
+    });
+
+    it('should process correct word drop and complete word', () => {
+      handler.createPuzzle(ctx);
+
+      expect(ctx.handleLetterDropEnd).toHaveBeenCalledWith(true, 'Word');
+      expect(ctx.lettersCountRef.value).toBe(1);
+      expect(ctx.promptText.droppedLetterIndex).not.toHaveBeenCalled(); // spelling is correct
+    });
+
+    it('should process partially correct word drop', () => {
+      (WordPuzzleLogic as jest.Mock).mockImplementation(() => ({
+        validateFedLetters: jest.fn().mockReturnValue(true),
+        validateWordPuzzle: jest.fn().mockReturnValue(false),
+        setGroupToDropped: jest.fn(),
+        getValues: jest.fn().mockReturnValue({
+          droppedHistory: { A: true },
+          droppedLetters: 'W',
+        }),
+      }));
+
+      handler = new PuzzleHandler({ levelMeta: { levelType: 'Word' } }, 0, {});
+      handler.createPuzzle(ctx);
+
+      expect(ctx.triggerMonsterAnimation).toHaveBeenCalledWith('isMouthClosed');
+      expect(ctx.promptText.droppedLetterIndex).toHaveBeenCalledWith(1); // english path
+      expect(ctx.lettersCountRef.value).toBe(1);
+    });
+
+    it('should process incorrect word drop', () => {
+      (WordPuzzleLogic as jest.Mock).mockImplementation(() => ({
+        validateFedLetters: jest.fn().mockReturnValue(false),
+        getValues: jest.fn().mockReturnValue({}),
+        setGroupToDropped: jest.fn(),
+      }));
+
+      handler = new PuzzleHandler({ levelMeta: { levelType: 'Word' } }, 0, {});
+      handler.createPuzzle(ctx);
+
+      expect(ctx.handleLetterDropEnd).toHaveBeenCalledWith(false, 'Word');
+      expect(ctx.lettersCountRef.value).toBe(1);
+    });
+  });
+
+  describe('processLetterDropFeedbackAudio', () => {
+    it('should play correct, partial, or incorrect audio', () => {
+      const instance = handler as any;
+
+      // simulate correct exact match
+      instance.processLetterDropFeedbackAudio('A', 0, true, true, 'A');
+      expect(instance.feedbackAudioHandler.playFeedback).toHaveBeenCalledWith(
+        FeedbackType.CORRECT_ANSWER,
+        0
+      );
+
+      // simulate partial match
+      instance.processLetterDropFeedbackAudio('A', 1, true, true, 'B');
+      expect(instance.feedbackAudioHandler.playFeedback).toHaveBeenCalledWith(
+        FeedbackType.PARTIAL_CORRECT,
+        1
+      );
+
+      // simulate incorrect
+      instance.processLetterDropFeedbackAudio('A', 0, false, true, 'B');
+      expect(instance.feedbackAudioHandler.playFeedback).toHaveBeenCalledWith(
+        FeedbackType.INCORRECT,
+        0
+      );
+    });
+  });
+
+  describe('utilities', () => {
+    it('getRandomInt returns value in bounds', () => {
+      const val = handler.getRandomInt(0, 1, ctx.feedBackTexts);
+      expect(val).toBeGreaterThanOrEqual(0);
+      expect(val).toBeLessThanOrEqual(1);
+    });
+
+    it('getRandomFeedBackText returns expected text', () => {
+      const text = handler.getRandomFeedBackText(0, ctx.feedBackTexts);
+      expect(text).toBe('Nice!');
+    });
+  });
+
+  it('should dispose feedback audio handler', () => {
+    const audioHandler = handler['feedbackAudioHandler'];
+    handler.dispose();
+    expect(audioHandler.dispose).toHaveBeenCalled();
   });
 });

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -37,8 +37,6 @@ export default class PuzzleHandler {
     if (feedbackAudios) {
       this.feedbackAudioHandler = new FeedbackAudioHandler(feedbackAudios);
     }
-    this.letterPuzzleLogic = null;
-    this.wordPuzzleLogic = null;
     this.feedbackTextEffects = new FeedbackTextEffects();
     this.initialize(levelData, counter);
   }

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -2,7 +2,6 @@ import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
 import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
 import { FeedbackTextEffects } from '@components/feedback-text';
 import { FeedbackAudioHandler, FeedbackType } from '@gamepuzzles';
-import gameStateService from '@gameStateService';
 
 /**
  * Context object for creating a puzzle/handling a letter drop.

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -2,6 +2,7 @@ import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
 import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
 import { FeedbackTextEffects } from '@components/feedback-text';
 import { FeedbackAudioHandler, FeedbackType } from '@gamepuzzles';
+import gameStateService from '@gameStateService';
 
 /**
  * Context object for creating a puzzle/handling a letter drop.
@@ -13,18 +14,13 @@ interface CreatePuzzleContext {
     frame: number;
   };
   targetLetterText: string; // Instead of passing the entire letterHandler
-  audioPlayer: any;
   promptText: any;
   feedBackTexts: Record<string, string>;
-  handleCorrectLetterDrop: (feedbackIndex: number) => void;
   handleLetterDropEnd: (isCorrect: boolean, type: string) => void;
   triggerMonsterAnimation: (name: string) => void;
   timerTicking: any;
-  isFeedBackTriggeredSetter: (v: boolean) => void;
   lang: string;
   lettersCountRef: { value: number };
-  counter?: number;
-  width?: number;
 }
 
 /**
@@ -35,13 +31,16 @@ export default class PuzzleHandler {
   private wordPuzzleLogic: WordPuzzleLogic | null = null;
   private letterPuzzleLogic: LetterPuzzleLogic | null = null;
   private feedbackAudioHandler: FeedbackAudioHandler;
+  private feedbackTextEffects: FeedbackTextEffects
 
   constructor(levelData: any, counter: number = 0, feedbackAudios?: any) {
     // Initialize feedback audio handler if audio resources are provided
     if (feedbackAudios) {
       this.feedbackAudioHandler = new FeedbackAudioHandler(feedbackAudios);
     }
-    
+    this.letterPuzzleLogic = null;
+    this.wordPuzzleLogic = null;
+    this.feedbackTextEffects = new FeedbackTextEffects();
     this.initialize(levelData, counter);
   }
 
@@ -57,11 +56,8 @@ export default class PuzzleHandler {
     if (levelType === "Word" || levelType === "SoundWord") {
       this.wordPuzzleLogic = new WordPuzzleLogic(levelData, counter);
     } else {
-      this.wordPuzzleLogic = null;
+      this.letterPuzzleLogic = new LetterPuzzleLogic();
     }
-    
-    // Letter puzzle logic is created on demand in handleLetterPuzzle
-    this.letterPuzzleLogic = null;
   }
 
   /**
@@ -83,28 +79,30 @@ export default class PuzzleHandler {
   /**
    * Handles Letter puzzle logic.
    */
-  private handleLetterPuzzle(ctx: CreatePuzzleContext): boolean | void {
-    if (!this.letterPuzzleLogic) {
-      this.letterPuzzleLogic = new LetterPuzzleLogic();
-      this.letterPuzzleLogic.setTargetLetter(ctx.targetLetterText);
+  private handleLetterPuzzle(ctx: CreatePuzzleContext) {
+    this.letterPuzzleLogic.setTargetLetter(ctx.targetLetterText);
+
+    const droppedText = ctx.pickedLetter.text;
+
+    // Get a random feedback index
+    const feedBackIndex = this.getRandomInt(0, 1, ctx.feedBackTexts);
+    const isCorrect = this.letterPuzzleLogic.validateLetterDrop(droppedText);
+
+    // Play appropriate audio feedback
+    this.processLetterDropFeedbackAudio(
+      ctx.targetLetterText,
+      feedBackIndex,
+      isCorrect,
+      false,
+      droppedText
+    );
+
+    if (isCorrect) {
+      // Handle correct letter drop if needed
+      this.handleCorrectLetterDrop(feedBackIndex, ctx);
     }
-    
-    return this.letterPuzzleLogic.handleLetterDrop({
-      droppedText: ctx.pickedLetter.text,
-      getRandomInt: (min: number, max: number) => this.getRandomInt(min, max, ctx.feedBackTexts),
-      handleCorrectLetterDrop: ctx.handleCorrectLetterDrop,
-      handleLetterDropEnd: ctx.handleLetterDropEnd,
-      isFeedBackTriggeredSetter: ctx.isFeedBackTriggeredSetter,
-      playFeedbackAudio: (feedBackIndex, isCorrect, isWord, droppedLetter) => {
-        this.processLetterDropFeedbackAudio(
-          ctx.targetLetterText,
-          feedBackIndex,
-          isCorrect,
-          isWord,
-          droppedLetter
-        );
-      }
-    });
+
+    ctx.handleLetterDropEnd(isCorrect, "Letter");
   }
 
   /**
@@ -129,9 +127,10 @@ export default class PuzzleHandler {
     );
     
     if (isCorrect) {
-      if (this.wordPuzzleLogic.validateWordPuzzle()) {
-        ctx.handleCorrectLetterDrop(feedBackIndex);
-        ctx.handleLetterDropEnd(isCorrect, "Word");
+      const isWordSpellingCorrect = this.wordPuzzleLogic.validateWordPuzzle();
+      if (isWordSpellingCorrect) {
+        this.handleCorrectLetterDrop(feedBackIndex, ctx);
+        ctx.handleLetterDropEnd(isWordSpellingCorrect, "Word");
         ctx.lettersCountRef.value = 1;
         return;
       }
@@ -266,23 +265,18 @@ export default class PuzzleHandler {
    */
   handleCorrectLetterDrop(
     feedbackIndex: number,
-    feedbackTextEffects: FeedbackTextEffects,
     ctx: CreatePuzzleContext,
-    addScore: (amount: number) => void
   ): void {
-    /**
-     The hardcoded value was carried over from the original implementation. The key change is that instead of directly modifying a score property (this.score += 100), we now call an injected function (addScore(100)). This improves separation of concerns - the PuzzleHandler doesn't manage the score directly but delegates that responsibility to the caller. In a future refactoring, this value could be made configurable rather than hardcoded.
-     */
-    addScore(100);
+
     
     // Get feedback text and display it
     const feedbackText = this.getRandomFeedBackText(feedbackIndex, ctx.feedBackTexts);
-    feedbackTextEffects.wrapText(feedbackText);
+    this.feedbackTextEffects.wrapText(feedbackText);
     
     // Hide feedback text after audio finishes
     const totalAudioDuration = 4500; // Approximate duration of feedback audio
     setTimeout(() => {
-      feedbackTextEffects.hideText();
+      this.feedbackTextEffects.hideText();
     }, totalAudioDuration);
   }
 

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -5,7 +5,6 @@ import {
   LevelIndicators,
   StoneHandler,
   BackgroundHtmlGenerator,
-  FeedbackTextEffects,
   AudioPlayer,
   PhasesBackground,
   TrailEffectsHandler
@@ -80,7 +79,6 @@ export class GameplayScene {
   isPauseButtonClicked: boolean;
   public background: any;
   feedBackTextCanavsElement: HTMLCanvasElement;
-  feedbackTextEffects: FeedbackTextEffects;
   public isGameStarted: boolean = false;
   public time: number = 0;
   public score: number = 0;
@@ -131,7 +129,6 @@ export class GameplayScene {
     this.startGameTime();
     this.startPuzzleTime();
     this.firebaseIntegration = new FirebaseIntegration();
-    this.feedbackTextEffects = new FeedbackTextEffects();
     this.audioPlayer = new AudioPlayer();
     this.puzzleHandler = new PuzzleHandler(this.levelData, this.counter, gamePlayData.feedbackAudios);
     this.unsubscribeEvent = gameStateService.subscribe(
@@ -316,37 +313,28 @@ export class GameplayScene {
           frame: this.pickedStone.frame
         },
         targetLetterText: this.stoneHandler.getCorrectTargetStone(), // Pass only the data needed
-        audioPlayer: this.audioPlayer,
         promptText: this.promptText,
-        handleCorrectLetterDrop: undefined, // will be set below
-        handleLetterDropEnd: this.handleStoneDropEnd.bind(this),
+        handleLetterDropEnd: (isCorrect, puzzleType) => {
+          this.isFeedBackTriggered = isCorrect;
+          if (isCorrect) {
+            this.score += 100; //100 as static default value for adding score.
+          }
+          this.handleStoneDropEnd(isCorrect, puzzleType);
+        },
         triggerMonsterAnimation: this.triggerMonsterAnimation.bind(this),
         timerTicking: this.timerTicking,
-        isFeedBackTriggeredSetter: (v) => { this.isFeedBackTriggered = v; },
         lang,
         lettersCountRef,
-        feedBackTexts: this.feedBackTexts,
-        levelData: this.levelData,
-        counter: this.counter,
-        width: this.width
+        feedBackTexts: this.feedBackTexts
       };
-      ctx.handleCorrectLetterDrop = (feedbackIndex) => {
-        this.puzzleHandler.handleCorrectLetterDrop(
-          feedbackIndex,
-          this.feedbackTextEffects,
-          ctx,
-          (amount) => this.score += amount
-        );
-        // Hide the picked letter after puzzle logic is handled
-        this.stoneHandler.hideStone(this.pickedStoneObject);
-      };
+
       this.puzzleHandler.createPuzzle(ctx);
+
       // For Word puzzles, hide the letter immediately after dropping it into the monster
       if (ctx.levelType === "Word" || ctx.levelType === "SoundWord") {
         this.stoneHandler.hideStone(this.pickedStoneObject);
       }
       this.stonesCount = lettersCountRef.value;
-      this.isFeedBackTriggered = true;
       this.trailEffectHandler.setGameHasStarted(false);
     } else if (this.pickedStoneObject) {
       // Handle letter drop (fail/miss case)
@@ -605,22 +593,12 @@ export class GameplayScene {
         gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_LEVEL_END);
         this.monster.dispose(); //Adding the monster dispose here due to the scenario that this.monster is still needed when restart game level is played.
       };
-
+      this.tutorial.hideTutorial(); // Turn off tutorial
       if (timerEnded) {
         handleLevelEnd();
-        return;
-      }
-      this.tutorial.hideTutorial(); // Turn off tutorial
-      const timeoutId = setTimeout(handleLevelEnd, this.loadPuzzleDelay); // added delay for switching to level end screen
-      if (this.isFeedBackTriggered) {
-        const audioSources = this.audioPlayer?.audioSourcs || [];
-        const lastAudio = audioSources[audioSources.length - 1];
-        if (lastAudio) {
-          lastAudio.onended = () => {
-            clearTimeout(timeoutId);
-            handleLevelEnd();
-          };
-        }
+      } else {
+        //Trigger the handleLevelEnd with a delay to let the audio play in puzzleHandler.ts before switching to level end screen.
+        setTimeout(handleLevelEnd, this.loadPuzzleDelay);
       }
     } else {
       const loadPuzzleEvent = new CustomEvent(LOADPUZZLE, {
@@ -761,14 +739,10 @@ export class GameplayScene {
     this.logPuzzleEndFirebaseEvent(isCorrect, puzzleType);
     this.dispatchStoneDropEvent(isCorrect);
     setTimeout(() => {
-      this.adjustLoadPuzzleDelay(isCorrect);
+      //Adjust the delay of 4500 (4.5 seconds) to 2500 (2.5 seconds) if the puzzle is incorrect.
+      this.loadPuzzleDelay = isCorrect ? 4500 : 3000;
       this.loadPuzzle();
     }, isCorrect ? 0 : 2000);
-  }
-
-  private adjustLoadPuzzleDelay(isCorrect) {
-    //Adjust the delay of 4500 (4.5 seconds) to 2500 (2.5 seconds) if the puzzle is incorrect.
-    this.loadPuzzleDelay = isCorrect ? 4500 : 3000;
   }
 
   private dispatchStoneDropEvent(isCorrect: boolean): void {


### PR DESCRIPTION
# Changes
- Removed nested callbacks methods in puzzleHandler.ts and LetterPuzzleLogic.ts
- Cleaned up the ctx method with multiple callbacks by optimizing the code flow and making sure the necessary methods and callbacks that actually needed in puzzleHandler.ts is what is being passed and removed the unnecessary ones.
- Deleted LetterPuzzleLogic.ts handleLetterDrop method as it adds no value and only extending the callbacks.
- Updated the flow in loadPuzzle of gameplay-scene.ts removing the automatic fire of handleLevelend. 

# How to test
- Start the FTM app.
- Play any game level.
- After solving the last game segment of that puzzle, the expectation is the levelend scene will display after the gameplay-scene has finished playing the audios.
-

Ref: [FM-581](https://curiouslearning.atlassian.net/browse/FM-581)


[FM-581]: https://curiouslearning.atlassian.net/browse/FM-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ