### PR TITLE
feat: Update logic to add and remove Next and Replay button on level 1 and other levels also check last level doesn't have next button.

### DIFF
--- a/src/scenes/levelend-scene/levelend-scene.scss
+++ b/src/scenes/levelend-scene/levelend-scene.scss
@@ -27,6 +27,30 @@
   }
 }
 
+#levelend-next-btn {
+  animation: pulse 1.5s infinite;
+  transition: transform 0.1s ease;
+  max-width: 70px;
+  max-height: 70px;
+}
+
+  @keyframes pulse {
+    0% {
+      transform: scale(1);
+      opacity: 1;
+    }
+
+    50% {
+      transform: scale(1.1);
+      opacity: 1;
+    }
+
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
 /* For ultrawide monitors or desktop screens that are not very tall  */
 @media screen and (min-width: 1080px) and (max-height: 650px) {
   .buttons-container {

--- a/src/scenes/levelend-scene/levelend-scene.ts
+++ b/src/scenes/levelend-scene/levelend-scene.ts
@@ -292,6 +292,7 @@ export class LevelEndScene {
 
   renderButtonsHTML() {
     const nextButton = document.getElementById('levelend-next-btn');
+    const replayButton = document.getElementById('levelend-retry-btn');
     // Define configurations for each button
     const buttonConfigs = [
       {
@@ -302,31 +303,55 @@ export class LevelEndScene {
         },
       },
     ];
-    
-    // Add NextButtonHtml only if not the last level and the star count is sufficient
-    if (!this.isLastLevel && this.starCount >= 2) {
-      buttonConfigs.push({
-        ButtonClass: NextButtonHtml,
-        id: 'levelend-next-btn',
-        onClick: () => {
-          this.buttonCallbackFn('next');
-        },
-      });
-    } else {
-      if (nextButton) {
-        nextButton.remove();
+
+    // Level 1 logic
+    if (this.currentLevel === 0) {
+      if (this.starCount >= 2) {
+        // PASS: Show Next Level 
+        buttonConfigs.push({
+          ButtonClass: NextButtonHtml,
+          id: 'levelend-next-btn',
+          onClick: () => {
+            this.buttonCallbackFn('next');
+          },
+        });
+
+        // Ensure Replay is removed if exists
+        if (replayButton) replayButton.remove();
+
+      }
+      else {
+        // FAIL: Show Replay
+        buttonConfigs.push({
+          ButtonClass: RetryButtonHtml,
+          id: 'levelend-retry-btn',
+          onClick: () => this.buttonCallbackFn('retry'),
+        });
       }
     }
-    
-    // Add retry button last as requested
-    buttonConfigs.push({
-      ButtonClass: RetryButtonHtml,
-      id: 'levelend-retry-btn',
-      onClick: () => {
-        this.buttonCallbackFn('retry');
-      },
-    });
-    
+    else {
+      if (this.starCount >= 2) {
+        // Show Next Level
+        buttonConfigs.push({
+          ButtonClass: NextButtonHtml,
+          id: 'levelend-next-btn',
+          onClick: () => this.buttonCallbackFn('next'),
+        });
+      }
+      // Show Replay Level
+      buttonConfigs.push({
+        ButtonClass: RetryButtonHtml,
+        id: 'levelend-retry-btn',
+        onClick: () => this.buttonCallbackFn('retry'),
+      });
+    }
+
+    // Remove Next if last level
+    if (this.isLastLevel) {
+      const index = buttonConfigs.findIndex(cfg => cfg.id === 'levelend-next-btn');
+      if (index > -1) buttonConfigs.splice(index, 1);
+      if (nextButton) nextButton.remove();
+    }
     // Create buttons based on configuration
     buttonConfigs.forEach(({ ButtonClass, id, onClick }) => {
       this.createButton(ButtonClass, id, onClick);


### PR DESCRIPTION
# Changes
- Updated logic to add and remove Next and Replay button on level 1 
- Added pulsating effect to make Next Level button the most prominent CTA

# How to test
- Play the 1st level game and other levels
- Level 1:
    If player passes: show Level Selection (left) + Next Level (right, large, pulsating)
    If player fails: show Level Selection (left) + Replay (right, current size, no animation)
    Layout and positioning match the rules above

- Level 2+:
    All three CTAs are visible:
    Level Selection (left, current size)
    Next Level (center, large, pulsating)
    Replay (right, current size, no animation)
    Button layout and functionality behave as expected
    
- Play the last level and check no next button on last level.

Ref: [FM-602](https://curiouslearning.atlassian.net/browse/FM-602)
