### PR TITLE
fix: Feedback text displays in the level-selection screen when we quickly change the screen. (FM-587)

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -302,7 +302,7 @@ img {
 .feedback-text.show {
   -webkit-animation: scale-up-center 0.4s cubic-bezier(0.39, 0.575, 0.565, 1) both;
   animation: scale-up-center 0.4s cubic-bezier(0.39, 0.575, 0.565, 1) both;
-  z-index: 5;
+  z-index: 4;
   opacity: 1;
 }
 


### PR DESCRIPTION
# Changes
- update z index of the feedback text

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Select any level and play the game
- Feed correct stone
- Feedback title appear and then quickly return to level select screen
- Makesure the feedback title dont show or overlap to the level select screen

Ref: [FM-587](https://curiouslearning.atlassian.net/browse/FM-587)


[FM-587]: https://curiouslearning.atlassian.net/browse/FM-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ