### PR TITLE
fix: Standardize foil string to a,c,t for Firebase & Statsig

### DIFF
--- a/src/Firebase/firebase-event-interface.ts
+++ b/src/Firebase/firebase-event-interface.ts
@@ -28,9 +28,8 @@ export interface PuzzleCompletedEvent extends CommonEventProperties {
     puzzle_number: number;
     item_selected: string;
     target: string;
-    foils: string[];
+    foils: string[] | string; // Allow both array and string formats
     response_time: number;
-    
 }
 export interface LevelCompletedEvent extends CommonEventProperties {
     success_or_failure: string;

--- a/src/Firebase/firebase-integration.spec.ts
+++ b/src/Firebase/firebase-integration.spec.ts
@@ -283,7 +283,7 @@ describe('Firebase Event Logging - puzzle_completed', () => {
             ? droppedLetters ?? 'TIMEOUT'
             : 'STONE_TEXT',
         target: correctTarget,
-        foils: foilStones,
+        foils: foilStones.join(','), // Convert array to comma-separated string
         response_time: (endTime - puzzleTime) / 1000,
       };
 
@@ -307,7 +307,7 @@ describe('Firebase Event Logging - puzzle_completed', () => {
         puzzle_number: 2,
         item_selected: 'DOG',
         target: 'CAT',
-        foils: ['BAT', 'RAT']
+        foils: 'BAT,RAT' // Expect comma-separated string
       })
     );
 

--- a/src/Firebase/firebase-integration.ts
+++ b/src/Firebase/firebase-integration.ts
@@ -84,8 +84,16 @@ export class FirebaseIntegration extends BaseFirebaseIntegration {
   }
 
   public sendPuzzleCompletedEvent(data: PuzzleCompletedEvent): void {
-    this.trackCustomEvent('puzzle_completed', data);
-  }
+    // Create event data
+    const eventData = { ...data };
+    
+    // Ensure foils is a comma-separated string
+    if (Array.isArray(eventData.foils)) {
+        eventData.foils = eventData.foils.join(',');
+    }
+    
+    this.trackCustomEvent('puzzle_completed', eventData);
+}
 
   public sendLevelCompletedEvent(data: LevelCompletedEvent): void {
     this.trackCustomEvent('level_completed', data);


### PR DESCRIPTION
# Changes
- Standardized the foils string for both Firebase and Statsig to: "a,c,t", Statsig was receiving a json array type string and was failing to validate because of that

# How to test
- Run the game in any language, complete the first level and observe the event data in BigQuery and Statsig

Ref: [AJ-338](https://curiouslearning.atlassian.net/browse/AJ-338)


[AJ-338]: https://curiouslearning.atlassian.net/browse/AJ-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ