### PR TITLE
Fix: issue with the tutorial showing in 2-5th puzzle when no interaction (FM-591)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -715,9 +715,7 @@ export class GameplayScene {
     this.tutorial.resetTutorialTimer();
 
     // Hide tutorial if counter is greater than 0
-    if(this.counter > 0) {
-      this.tutorial.hideTutorial();
-    }
+    this.counter > 0 && this.tutorial.hideTutorial();
 
     // Reset the 6-second tutorial delay timer each time a new puzzle is loaded
     this.tutorial.resetQuickStartTutorialDelay();


### PR DESCRIPTION
# Changes
- Hide tutorial in gameplay scene when the counter is more than 0

# How to test
- Open the start screen of FTM.
- Tap or click any part of the start screen to proceed to the next screen
- Choose level that has tutorial (1 or 8)
- Don't interact with the tutorial and wait for the time to finish
- Make sure the tutorial don't appear in the 2-5th puzzle

Ref: [FM-591](https://curiouslearning.atlassian.net/browse/FM-591)


[FM-591]: https://curiouslearning.atlassian.net/browse/FM-591