### PR TITLE
enhance: Updated css styling and adjusted how spell word audio puzzle is being handled with styling (FM-597)

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -27,21 +27,21 @@
   @media (max-width: 376px) {
     width: 50%;
     height: 26%;
-    top: 18%;
+    top: 19%;
   }
 
   // Large mobile (377-480px)
   @media (min-width: 377px) and (max-width: 480px) {
     width: 50%;
     height: 22%;
-    top: 15%;
+    top: 18%;
   }
 
   // Tablets (481-820px)
   @media (min-width: 481px) and (max-width: 820px) {
     width: 48%;
     height: 22%;
-    top: 20%;
+    top: 25%;
   }
 
   // large tablet (>820px)
@@ -54,7 +54,7 @@
 
 #prompt-bubble {
   position: absolute;
-  transition: transform 0.05s ease;
+  transition: width 0.3s ease, height 0.3s ease, transform 0.05s ease;
 }
 
 //Custom position and size for prompt bubble. Used for Spell Word Audio puzzle.
@@ -64,26 +64,18 @@
   @media (max-width: 376px) {
     width: 300px;
     height: 235px;
-    top: 16%;
   }
 
   // Large mobile (377-480px)
   @media (min-width: 377px) and (max-width: 480px) {
     width: 280px;
     height: 245px;
-    top: 13%;
   }
 
   // Tablets (481 above)
   @media (min-width: 481px) {
     width: 280px;
     height: 300px;
-    top: 18%;
-  }
-
-  // large tablet (>820px)
-  @media (min-width: 821px) {
-    top: 20%;
   }
 
 }
@@ -179,9 +171,9 @@
     gap: 3px;
 
   .slot {
-    min-width: 24px;
+    min-width: 18px;
     height: 28px;
-    font-size: 24px;
+    font-size: 23px;
     text-align: center;
     font-weight: bold;
     font-family: 'Quicksand', sans-serif;

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -228,8 +228,8 @@ export class PromptText extends BaseHTML {
         this.promptSlotElement = this.promptContainer.querySelector('#prompt-slots') as HTMLDivElement;
 
         if (this.isSpellSoundMatch()) {
-            //Add custom style for prompt bubble for Spell Word Audio puzzle.
             this.promptBubbleImg.classList.add('prompt-bubble-spell-audio');
+            this.promptContent.style.marginTop = '35px';
         }
 
         // Update event listeners to include the callback
@@ -281,11 +281,16 @@ export class PromptText extends BaseHTML {
         if (!this.promptSlotElement) return;
 
         this.promptSlotElement.innerHTML = ""; // Clear any previous slots
+        const isLargeWord = this.targetStones.length > 4;
 
         //Create slots based on number of target letters.
         [...this.targetStones].forEach((letter, index) => {
             const slot: any = document.createElement("div");
             slot.classList.add("slot");
+            if (isLargeWord) {
+                slot.style.fontSize = "20px";
+                slot.style.minWidth = "15px";
+            }
 
             //If index of the char is less than the active letter index. It means letter should be revealed.
             if (index < this.currentActiveLetterIndex) {
@@ -459,8 +464,7 @@ export class PromptText extends BaseHTML {
         this.runAfterInitialAudioDelay(
             6000, //6 seconds to sync the rendering when the stone letter drops.
             () => {
-                this.promptSlotElement.style.display = 'flex';
-                this.generatePromptSlots();
+                this.showSpellSlots();
             }
         )
     }
@@ -515,7 +519,7 @@ export class PromptText extends BaseHTML {
      */
     calculateFont(): number {
         const size = this.width * 0.65 / this.currentPromptText.length;
-        return size > 35 || this.currentPromptText.length > 4 ? 25 : size;
+        return size > 35 || this.currentPromptText.length > 5 ? 19 : size;
     }
 
     /**


### PR DESCRIPTION
# Changes
- CSS top styling for prompt-bubble-spell-audio has been removed. prompt-center-responsive top styling has been adjusted.
- Added adding margin logic to prompt-content for spell word puzzle to fix the alignment.
- Added logic for checking the text word to determine the appropriate font size and avoid overlapping from the prompt bubble.

# How to test
- Run FTPM App
- play any game level
- prompt position should be properly aligned and position,

Ref: [FM-597](https://curiouslearning.atlassian.net/browse/FM-597)


[FM-597]: https://curiouslearning.atlassian.net/browse/FM-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ