### PR TITLE
fix: Re-apply line of code of FM-516 recent changes.

### DIFF
--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -394,7 +394,6 @@ export class PromptText extends BaseHTML {
         if (protoType === "Hidden") {
             // Show play button instead of text for audioPlayerWord levelType or hidden prototypes
             this.setPromptButtonVisible(true);
-            this.isSpellSoundMatch() && this.generatePromptSlots();
             return;
         }
 


### PR DESCRIPTION
# Changes
- Remove `this.isSpellSoundMatch() && this.generatePromptSlots();` that was re-added on test branch merging.

# How to test
- Run FTM app with /?cr_lang=yoruba
- On levels 12 and 12, the text slot should be hidden at first.

Ref: [FM-516](https://curiouslearning.atlassian.net/browse/FM-516)


[FM-516]: https://curiouslearning.atlassian.net/browse/FM-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ