### PR TITLE
feat: Updated Tutorial gameplay for Spell (FM-511).

### DIFF
--- a/src/gameStateService/gameStateService.ts
+++ b/src/gameStateService/gameStateService.ts
@@ -28,6 +28,7 @@ export class GameStateService extends PubSub {
         GAME_PAUSE_STATUS_EVENT: string;
         LEVEL_END_DATA_EVENT: string;
         CORRECT_STONE_POSITION: string;
+        WORD_PUZZLE_SUBMITTED_LETTERS_COUNT: string;
     }
     public data: null | DataModal;
     public isGamePaused: boolean;
@@ -104,7 +105,8 @@ export class GameStateService extends PubSub {
             GAMEPLAY_DATA_EVENT: 'GAMEPLAY_DATA_EVENT',
             GAME_PAUSE_STATUS_EVENT: 'GAME_PAUSE_STATUS_EVENT',
             LEVEL_END_DATA_EVENT: 'LEVEL_END_DATA_EVENT', // To move this event on DOM Event once created.
-            CORRECT_STONE_POSITION: 'CORRECT_STONE_POSITION'  //Stone image, position and level data for tutorial.
+            CORRECT_STONE_POSITION: 'CORRECT_STONE_POSITION',  //Stone image, position and level data for tutorial.
+            WORD_PUZZLE_SUBMITTED_LETTERS_COUNT: 'WORD_PUZZLE_SUBMITTED_LETTERS_COUNT',
         };
         this.data = null;
         /* Gameplay States */

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -2,6 +2,7 @@ import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
 import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
 import { FeedbackTextEffects } from '@components/feedback-text';
 import { FeedbackAudioHandler, FeedbackType } from '@gamepuzzles';
+import gameStateService from '@gameStateService';
 
 /**
  * Context object for creating a puzzle/handling a letter drop.
@@ -107,14 +108,14 @@ export default class PuzzleHandler {
    */
   private handleWordPuzzle(ctx: CreatePuzzleContext): void {
     if (!this.wordPuzzleLogic) return;
-    
+
     // Use our own stopFeedbackAudio method instead of ctx.audioPlayer
     this.stopFeedbackAudio();
-    
+
     const feedBackIndex = this.getRandomInt(0, 1, ctx.feedBackTexts);
     this.wordPuzzleLogic.setGroupToDropped();
     const isCorrect = this.wordPuzzleLogic.validateFedLetters();
-    
+
     this.processLetterDropFeedbackAudio(
       ctx.targetLetterText,
       feedBackIndex,
@@ -122,7 +123,7 @@ export default class PuzzleHandler {
       true,
       this.getWordPuzzleDroppedLetters()
     );
-    
+
     if (isCorrect) {
       const isWordSpellingCorrect = this.wordPuzzleLogic.validateWordPuzzle();
       if (isWordSpellingCorrect) {
@@ -131,18 +132,22 @@ export default class PuzzleHandler {
         ctx.lettersCountRef.value = 1;
         return;
       }
-      
+
       ctx.triggerMonsterAnimation('isMouthClosed');
       ctx.triggerMonsterAnimation('backToIdle');
       ctx.timerTicking.startTimer();
-      
+
       const { droppedHistory } = this.wordPuzzleLogic.getValues();
-      const droppedLettersCount = Object.keys(droppedHistory).length;
-      
-      ctx.promptText.droppedLetterIndex(
-        ctx.lang === "arabic" ? ctx.lettersCountRef.value : droppedLettersCount
+      const droppedLettersCount = ctx.lang === "arabic"
+        ? ctx.lettersCountRef.value
+        : Object.keys(droppedHistory).length;
+
+      gameStateService.publish(
+        gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
+        droppedLettersCount
       );
-      
+
+      ctx.promptText.droppedLetterIndex(droppedLettersCount);
       ctx.lettersCountRef.value++;
     } else {
       ctx.handleLetterDropEnd(isCorrect, "Word");
@@ -237,8 +242,8 @@ export default class PuzzleHandler {
   /**
    * Handles checking hovered letter for word puzzles.
    */
-  handleCheckHoveredLetter(letterText: string, letterIndex: number): boolean | undefined {
-    return this.wordPuzzleLogic?.handleCheckHoveredLetter(letterText, letterIndex);
+  handleCheckHoveredLetter(letterText: string, letterIndex: number): boolean {
+     return this.wordPuzzleLogic?.handleCheckHoveredLetter(letterText, letterIndex);
   }
 
   /**

--- a/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.ts
+++ b/src/gamepuzzles/wordPuzzleLogic/wordPuzzleLogic.ts
@@ -178,6 +178,7 @@ export default class WordPuzzleLogic {
      * Moves grouped letters to dropped letters
      */
     setGroupToDropped(): void {
+       
         this.droppedLetters = `${this.droppedLetters}${this.groupedLetters}`;
         this.droppedHistory = {
             ...this.droppedHistory,

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -409,6 +409,7 @@ export class GameplayScene {
       event.clientX,
       event.clientY
     );
+
     this.pickedStone = newStoneCoordinates;
     let trailX = newStoneCoordinates.x;
     let trailY = newStoneCoordinates.y;

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -1,21 +1,18 @@
 import TutorialComponent from '../base-tutorial/base-tutorial-component';
+import gameStateService from '@gameStateService';
 
 export default class WordPuzzleTutorial extends TutorialComponent {
   // Animation timing properties
   private animationStartTime = 0;
-  private animationStartDelay = 0; // Track when animation frame reaches 100%
-  private initialDelay = 800; // 800ms initial delay before starting any animation
-  private initialDelayElapsed = false;
   public frame = 0;
   private animationDuration = 700; // 700ms animation (faster than original 1000ms)
-  private isAnimatingNextStone = false;
   private stonePositions: number[][] = [];
   private currentStoneIndex = 0;
   // stoneImg is declared in the base class
   private imageSize: number;
-  private isInitialized = false;
-  private animationCompleted = false; // Track if current stone animation is complete
-  private levelData: any; // Store level data for accessing prompt text
+  private pauseWordTutorialRendering: boolean = false; // Track if current stone animation is complete
+
+  private unsubscribeSubmittedLettersCountHandler: () => void;
 
   constructor({
     context,
@@ -38,90 +35,64 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     this.height = height;
     this.stoneImg = stoneImg;
     this.imageSize = height / 9.5;
-    this.levelData = levelData;
+    this.getFoilAndStonesFromData(stonePositions, levelData);
+    this.initializeStoneAnimation(0);
+    this.currentStoneIndex = 0;
 
+    this.unsubscribeSubmittedLettersCountHandler = gameStateService.subscribe(
+      gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
+      (droppedLettersCount: number) => {
+        this.pauseWordTutorialRendering = true;
+        this.currentStoneIndex = droppedLettersCount % this.stonePositions.length;
+        this.initializeStoneAnimation(this.currentStoneIndex);
+      }
+    )
+  }
+
+  private getFoilAndStonesFromData(stonePositions, levelData) {
     // Get target stones and foil stones from level data
-    if (this.levelData && stonePositions?.length > 0) {
-      const currentPuzzleData = this.levelData.puzzles[0]; // Tutorial is always for first puzzle
+    if (levelData && stonePositions?.length > 0) {
+      const currentPuzzleData = levelData.puzzles[0]; // Tutorial is always for first puzzle
       const targetStones = currentPuzzleData.targetStones || [];
-      
+
       // Get foil stones from the puzzle data
-      let foilStones = [];
-      if (currentPuzzleData.foilStones) {
-        // Clone the foil stones array to avoid modifying the original
-        foilStones = [...currentPuzzleData.foilStones];
-        
-        // Add target stones to foil stones (as done in StoneHandler.getFoilStones)
-        targetStones.forEach(stone => {
-          foilStones.push(stone);
-        });
-      }
-      
+      // Clone the foil stones array to avoid modifying the original
+      const foilStones = [...currentPuzzleData.foilStones];
+
       // If we have both foil stones and target stones, calculate the correct positions
-      if (foilStones.length > 0 && targetStones.length > 0) {
+      this.stonePositions = foilStones.length > 0 && targetStones.length > 0
         // Find the correct positions for target stones, handling duplicates
-        const targetStonePositions = this.findTargetStonePositions(targetStones, foilStones, stonePositions);
-        this.stonePositions = targetStonePositions;
-      }
-      // Otherwise use the provided positions directly
-      else {
-        this.stonePositions = [...stonePositions];
-      }
+        ? this.findTargetStonePositions(targetStones, foilStones, stonePositions)
+        // Otherwise use the provided positions directly
+        : [ ...stonePositions ];
     } else {
       this.stonePositions = stonePositions?.length > 0 ? [...stonePositions] : [];
-    }
-    
-    // Initialize the tutorial if we have positions
-    if (this.stonePositions.length > 0) {
-      this.isInitialized = true;
-      this.initializeStoneAnimation(0);
-    } else {
-      this.isInitialized = true;
     }
   }
 
   public drawTutorial(deltaTime: number): void {
-    if (!this.isInitialized) {
-      return; // Don't draw anything until initialization is complete
-    }
-
-    // Apply initial delay before starting any animation
-    if (!this.initialDelayElapsed) {
+    // Update animation based on actual time elapsed
+    if (this.frame < 250) {
       if (this.animationStartTime === 0) {
         this.animationStartTime = performance.now();
       }
-      const initialElapsed = performance.now() - this.animationStartTime;
-      if (initialElapsed < this.initialDelay) {
-        return; // Wait until initial delay is complete
-      }
-      this.initialDelayElapsed = true;
-      this.animationStartTime = performance.now(); // Reset animation start time after delay
+      const elapsed = performance.now() - this.animationStartTime;
+      // Use a frame-based delay system instead of relying on time-based checks like performance.now().
+      // The frame progresses based on elapsed time, scaled by animationDuration,
+      // and is clamped at a max of 250 to act as a hard delay cap.
+      // Once frame reaches 250, we treat the delay as completed and allow the next logic to run.
+      this.frame = Math.min(250, (elapsed / this.animationDuration) * 100);
     }
 
-    // Update animation based on actual time elapsed
-    const elapsed = performance.now() - this.animationStartTime;
-    this.frame = Math.min(100, (elapsed / this.animationDuration) * 100);
-
-    // Only start stone drag animation after initial animation frame reaches 100
+    // Only start stone drag animation after initial animation frame reaches 250
     // This matches the approach used in MatchLetterPuzzleTutorial
-    if (this.stonePosDetailsType) {
-      // Track time since animation frame reached 100%
-      if (!this.animationStartDelay) {
-        this.animationStartDelay = performance.now();
-      }
-      
-      // Add a 500 delay before actually starting the drag animation (reduced from 500ms)
-      const delayElapsed = performance.now() - this.animationStartDelay;
-      if (delayElapsed < 500) {
-        return; // Wait until delay is complete before starting animation
-      }
-
+    if (!this.pauseWordTutorialRendering && this.stonePosDetailsType && this.frame >= 250) {
       const { dx, absdx, dy, absdy } = this.animateImagePosVal;
       const { startX, startY, endX, endY, monsterStoneDifference } = this.stonePosDetailsType;
 
       // Use similar position update logic as MatchLetterPuzzleTutorial but with speed boost
-      const speedMultiplier = 1.8; // Make animation 1.8x faster (increased from 1.2x)
-      
+      const speedMultiplier = 1.5; // Make animation 1.5x faster (increased from 1.2x)
+
       this.x = dx >= 0
         ? this.x + absdx * deltaTime * speedMultiplier
         : this.x - absdx * deltaTime * speedMultiplier;
@@ -134,7 +105,7 @@ export default class WordPuzzleTutorial extends TutorialComponent {
       const disy = this.y - endY + absdy;
       const distance = Math.sqrt(disx * disx + disy * disy);
       const monsterStoneDifferenceInPercentage = (100 * distance / monsterStoneDifference);
-      
+
       // Directly call the specialized word puzzle animation method
       // This reduces conditional complexity in the base class
       this.animateWordPuzzleStoneDrag({
@@ -147,65 +118,38 @@ export default class WordPuzzleTutorial extends TutorialComponent {
         endX,
         endY
       });
-      
-      // Check if stone has reached the monster (near the end position)
-      if (monsterStoneDifferenceInPercentage < 15 && !this.animationCompleted) {
-        this.animationCompleted = true;
+
+      //Check if stone has reached the monster (near the end position)
+      if (monsterStoneDifferenceInPercentage < 15) {
+        this.pauseWordTutorialRendering = true;
+        //Reset position to redo the dragging tutorial.
+        this.initializeStoneAnimation(this.currentStoneIndex);
       }
-    }
-
-    // Check if current stone animation is complete and we should move to the next stone
-    // Only trigger once when animation completes
-    if (this.animationCompleted && !this.isAnimatingNextStone) {
-      this.isAnimatingNextStone = true;
-
-      // Make the transition to the next stone immediate
-      setTimeout(() => {
-        const nextIndex = (this.currentStoneIndex + 1) % this.stonePositions.length;
-        this.initializeStoneAnimation(nextIndex);
-        this.isAnimatingNextStone = false;
-        this.animationCompleted = false; // Reset for next stone
-      }, 50); // Minimal delay to make the tutorial extremely responsive (reduced from 100ms)
     }
   }
 
 
   public initializeStoneAnimation(stoneIndex: number): void {
-    if (!this.isInitialized || !this.stonePositions?.length || stoneIndex < 0 || stoneIndex >= this.stonePositions.length) {
+    if (!this.stonePositions?.length || stoneIndex < 0 || stoneIndex >= this.stonePositions.length) {
       return;
     }
 
     const position = this.stonePositions[stoneIndex];
-
     // Reset animation state completely
     this.frame = 0;
     this.animationStartTime = 0;
-    this.animationStartDelay = 0; // Reset the animation start delay
     this.currentStoneIndex = stoneIndex;
-    this.animationCompleted = false;
-    this.initialDelayElapsed = stoneIndex > 0; // Only apply initial delay for the first stone
 
-    try {
-      // Clear any previous drawing artifacts
-      if (this.context && this.width && this.height) {
-        // We don't actually clear the canvas here as that would affect other game elements
-        // Instead, we ensure our state is properly reset
-      }
+    // Set up new animation positions
+    this.stonePosDetailsType = this.updateTargetStonePositions(position);
 
-      // Set up new animation positions
-      this.stonePosDetailsType = this.updateTargetStonePositions(position);
-
-      if (this.stonePosDetailsType) {
-        this.animateImagePosVal = this.stonePosDetailsType.animateImagePosVal;
-        this.x = this.animateImagePosVal.x;
-        this.y = this.animateImagePosVal.y;
-
-      } else {
-        // Position details failed to update
-      }
-    } catch (error) {
-      // Handle animation initialization error
+    if (this.stonePosDetailsType) {
+      this.animateImagePosVal = this.stonePosDetailsType.animateImagePosVal;
+      this.x = this.animateImagePosVal.x;
+      this.y = this.animateImagePosVal.y;
     }
+
+    this.pauseWordTutorialRendering = false;
   }
 
   /**
@@ -220,31 +164,28 @@ export default class WordPuzzleTutorial extends TutorialComponent {
    */
   private findTargetStonePositions(targetStones: string[], foilStones: string[], positions: number[][]): number[][] {
     const usedIndices = new Set<number>();
-    
+
     return targetStones.map(targetChar => {
       // Find the index of the first unused occurrence of this character
       const targetIndex = foilStones.findIndex((stone, index) => 
         stone === targetChar && !usedIndices.has(index)
       );
-      
+
       if (targetIndex !== -1) {
         usedIndices.add(targetIndex); // Mark this index as used
         return positions[targetIndex];
       }
-      
+
       return null; // Handle case where character isn't found (shouldn't happen)
     }).filter(position => position !== null); // Filter out any nulls
   }
 
   public dispose(): void {
-    // Reset state
-    this.isInitialized = false;
-    this.animationCompleted = false;
-    this.isAnimatingNextStone = false;
+    // Reset states
     this.frame = 0;
     this.animationStartTime = 0;
-    this.animationStartDelay = 0;
     this.currentStoneIndex = 0;
-    this.initialDelayElapsed = false;
+    this.pauseWordTutorialRendering = false;
+    this.unsubscribeSubmittedLettersCountHandler();
   }
 }

--- a/src/tutorials/base-tutorial/base-tutorial-component.ts
+++ b/src/tutorials/base-tutorial/base-tutorial-component.ts
@@ -264,7 +264,7 @@ export default class TutorialComponent {
   }) {
     // Draw the stone at current position with slightly higher opacity for word puzzles
     const previousAlpha = this.context.globalAlpha;
-    
+  
     // Near the start position
     if (monsterStoneDifferenceInPercentage > 80) {
       this.context.globalAlpha = 0.8;

--- a/src/tutorials/tutorial-handler.spec.ts
+++ b/src/tutorials/tutorial-handler.spec.ts
@@ -58,7 +58,9 @@ describe('TutorialHandler', () => {
       puzzleLevel: 0
     });
 
-    (handler as any).activeTutorial = {} as MatchLetterPuzzleTutorial;
+    (handler as any).activeTutorial = {
+      dispose: jest.fn()
+    } as unknown as MatchLetterPuzzleTutorial;
     handler.hideTutorial();
 
     expect((handler as any).activeTutorial).toBeNull();


### PR DESCRIPTION
# Changes
- Optimized stone-handler create stone methods and added comments for better clarity on the logic.
- Added new game state event called WORD_PUZZLE_SUBMITTED_LETTERS_COUNT to allow communication between the puzzle-handler and word puzzle tutorial.
- Added the publish event of WORD_PUZZLE_SUBMITTED_LETTERS_COUNT in puzzle-handler.ts
- Optimized word puzzle tutorial; Removed unnecessary logics like flags and set time out trigger, and duplicate delays. Code clean up and implemented the switching of tutorial dragged based on the stones submitted received from the WORD_PUZZLE_SUBMITTED_LETTERS_COUNT  event.
- Updated the logic in tutorial-handler/index.ts regarding the hide tutorial (it won't hide the tutorial entirely if it is word puzzle tutorial).

# How to test
- Start FTM app.
- Select any game with tutorial (first instance of any game play).
- Tutorial should appear without any issues.
- In word puzzle tutorial, the drag tutorial should be now per the letter you are solving instead of in sequence drag.

Ref: [FM-511](https://curiouslearning.atlassian.net/browse/FM-511)


[FM-511]: https://curiouslearning.atlassian.net/browse/FM-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ