### PR TITLE
enhance: Update css styling for prompt rending (FM-597)

### DIFF
--- a/src/components/prompt-text/prompt-text.scss
+++ b/src/components/prompt-text/prompt-text.scss
@@ -63,13 +63,29 @@
   // Small mobile (≤376px)
   @media (max-width: 376px) {
     width: 300px;
-    height: 235px;
+    height: 245px;
   }
 
-  // Large mobile (377-480px)
+  // Small mobile (≤376px)
+  @media (max-width: 360px) {
+    width: 300px;
+    height: 245px;
+  }
+
+  // Small mobile (≤376px) with higher heights
+  @media (max-width: 376px) and (min-height: 882px) {
+    top: 21%;
+  }
+
+  // medium mobile (377-480px)
   @media (min-width: 377px) and (max-width: 480px) {
     width: 280px;
-    height: 245px;
+    height: 270px;
+  }
+
+  // medium mobile (377-480px) and height lower than 791px
+  @media (min-width: 377px) and (max-width: 480px) and (max-height:790px) {
+    top: 16%;
   }
 
   // Tablets (481 above)
@@ -78,7 +94,22 @@
     height: 300px;
   }
 
+  // Specific tablets
+  @media (width: 540px) and (height: 720px){
+    top: 21%;
+  }
+
+  // large tablet (>820px)
+  @media (min-width: 821px) {
+    top: 28%;
+  }
+
+  // large tablet (>820px) with height 1000px below.
+  @media (min-width: 821px) and (max-height: 999px) {
+    top: 21%;
+  }
 }
+
 
 @keyframes float {
   0% {
@@ -163,6 +194,10 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 
   .prompt-slots {

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -84,6 +84,7 @@ export class PromptText extends BaseHTML {
     public promptTextElement: HTMLDivElement;
     public promptPlayButtonElement: HTMLDivElement;
     public promptSlotElement: HTMLDivElement;
+    public promptTextButtonContainer: HTMLDivElement;
     private eventManager: EventManager;
 
     private onClickCallback?: () => void;
@@ -226,10 +227,14 @@ export class PromptText extends BaseHTML {
         this.promptTextElement = this.promptContainer.querySelector('#prompt-text') as HTMLDivElement;
         this.promptPlayButtonElement = this.promptContainer.querySelector('#prompt-play-button') as HTMLDivElement;
         this.promptSlotElement = this.promptContainer.querySelector('#prompt-slots') as HTMLDivElement;
+        this.promptTextButtonContainer = this.promptContainer.querySelector('#prompt-text-button-container') as HTMLDivElement;
 
         if (this.isSpellSoundMatch()) {
             this.promptBubbleImg.classList.add('prompt-bubble-spell-audio');
-            this.promptContent.style.marginTop = '35px';
+            /*Only during spell sound match; Set height from 74% to 100% so that
+            prompt-button-slots-wrapper would be properly be centered.
+            */
+            this.promptTextButtonContainer.style.height = '100%';
         }
 
         // Update event listeners to include the callback


### PR DESCRIPTION
# Changes
- Update spell sound audio styling.

# How to test
- Run FTM app
- Play any game level.
- Prompt bubble should always be properly positioned along with its audio button and text content.

Ref: [FM-597](https://curiouslearning.atlassian.net/browse/FM-597)


[FM-597]: https://curiouslearning.atlassian.net/browse/FM-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ