### PR TITLE
fix: Fixed word tutorial showing way too fast before the stones are in position and fix for click pointer in audio (FM-606).

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -263,7 +263,7 @@
 
 /* For desktops or larger devices above 1080px */
 @media (min-width: 1080px){
-  .prompt-background{
+  .prompt-content{
     width: 50%;
     height: 25%;
     top: 18%;

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -3,7 +3,7 @@ import gameStateService from '@gameStateService';
 
 export default class WordPuzzleTutorial extends TutorialComponent {
   // Animation timing properties
-  private animationDuration = 700; // 700ms animation (faster than original 1000ms)
+  private animationDuration = 1500; // 1.5 second animation same with match letter puzzle
   private stonePositions: number[][] = [];
   private currentStoneIndex = 0;
   // stoneImg is declared in the base class

--- a/src/tutorials/base-tutorial/base-tutorial-component.ts
+++ b/src/tutorials/base-tutorial/base-tutorial-component.ts
@@ -457,7 +457,7 @@ export default class TutorialComponent {
     pointer.className = 'hand-pointer';
     pointer.alt = 'Tutorial hand pointer';
     // Optionally, you can add ARIA attributes or tabIndex for accessibility
-    const target = document.querySelector(targetSelector || '#prompt-background');
+    const target = document.querySelector(targetSelector || '#prompt-content');
     if (target) {
       target.appendChild(pointer);
     }


### PR DESCRIPTION

# Changes
- Updated the animation duration for Word Puzzle Tutorial.
- Updated prompt-background to prompt-content (left over from FM-597).

# How to test
- Run FTM app in English.
- Select game level 4, tutorial pointer should show up hovering the audio button.
- Next select game level 8 for word puzzle, the tutorial word puzzle should only show up after the stones are in position.

Ref: [FM-606](https://curiouslearning.atlassian.net/browse/FM-606)
