### PR TITLE
fix: Star Count Increases on Level Failures, skipping Monster Evolution Animation (FM-580)

### DIFF
--- a/src/data/game-score.ts
+++ b/src/data/game-score.ts
@@ -42,7 +42,8 @@ export class GameScore {
   private static updateTotalStarCount(): void {
     const allGameLevelInfo = this.getAllGameLevelInfo();
     const totalStarCount = allGameLevelInfo.reduce(
-      (sum, level) => sum + level.starCount,
+      // Only count levels with 2 or more stars toward the total
+      (sum, level) => sum + (level.starCount >= 2 ? level.starCount : 0),
       0
     );
     localStorage.setItem(this.currentlanguage + "totalStarCount", totalStarCount.toString());

--- a/src/data/game-score.ts
+++ b/src/data/game-score.ts
@@ -43,7 +43,7 @@ export class GameScore {
     const allGameLevelInfo = this.getAllGameLevelInfo();
     const totalStarCount = allGameLevelInfo.reduce(
       // Only count levels with 2 or more stars toward the total
-      (sum, level) => sum + (level.starCount >= 2 ? level.starCount : 0),
+      (sum, level) => sum + level.starCount,
       0
     );
     localStorage.setItem(this.currentlanguage + "totalStarCount", totalStarCount.toString());

--- a/src/data/game-score.ts
+++ b/src/data/game-score.ts
@@ -42,7 +42,6 @@ export class GameScore {
   private static updateTotalStarCount(): void {
     const allGameLevelInfo = this.getAllGameLevelInfo();
     const totalStarCount = allGameLevelInfo.reduce(
-      // Only count levels with 2 or more stars toward the total
       (sum, level) => sum + level.starCount,
       0
     );

--- a/src/gameStateService/gameStateService.ts
+++ b/src/gameStateService/gameStateService.ts
@@ -271,13 +271,13 @@ export class GameStateService extends PubSub {
     }
 
     public checkMonsterPhaseUpdation(): number {
-        const totalStarCount = this.getTotalStars();
+        const successStarCount = GameScore.getAllGameLevelInfo().reduce((sum, level) => sum + (level.starCount >= 2 ? level.starCount : 0), 0);
         switch (true) {
-            case totalStarCount >= 38:
+            case successStarCount >= 38:
                 return 3; // Phase 4
-            case totalStarCount >= 23:
+            case successStarCount >= 23:
                 return 2; // Phase 3
-            case totalStarCount >= 8:
+            case successStarCount >= 8:
                 return 1; // Phase 2
             default:
                 return 0; // Phase 1 (default)


### PR DESCRIPTION
# Changes
- fix: Prevent 0-1 Star Levels from Contributing to Evolution Progress
- Modified the star count calculation logic to only include levels with 2 or more stars in the total star count used for evolution mechanics, while still displaying the correct visual representation of stars (0-3) in the UI.

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen 
- Play level 1: Earn 2 stars
- Play level 2: Earn 2 stars
- Play level 3: Earn 3 stars
- Total accumulated: 7 stars (all counting toward evolution)
- Play level 4: Deliberately earn only 0 or 1 star
- Verify the star is displayed visually in the UI
- Verify the evolution animation does NOT trigger

Ref: [FM-580](https://curiouslearning.atlassian.net/browse/FM-580)


[FM-580]: https://curiouslearning.atlassian.net/browse/FM-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ