### PR TITLE
feat: Added slots and text reveal for audio spelling game (FM-516)

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -135,7 +135,36 @@
     }
   }
 
-  
+  .prompt-button-slots-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 8px; // space between text and button+slots
+  }
+
+  .prompt-slots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+
+  .slot {
+    min-width: 24px;
+    height: 28px;
+    font-size: 24px;
+    text-align: center;
+    font-weight: bold;
+    font-family: 'Quicksand', sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: black;
+  }
+
+  .revealed-letter {
+    color: #000; // You can customize this for correct/incorrect colors
+  }
+}
 }
 
 // Text color classes

--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -78,7 +78,7 @@
   }
 
   // Tablets (481-820px)
-  @media (min-width: 481px) and (max-width: 820px) {
+  @media (min-width: 481px) {
     width: 260px;
     height: 300px;
     top: 20%;
@@ -86,8 +86,6 @@
 
   // large tablet (>820px)
   @media (min-width: 821px) {
-    width: 260px;
-    height: 300px;
     top: 25%;
   }
 }

--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -18,6 +18,8 @@
   }
 }
 
+
+
 .prompt-background {
   position: relative;
   background-size: contain;
@@ -52,6 +54,40 @@
   @media (min-width: 821px) {
     width: 48%;
     height: 22%;
+    top: 25%;
+  }
+}
+
+// TEMP: Spell Sound only - overrides prompt bubble size
+// This is a band-aid fix to force specific dimensions for that gameplay.
+// Consider refactoring layout structure if background scaling becomes shared.
+.prompt-bubble-custom {
+
+  // Small mobile (≤376px)
+  @media (max-width: 376px) {
+    width: 300px;
+    height: 210px;
+    top: 18%;
+  }
+
+  // Large mobile (377-480px)
+  @media (min-width: 377px) and (max-width: 480px) {
+    width: 230px;
+    height: 230px;
+    top: 15%;
+  }
+
+  // Tablets (481-820px)
+  @media (min-width: 481px) and (max-width: 820px) {
+    width: 260px;
+    height: 300px;
+    top: 20%;
+  }
+
+  // large tablet (>820px)
+  @media (min-width: 821px) {
+    width: 260px;
+    height: 300px;
     top: 25%;
   }
 }
@@ -139,14 +175,12 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: 8px; // space between text and button+slots
   }
 
   .prompt-slots {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-  margin-top: 10px;
+    display: flex;
+    justify-content: center;
+    gap: 8px;
 
   .slot {
     min-width: 24px;

--- a/src/components/prompt-text/prompt-text.spec.ts
+++ b/src/components/prompt-text/prompt-text.spec.ts
@@ -132,7 +132,23 @@ describe('PromptText', () => {
 
   describe('generatePromptSlots', () => {
     it('should generate underscore slots initially', () => {
-      promptText.levelData.levelMeta.protoType = 'Hidden';
+      // Reconstruct with tutorial enabled
+      promptText = new PromptText(
+        500,
+        puzzleDataMock,
+        {
+          ...levelDataMock,
+          levelMeta: {
+            levelType: 'Word',
+            protoType: 'Hidden' // triggers slot logic
+          }
+        },
+        false,
+        'prompt-container',
+        undefined,
+        true, // ✅ tutorial enabled for generatePromptSlots
+        onClickMock
+      );
       (promptText as any).generateTextMarkup(); // Re-trigger slot logic with updated protoType
       const slots = document.querySelectorAll('#prompt-slots .slot');
       expect(slots.length).toBe(3);

--- a/src/components/prompt-text/prompt-text.spec.ts
+++ b/src/components/prompt-text/prompt-text.spec.ts
@@ -21,7 +21,7 @@ jest.mock('@gameStateService', () => ({
   EVENTS: {
     WORD_PUZZLE_SUBMITTED_LETTERS_COUNT: 'WORD_PUZZLE_SUBMITTED_LETTERS_COUNT'
   },
-  subscribe: jest.fn(() => jest.fn()) // unsubscribe fn
+  subscribe: jest.fn(() => jest.fn()) // unsubscribe function
 }));
 
 describe('PromptText', () => {
@@ -36,7 +36,10 @@ describe('PromptText', () => {
         <div id="prompt-background" class="prompt-background">
           <div id="prompt-text-button-container">
             <div id="prompt-text" class="prompt-text"></div>
-            <div id="prompt-play-button" class="prompt-play-button"></div>
+            <div class="prompt-button-slots-wrapper">
+              <div id="prompt-play-button" class="prompt-play-button"></div>
+              <div id="prompt-slots" class="prompt-slots"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -75,7 +78,7 @@ describe('PromptText', () => {
   });
 
   afterEach(() => {
-    jest.clearAllTimers();
+    jest.clearAllMocks();
     jest.useRealTimers();
   });
 
@@ -113,11 +116,9 @@ describe('PromptText', () => {
       const promptEl = document.querySelector('#prompt-text');
       expect(promptEl).toBeTruthy();
 
-      // Get the wrapper span (it contains the child letter spans)
       const wrapper = promptEl?.querySelector('span');
       expect(wrapper).toBeTruthy();
 
-      // Get only the inner spans (the actual letter elements)
       const letterSpans = wrapper?.querySelectorAll('span') ?? [];
 
       const characters = Array.from(letterSpans)
@@ -129,4 +130,34 @@ describe('PromptText', () => {
     });
   });
 
+  describe('generatePromptSlots', () => {
+    it('should generate underscore slots initially', () => {
+      promptText.levelData.levelMeta.protoType = 'Hidden';
+      (promptText as any).generateTextMarkup(); // Re-trigger slot logic with updated protoType
+      const slots = document.querySelectorAll('#prompt-slots .slot');
+      expect(slots.length).toBe(3);
+
+      slots.forEach((slot, i) => {
+        expect(slot.textContent).toBe('_');
+        expect(slot.classList.contains('revealed-letter')).toBe(false);
+      });
+    });
+
+    it('should display revealed letters when active index advances', () => {
+      // Simulate some letters already solved
+      promptText.currentActiveLetterIndex = 2;
+      promptText.generatePromptSlots();
+
+      const slots = document.querySelectorAll('#prompt-slots .slot');
+      expect(slots.length).toBe(3);
+
+      expect(slots[0].textContent).toBe('c');
+      expect(slots[1].textContent).toBe('a');
+      expect(slots[2].textContent).toBe('_');
+
+      expect(slots[0].classList.contains('revealed-letter')).toBe(true);
+      expect(slots[1].classList.contains('revealed-letter')).toBe(true);
+      expect(slots[2].classList.contains('revealed-letter')).toBe(false);
+    });
+  });
 });

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -344,17 +344,10 @@ export class PromptText extends BaseHTML {
         this.promptTextElement.setAttribute('dir', cssDirection);
 
         // Handle special types where only the play button is shown
-        if (
-            protoType === "Hidden" &&
-            (
-                levelType == "Word" ||
-                levelType == "SoundWord" ||
-                levelType == "audioPlayerWord"
-            )
-        ) {
+        if (protoType === "Hidden") {
             // Show play button instead of text for audioPlayerWord levelType or hidden prototypes
             this.setPromptButtonVisible(true);
-            this.generatePromptSlots();
+            this.isSpellSoundMatchTutorial() && this.generatePromptSlots();
             return;
         }
 

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -44,7 +44,7 @@ export const PROMPT_TEXT_LAYOUT = (
                     <div class="prompt-button-slots-wrapper">
                         <div id="prompt-play-button"
                             class="prompt-play-button ${audioBtnPulsateStyle}"
-                            style="background-image: url(${AUDIO_PLAY_BUTTON}); pointer-events: auto;">
+                            style="background-image: url(${AUDIO_PLAY_BUTTON});">
                         </div>
                         <div id="prompt-slots" class="prompt-slots"></div>
                     </div>

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -26,12 +26,17 @@ export const PROMPT_TEXT_LAYOUT = (
     }) => {
     //If the game type is audio puzzle (audio button displayed instead of word or letter), we won't apply the bubble pulsate effect.
     const bubblePulsateStyle = isGameTypeAudio(gamePrototype) ? '' : 'floating-pulse';
+
     //If the game type is audio and it is the audio tutorial level then we apply the button pulsate effect for the button.
-    const audioBtnPulsateStyle = isLevelHaveTutorial ? 'pulsing' : '';
+    const audioBtnPulsateStyle = isLevelHaveTutorial && isGameTypeAudio(gamePrototype) ? 'pulsing' : '';
 
     return (`
-        <div id="${id}" class="prompt-container">
-            <div id="prompt-background" class="prompt-background ${bubblePulsateStyle}" style="background-image: url(${PROMPT_TEXT_BG})">
+        <div id="${id}" class="prompt-container ">
+            <div
+                id="prompt-background"
+                class="prompt-background ${bubblePulsateStyle} "
+                style="background-image: url(${PROMPT_TEXT_BG})"
+            >
                 <div id="prompt-text-button-container">
                     <div id="prompt-text" class="prompt-text"></div>
 
@@ -181,6 +186,13 @@ export class PromptText extends BaseHTML {
         this.promptTextElement = this.promptContainer.querySelector('#prompt-text') as HTMLDivElement;
         this.promptPlayButtonElement = this.promptContainer.querySelector('#prompt-play-button') as HTMLDivElement;
         this.promptSlotElement = this.promptContainer.querySelector('#prompt-slots') as HTMLDivElement;
+
+        if (this.isSpellSoundMatchTutorial()) {
+            // Patch fix: Apply 'prompt-bubble-custom' to override prompt background dimensions
+            // for Spell Sound tutorial layout. This ensures the audio button and slot text
+            // fit properly inside the bubble. Not a scalable solution — revisit if reused elsewhere.
+            this.promptBackground.classList.add('prompt-bubble-custom');
+        }
 
         // Update event listeners to include the callback
         const handleClick = (e: Event) => {

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -212,7 +212,7 @@ export default class TutorialHandler {
       }
 
       // For word puzzles (multiple stones in sequence)
-      if (gameTypeName === 'Word') {
+      if (gameTypeName === 'Word' || gameTypeName === 'SoundWord') {
         return new WordPuzzleTutorial({
           context: this.context,
           width: this.width,


### PR DESCRIPTION
# Changes
- Updated Prompt-Text base HTML, adding a wrapper to handle audio button and slot for text.
- Updated tutorial handler if condition for word puzzle, adding SoundWord in the if flag for spelling puzzles.
- Updated Prompt-Text spec file.

# How to test
- Run FTM app with `?cr_lang=` set to either Yoruba, Bangla, Hausa, or Sesotho.
- For Yoruba Language, on level 12.
- Play the game and the segment 1 should 

Ref: [FM-516](https://curiouslearning.atlassian.net/browse/FM-516)


[FM-516]: https://curiouslearning.atlassian.net/browse/FM-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ