### PR TITLE
enhancement: Updated prompt bubble rendering and its CSS styling (FM-597)

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -18,7 +18,7 @@
   }
 }
 
-.responsive-position {
+.prompt-center-responsive {
   position: relative;
   left: 50%;
   transform: translateX(-50%);
@@ -58,7 +58,7 @@
 }
 
 //Custom position and size for prompt bubble. Used for Spell Word Audio puzzle.
-.prompt-bubble-custom {
+.prompt-bubble-spell-audio {
 
   // Small mobile (≤376px)
   @media (max-width: 376px) {
@@ -70,7 +70,7 @@
   // Large mobile (377-480px)
   @media (min-width: 377px) and (max-width: 480px) {
     width: 280px;
-    height: 240px;
+    height: 245px;
     top: 13%;
   }
 

--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -18,14 +18,8 @@
   }
 }
 
-
-
-.prompt-background {
+.responsive-position {
   position: relative;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  transition: transform 0.05s ease;
   left: 50%;
   transform: translateX(-50%);
 
@@ -58,36 +52,40 @@
   }
 }
 
-// TEMP: Spell Sound only - overrides prompt bubble size
-// This is a band-aid fix to force specific dimensions for that gameplay.
-// Consider refactoring layout structure if background scaling becomes shared.
+#prompt-bubble {
+  position: absolute;
+  transition: transform 0.05s ease;
+}
+
+//Custom position and size for prompt bubble. Used for Spell Word Audio puzzle.
 .prompt-bubble-custom {
 
   // Small mobile (≤376px)
   @media (max-width: 376px) {
     width: 300px;
-    height: 210px;
-    top: 18%;
+    height: 235px;
+    top: 16%;
   }
 
   // Large mobile (377-480px)
   @media (min-width: 377px) and (max-width: 480px) {
-    width: 230px;
-    height: 230px;
-    top: 15%;
+    width: 280px;
+    height: 240px;
+    top: 13%;
   }
 
-  // Tablets (481-820px)
+  // Tablets (481 above)
   @media (min-width: 481px) {
-    width: 260px;
+    width: 280px;
     height: 300px;
-    top: 20%;
+    top: 18%;
   }
 
   // large tablet (>820px)
   @media (min-width: 821px) {
-    top: 25%;
+    top: 20%;
   }
+
 }
 
 @keyframes float {
@@ -107,7 +105,7 @@
   animation: float 2s ease-in-out infinite;
 }
 
-.prompt-background {
+#prompt-content {
 
   .prompt-text {
     width: 100%;
@@ -178,7 +176,7 @@
   .prompt-slots {
     display: hidden; //Hidden by default, will be set to flex when rendering.
     justify-content: center;
-    gap: 8px;
+    gap: 3px;
 
   .slot {
     min-width: 24px;

--- a/src/components/prompt-text/prompt-text.spec.ts
+++ b/src/components/prompt-text/prompt-text.spec.ts
@@ -35,7 +35,7 @@ describe('PromptText', () => {
       <div id="prompt-container">
         <img
           id="prompt-bubble"
-          class="responsive-position"
+          class="prompt-center-responsive"
           alt="audio button"
         />
         <div id="prompt-content" class="prompt-content">

--- a/src/components/prompt-text/prompt-text.spec.ts
+++ b/src/components/prompt-text/prompt-text.spec.ts
@@ -33,7 +33,12 @@ describe('PromptText', () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <div id="prompt-container">
-        <div id="prompt-background" class="prompt-background">
+        <img
+          id="prompt-bubble"
+          class="responsive-position"
+          alt="audio button"
+        />
+        <div id="prompt-content" class="prompt-content">
           <div id="prompt-text-button-container">
             <div id="prompt-text" class="prompt-text"></div>
             <div class="prompt-button-slots-wrapper">
@@ -91,7 +96,7 @@ describe('PromptText', () => {
     it('should inject click event listeners into prompt elements', () => {
       const playButton = document.getElementById('prompt-play-button');
       const textElement = document.getElementById('prompt-text');
-      const background = document.getElementById('prompt-background');
+      const background = document.getElementById('prompt-content');
 
       playButton?.click();
       textElement?.click();

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -10,7 +10,7 @@ import gameStateService from '@gameStateService';
 export const DEFAULT_SELECTORS = {
     root: '#background', // The background element to append the prompt to
     promptText: '.prompt-text',
-    promptBackground: '.prompt-background',
+    promptBackground: '.prompt-position',
     promptPlayButton: '.prompt-play-button'
 };
 
@@ -32,10 +32,15 @@ export const PROMPT_TEXT_LAYOUT = (
 
     return (`
         <div id="${id}" class="prompt-container ">
+            <img
+                id="prompt-bubble"
+                class="responsive-position ${bubblePulsateStyle}"
+                src="${PROMPT_TEXT_BG}"
+                alt="audio button"
+            />
             <div
-                id="prompt-background"
-                class="prompt-background ${bubblePulsateStyle} "
-                style="background-image: url(${PROMPT_TEXT_BG})"
+                id="prompt-content"
+                class="responsive-position ${bubblePulsateStyle}"
             >
                 <div id="prompt-text-button-container">
                     <div id="prompt-text" class="prompt-text"></div>
@@ -75,6 +80,7 @@ export class PromptText extends BaseHTML {
     // HTML elements for the prompt
     public promptContainer: HTMLDivElement;
     public promptBackground: HTMLDivElement;
+    public promptBubbleImg: HTMLImageElement;
     public promptTextElement: HTMLDivElement;
     public promptPlayButtonElement: HTMLDivElement;
     public promptSlotElement: HTMLDivElement;
@@ -197,10 +203,7 @@ export class PromptText extends BaseHTML {
             this.runAfterInitialAudioDelay(
                 totalInitialAudioDuration,
                 () => {
-                    if (this.isSpellSoundMatch()) {
-                        this.promptSlotElement.style.display = 'flex';
-                        this.generatePromptSlots();
-                    }
+                    this.showSpellSlots();
                     this.removePulseAudioEffect();
                 }
             );
@@ -218,16 +221,15 @@ export class PromptText extends BaseHTML {
     public initializeHtmlElements(containerId: string) {
         // Get references to the created elements
         this.promptContainer = document.getElementById(containerId) as HTMLDivElement;
-        this.promptBackground = this.promptContainer.querySelector('#prompt-background') as HTMLDivElement;
+        this.promptBackground = this.promptContainer.querySelector('#prompt-content') as HTMLDivElement;
+        this.promptBubbleImg = this.promptContainer.querySelector('#prompt-bubble') as HTMLImageElement;
         this.promptTextElement = this.promptContainer.querySelector('#prompt-text') as HTMLDivElement;
         this.promptPlayButtonElement = this.promptContainer.querySelector('#prompt-play-button') as HTMLDivElement;
         this.promptSlotElement = this.promptContainer.querySelector('#prompt-slots') as HTMLDivElement;
 
         if (this.isSpellSoundMatch()) {
-            // Patch fix: Apply 'prompt-bubble-custom' to override prompt background dimensions
-            // for Spell Sound tutorial layout. This ensures the audio button and slot text
-            // fit properly inside the bubble. Not a scalable solution — revisit if reused elsewhere.
-            this.promptBackground.classList.add('prompt-bubble-custom');
+            //Add custom style for prompt bubble for Spell Word Audio puzzle.
+            this.promptBubbleImg.classList.add('prompt-bubble-custom');
         }
 
         // Update event listeners to include the callback
@@ -513,7 +515,7 @@ export class PromptText extends BaseHTML {
      */
     calculateFont(): number {
         const size = this.width * 0.65 / this.currentPromptText.length;
-        return size > 35 ? 25 : size;
+        return size > 35 || this.currentPromptText.length > 4 ? 25 : size;
     }
 
     /**

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -10,7 +10,7 @@ import gameStateService from '@gameStateService';
 export const DEFAULT_SELECTORS = {
     root: '#background', // The background element to append the prompt to
     promptText: '.prompt-text',
-    promptBackground: '.prompt-position',
+    promptContent: '.prompt-position',
     promptPlayButton: '.prompt-play-button'
 };
 
@@ -34,13 +34,13 @@ export const PROMPT_TEXT_LAYOUT = (
         <div id="${id}" class="prompt-container ">
             <img
                 id="prompt-bubble"
-                class="responsive-position ${bubblePulsateStyle}"
+                class="prompt-center-responsive ${bubblePulsateStyle}"
                 src="${PROMPT_TEXT_BG}"
                 alt="audio button"
             />
             <div
                 id="prompt-content"
-                class="responsive-position ${bubblePulsateStyle}"
+                class="prompt-center-responsive ${bubblePulsateStyle}"
             >
                 <div id="prompt-text-button-container">
                     <div id="prompt-text" class="prompt-text"></div>
@@ -79,7 +79,7 @@ export class PromptText extends BaseHTML {
 
     // HTML elements for the prompt
     public promptContainer: HTMLDivElement;
-    public promptBackground: HTMLDivElement;
+    public promptContent: HTMLDivElement;
     public promptBubbleImg: HTMLImageElement;
     public promptTextElement: HTMLDivElement;
     public promptPlayButtonElement: HTMLDivElement;
@@ -221,7 +221,7 @@ export class PromptText extends BaseHTML {
     public initializeHtmlElements(containerId: string) {
         // Get references to the created elements
         this.promptContainer = document.getElementById(containerId) as HTMLDivElement;
-        this.promptBackground = this.promptContainer.querySelector('#prompt-content') as HTMLDivElement;
+        this.promptContent = this.promptContainer.querySelector('#prompt-content') as HTMLDivElement;
         this.promptBubbleImg = this.promptContainer.querySelector('#prompt-bubble') as HTMLImageElement;
         this.promptTextElement = this.promptContainer.querySelector('#prompt-text') as HTMLDivElement;
         this.promptPlayButtonElement = this.promptContainer.querySelector('#prompt-play-button') as HTMLDivElement;
@@ -229,7 +229,7 @@ export class PromptText extends BaseHTML {
 
         if (this.isSpellSoundMatch()) {
             //Add custom style for prompt bubble for Spell Word Audio puzzle.
-            this.promptBubbleImg.classList.add('prompt-bubble-custom');
+            this.promptBubbleImg.classList.add('prompt-bubble-spell-audio');
         }
 
         // Update event listeners to include the callback
@@ -246,7 +246,7 @@ export class PromptText extends BaseHTML {
 
         // Add event listeners to all prompt elements
         this.promptPlayButtonElement.addEventListener('click', handleClick);
-        this.promptBackground.addEventListener('click', handleClick);
+        this.promptContent.addEventListener('click', handleClick);
         this.promptTextElement.addEventListener('click', handleClick);
 
         this.updatePromptFontSize();// Set initial font size


### PR DESCRIPTION
# Changes
- Updated Prompt Bubble rendering by moving it from background-image style of a dive into img html tag.
- Updated the CSS styling to accommodate the new img tag for prompt bubble.

# How to test
- Run FTM app.
- Play any game level and expect prompt bubble should be properly aligned with the audio button or text prompt.

Ref: [FM-597](https://curiouslearning.atlassian.net/browse/FM-597)


[FM-597]: https://curiouslearning.atlassian.net/browse/FM-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ