### PR TITLE
feat: Spell sound tutorial - Updated audio logic for Auto replay (FM-577)

### DIFF
--- a/src/components/audio-player.ts
+++ b/src/components/audio-player.ts
@@ -119,22 +119,25 @@ export class AudioPlayer {
 
 
   /**
-  To manage audio playback in response to user clicks, we use both a timeout delay 
-  and a playback flag (`isPromptAudioPlaying`).
-
-  - The `setTimeout` serves as a debounce mechanism, preventing immediate playback on every click.
-    The delay is dynamically calculated as half of the audio’s duration. This adapts to different 
-    sound lengths and avoids relying on a fixed delay like 500ms.
-
-  - The `isPromptAudioPlaying` flag ensures that once an audio clip is actively playing, 
-    no other playback is triggered until it ends. This prevents overlapping or duplicated playback.
-
-  Using both strategies together allows us to:
-    - Prevent audio spam and overlapping sounds
-    - Ensure that at least one playback still happens even during rapid clicks
-    - Maintain a smooth and responsive user experience during frequent interactions
-**/
-  handlePlayPromptAudioClickEvent() {
+  ** To manage audio playback in response to user clicks, we use both a timeout delay 
+  ** and a playback flag (`isPromptAudioPlaying`).
+  **
+  ** - The `setTimeout` serves as a debounce mechanism, preventing immediate playback on every click.
+  **   The delay is dynamically calculated as half of the audio’s duration. This adapts to different 
+  **   sound lengths and avoids relying on a fixed delay like 500ms.
+  **
+  ** - The `isPromptAudioPlaying` flag ensures that once an audio clip is actively playing, 
+  **   no other playback is triggered until it ends. This prevents overlapping or duplicated playback.
+  ** - An optional `externalCallback` can now be provided, allowing external logic (e.g., starting animations)
+  **   to be triggered right after the audio finishes playing. This keeps the method flexible and decoupled.
+  **
+  ** Using both strategies together allows us to:
+  ** - Prevent audio spam and overlapping sounds
+  ** - Ensure that at least one playback still happens even during rapid clicks
+  ** - Maintain a smooth and responsive user experience during frequent interactions
+  ** 
+  **/
+  handlePlayPromptAudioClickEvent(externalCallback: () => void = null) {
     // Only proceed if audio isn't already playing
     if (this.promptAudioBuffer && !this.isPromptAudioPlaying) {
       const audioDuration = this.promptAudioBuffer?.duration;
@@ -154,6 +157,11 @@ export class AudioPlayer {
         //Call playPromptAudio with a callback for onended method to call.
         this.playPromptAudio(() => {
           this.isPromptAudioPlaying = false;
+
+          // Trigger optional external callback after audio finishes
+          if (externalCallback) {
+            externalCallback();
+          }
         });
       }, timeoutDelay);
     }

--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -73,21 +73,48 @@
   }
 
   .prompt-play-button {
-    width: 120px;
-    height: 120px;
+    width: 60px;
+    height: 60px;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
     cursor: pointer;
     pointer-events: auto; // Make sure the play button is clickable
-    position: absolute;
-    top: 10px;
     // Prevent highlight on press
     -webkit-tap-highlight-color: transparent;
     outline: none;
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
+    transition: transform 0.1s ease;
+  }
+
+  .prompt-play-button:active {
+    transform: scale(0.95);
+  }
+
+  .pulsing {
+    animation: pulse 1.5s infinite;
+    transition: transform 0.1s ease;
+  }
+
+  .pulsing:active {
+    transform: scale(0.95);
+  }
+  
+  @keyframes pulse {
+    0% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    50% {
+      transform: scale(1.1);
+      opacity: 0.7;
+    }
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
   }
 }
 

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -133,7 +133,7 @@ export class PromptText extends BaseHTML {
     }
 
     private removePulseClassIfSpellMatchTutorial() {
-        if (this.isSpellMatchTutorial()) {
+        if (this.isSpellSoundMatchTutorial()) {
             const playButton = document.getElementById("prompt-play-button");
             if (playButton?.classList.contains("pulsing")) {
                 playButton.classList.remove("pulsing");
@@ -483,7 +483,7 @@ export class PromptText extends BaseHTML {
         }
     }
 
-    private isSpellMatchTutorial(): boolean {
+    private isSpellSoundMatchTutorial(): boolean {
         return (
             this.isLevelHaveTutorial &&
             this.levelData?.levelMeta?.levelType === "LetterOnly" &&
@@ -510,7 +510,7 @@ export class PromptText extends BaseHTML {
             this.audioPlayer.handlePlayPromptAudioClickEvent(
                 () => {
                     if (
-                        this.isSpellMatchTutorial() &&
+                        this.isSpellSoundMatchTutorial() &&
                         time <= this.AUTO_PROMPT_ACTIVE_WINDOW_END // Ensures auto audio replay only happens within the range of 3000–9300ms.
                     ) {
                         // Trigger a 1-second delay before allowing another auto replay.

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -114,7 +114,6 @@ export class PromptText extends BaseHTML {
         this.audioPlayer = new AudioPlayer();
         this.audioPlayer.preloadPromptAudio(this.getPromptAudioUrl());
         document.addEventListener(VISIBILITY_CHANGE, this.handleVisibilityChange, false);
-        this.isAutoPromptPlaying = false;
         //Set initial auto audio play timing.
         this.setPromptInitialAudioDelayValues(isLevelHaveTutorial);
 
@@ -494,7 +493,7 @@ export class PromptText extends BaseHTML {
 
     private stopAutoPromptReplay(): void {
         this.isAutoPromptPlaying = true;
-        this.AUTO_PROMPT_ACTIVE_WINDOW_END = this.AUTO_PROMPT_ACTIVE_WINDOW_START; //Closes the time window gap to trigger the auto replay.
+        this.AUTO_PROMPT_ACTIVE_WINDOW_END = this.AUTO_PROMPT_ACTIVE_WINDOW_START; //Closes the time window gap that triggers the auto replay.
     }
 
     private handleAutoPromptPlay(time) {


### PR DESCRIPTION
# Changes
-Updated handlePlayPromptAudioClickEvent in audio-player.ts to support external callbacks for triggering logic outside the audio player.
- Restored the audio button for Spell Sound Match tutorial levels.
- Updated CSS styles for the audio button; Added pulsating effect during tutorial, and Added press-down visual effect when clicked.
- Updated logic in prompt-text.ts to handle auto replay for the tutorial audio, ensuring it respects timing and user interaction.
- Added a note in startAnimationLoop highlighting why it should eventually be deprecated and refactored.

# How to test
- Run FTM app in English
- Play the game until you reach level 4.
- In level 4 (English), the Spell Match Sound tutorial should appear.
- The prompt button inside the speech bubble should pulsate, and the tutorial audio should auto-replay for up to 6 seconds.
- Clicking the button should stop both the pulsating effect and auto replay.

Ref: [FM-577](https://curiouslearning.atlassian.net/browse/FM-577)
