### PR TITLE
feat: Added cache invalidation job in s3-delpoy-workflow (EN-64)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ commands:
         default: '/*'
     steps:
       - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY
-          aws-region: AWS_DEFAULT_REGION
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws_access_key_id: AWS_ACCESS_KEY
+          region: AWS_DEFAULT_REGION
+          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
       - run: |
           aws cloudfront create-invalidation \
           --distribution-id << parameters.distribution-id >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - invalidate-cloudfront-cache:
           distribution-id: 'E2QD6IZIYBGTJK'
-          paths: '"/src'
+          paths: '"/src"'
 
 # http://curious-reader-books-production.s3-website.ap-south-1.amazonaws.com/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,17 +77,15 @@ jobs:
     steps:
       - invalidate-cloudfront-cache:
           distribution-id: 'E2QD6IZIYBGTJK'
-          paths: '"/src"'
+          paths: '"/*"'
+
+# TODO: move invalidate-cloudfront-cache parameters to project env variables
+# Eventually these will be the new cloudfront name for apps and app name respectively.
+
 
 # http://curious-reader-books-production.s3-website.ap-south-1.amazonaws.com/
 
 workflows:
-  test-invalidation:
-    jobs:
-      - invalidate-cloudfront-cache-prod:
-          context:
-            - aws-context
-
   s3-deploy-workflow:
     jobs:
       - node/test
@@ -108,7 +106,12 @@ workflows:
       - build-and-deploy-prod:
           context:
             - aws-context
+          requires:
+            - node/test
           filters:
             branches:
               only:
                 - main
+      - invalidate-cloudfront-cache-prod:
+          requires:
+            - build-and-deploy-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ commands:
           aws_access_key_id: AWS_ACCESS_KEY
           region: AWS_DEFAULT_REGION
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+      - run: cat ~/.aws/credentials
       - run: |
           aws cloudfront create-invalidation \
           --distribution-id << parameters.distribution-id >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ jobs:
 workflows:
   test-invalidation:
     jobs:
-      - invalidate-cloudfront-cache-prod
+      - invalidate-cloudfront-cache-prod:
+          context:
+            - aws-context
 
   s3-deploy-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  # aws-cli: circleci/aws-cli@5.2.0
+  aws-cli: circleci/aws-cli@5.2.0
   # aws-s3: circleci/aws-s3@4.1.1
   aws-s3: circleci/aws-s3@3.0
   node: circleci/node@7.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
     steps:
       - invalidate-cloudfront-cache:
           distribution-id: 'E2QD6IZIYBGTJK'
-          paths: '"/src"'
 
 # http://curious-reader-books-production.s3-website.ap-south-1.amazonaws.com/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ commands:
         default: '"/*"'
     steps:
       - aws-cli/setup:
-          aws_access_key_id: AWS_ACCESS_KEY
-          region: AWS_DEFAULT_REGION
-          aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+          aws_access_key_id: $AWS_ACCESS_KEY
+          region: $AWS_DEFAULT_REGION
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
       - run: cat ~/.aws/credentials
       - run: >
           aws cloudfront create-invalidation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
         default: ''
       paths:
         type: string
-        default: '/*'
+        default: '"/*"'
     steps:
       - aws-cli/setup:
           aws_access_key_id: AWS_ACCESS_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ commands:
           region: AWS_DEFAULT_REGION
           aws_secret_access_key: AWS_SECRET_ACCESS_KEY
       - run: cat ~/.aws/credentials
-      - run: |
-          aws cloudfront create-invalidation \
-          --distribution-id << parameters.distribution-id >> \
+      - run: >
+          aws cloudfront create-invalidation
+          --distribution-id << parameters.distribution-id >>
           --paths << parameters.paths >>
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
     steps:
       - invalidate-cloudfront-cache:
           distribution-id: 'E2QD6IZIYBGTJK'
+          paths: '"/src'
 
 # http://curious-reader-books-production.s3-website.ap-south-1.amazonaws.com/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,23 @@ commands:
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           from: ./build/
           to: << parameters.to >>
+  invalidate-cloudfront-cache:
+    parameters:
+      distribution-id:
+        type: string
+        default: ''
+      paths:
+        type: string
+        default: '/*'
+    steps:
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY
+          aws-region: AWS_DEFAULT_REGION
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+      - run: |
+          aws cloudfront create-invalidation \
+          --distribution-id << parameters.distribution-id >> \
+          --paths << parameters.paths >>
 
 jobs:
   build-and-deploy-dev:
@@ -53,9 +70,21 @@ jobs:
       - build-and-deploy:
           to: 's3://feedthemonster-production'
 
+  invalidate-cloudfront-cache-prod:
+    docker:
+      - image: cimg/python:3.13.2-node
+    steps:
+      - invalidate-cloudfront-cache:
+          distribution-id: 'E2QD6IZIYBGTJK'
+          paths: '"/src"'
+
 # http://curious-reader-books-production.s3-website.ap-south-1.amazonaws.com/
 
 workflows:
+  test-invalidation:
+    jobs:
+      - invalidate-cloudfront-cache-prod
+
   s3-deploy-workflow:
     jobs:
       - node/test


### PR DESCRIPTION
# Changes
- Added `invalidate-cloudfront-cache-prod` job in circle ci config.yml

# How to test
- DEV only, we will need to update the config to trigger in `dev` merge and PR'd there. 
- preliminary [test](https://app.circleci.com/pipelines/github/curiouslearning/FeedTheMonsterJS/4235/workflows/60362b69-e5c0-4770-931f-1f5fdf8c59bd)

Ref: [EN-64](https://curiouslearning.atlassian.net/browse/EN-64)


[EN-64]: https://curiouslearning.atlassian.net/browse/EN-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ