### PR TITLE
AJ-391 - Analytics refactoring

### DIFF
--- a/src/analytics/analytics-event-interface.ts
+++ b/src/analytics/analytics-event-interface.ts
@@ -1,27 +1,31 @@
-interface CommonEventProperties {
+export interface CommonEventProperties {
     cr_user_id: string;
     ftm_language: string;
     profile_number: number;
     version_number: string;
     json_version_number: string;
 }
-export interface SessionStart extends CommonEventProperties{
-    days_since_last:Number;
+
+export interface SessionStart extends CommonEventProperties {
+    days_since_last: Number;
 }
-export interface SessionEnd extends CommonEventProperties{
+
+export interface SessionEnd extends CommonEventProperties {
     duration: number;
 }
 
-export interface DowloadPercentCompleted extends CommonEventProperties{
-    ms_since_session_start:Number;
-   }
-
-export interface TappedStart extends CommonEventProperties{
-   
+export interface DowloadPercentCompleted extends CommonEventProperties {
+    ms_since_session_start: Number;
 }
-export interface SelectedLevel extends CommonEventProperties{
+
+export interface TappedStart extends CommonEventProperties {
+
+}
+
+export interface SelectedLevel extends CommonEventProperties {
     level_selected: number;
 }
+
 export interface PuzzleCompletedEvent extends CommonEventProperties {
     success_or_failure: string;
     level_number: number;
@@ -31,12 +35,13 @@ export interface PuzzleCompletedEvent extends CommonEventProperties {
     foils: string[] | string; // Allow both array and string formats
     response_time: number;
 }
+
 export interface LevelCompletedEvent extends CommonEventProperties {
     success_or_failure: string;
     level_number: number;
     number_of_successful_puzzles: number;
     duration: number;
-}  
+}
 
 export interface levelEndButtonsCLick extends CommonEventProperties {
     buttonType: string;

--- a/src/analytics/analytics-integration.ts
+++ b/src/analytics/analytics-integration.ts
@@ -1,5 +1,6 @@
 import {BaseAnalyticsIntegration} from './base-analytics-integration';
-import {
+import type {
+  CommonEventProperties,
   DowloadPercentCompleted,
   LevelCompletedEvent,
   PuzzleCompletedEvent,
@@ -7,7 +8,40 @@ import {
   SessionEnd,
   SessionStart,
   TappedStart,
+  levelEndButtonsCLick,
 } from './analytics-event-interface';
+import { lang, pseudoId } from '@common';
+
+export const enum AnalyticsEventType {
+  SESSION_START = 'session_start',
+  SESSION_END = 'session_end',
+  PUZZLE_COMPLETED = 'puzzle_completed',
+  LEVEL_COMPLETED = 'level_completed',
+  TAPPED_START = 'tapped_start',
+  SELECTED_LEVEL = 'selected_level',
+  DOWNLOAD_25 = 'download_25',
+  DOWNLOAD_50 = 'download_50',
+  DOWNLOAD_75 = 'download_75',
+  DOWNLOAD_COMPLETED = 'download_completed',
+  LEVEL_END_BUTTON_CLICK = 'level_end_button_click',
+  /** @deprecated Deprecated in favor of tapped_start event. */
+  USER_CLICKED = 'user_clicked'
+}
+
+type EventDataMap = {
+  [AnalyticsEventType.SESSION_START]: SessionStart;
+  [AnalyticsEventType.SESSION_END]: SessionEnd;
+  [AnalyticsEventType.PUZZLE_COMPLETED]: PuzzleCompletedEvent;
+  [AnalyticsEventType.LEVEL_COMPLETED]: LevelCompletedEvent;
+  [AnalyticsEventType.TAPPED_START]: TappedStart;
+  [AnalyticsEventType.SELECTED_LEVEL]: SelectedLevel;
+  [AnalyticsEventType.DOWNLOAD_25]: DowloadPercentCompleted;
+  [AnalyticsEventType.DOWNLOAD_50]: DowloadPercentCompleted;
+  [AnalyticsEventType.DOWNLOAD_75]: DowloadPercentCompleted;
+  [AnalyticsEventType.DOWNLOAD_COMPLETED]: DowloadPercentCompleted;
+  [AnalyticsEventType.LEVEL_END_BUTTON_CLICK]: levelEndButtonsCLick;
+  [AnalyticsEventType.USER_CLICKED]: { click: 'Click' };
+};
 
 /**
  * AnalyitcsIntegration is a singleton class that handles all Analytics analytics.
@@ -33,6 +67,16 @@ export class AnalyticsIntegration extends BaseAnalyticsIntegration {
 
   protected constructor() {
     super();
+  }
+
+  private createBaseEventData(jsonVersionNumber: string): CommonEventProperties {
+    return {
+      cr_user_id: pseudoId,
+      ftm_language: lang,
+      profile_number: 0,
+      version_number: document.getElementById("version-info-id")?.innerHTML || '',
+      json_version_number: jsonVersionNumber,
+    };
   }
 
   /**
@@ -67,61 +111,82 @@ export class AnalyticsIntegration extends BaseAnalyticsIntegration {
     await super.initialize();
   }
 
+  /**
+   * Core method to track all analytics events
+   * @param eventType The type of event to track
+   * @param data The event data
+   */
+  public track<T extends AnalyticsEventType>(
+    eventType: T,
+    eventData: Partial<CommonEventProperties> & { json_version_number: string } & Omit<EventDataMap[T], keyof CommonEventProperties>
+  ): void {
+    const baseData = this.createBaseEventData(eventData.json_version_number);
+    let data = { ...baseData, ...eventData } as EventDataMap[T];
+
+    this.trackCustomEvent(eventType, data);
+  }
+
+  /** @deprecated Use track(AnalyticsEventType.SESSION_START, data) instead */
   public sendSessionStartEvent(data: SessionStart): void {
-    this.trackCustomEvent('session_start', data);
+    this.track(AnalyticsEventType.SESSION_START, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.SESSION_END, data) instead */
   public sendSessionEndEvent(data: SessionEnd): void {
-    this.trackCustomEvent('session_end', data);
+    this.track(AnalyticsEventType.SESSION_END, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.SELECTED_LEVEL, data) instead */
   public sendSelectedLevelEvent(data: SelectedLevel): void {
-    this.trackCustomEvent('selected_level', data);
+    this.track(AnalyticsEventType.SELECTED_LEVEL, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.TAPPED_START, data) instead */
   public sendTappedStartEvent(data: TappedStart): void {
-    this.trackCustomEvent('tapped_start', data);
+    this.track(AnalyticsEventType.TAPPED_START, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.PUZZLE_COMPLETED, data) instead */
   public sendPuzzleCompletedEvent(data: PuzzleCompletedEvent): void {
-    // Create event data
-    const eventData = { ...data };
-    
-    // Ensure foils is a comma-separated string
-    if (Array.isArray(eventData.foils)) {
-        eventData.foils = eventData.foils.join(',');
-    }
-    
-    this.trackCustomEvent('puzzle_completed', eventData);
-}
+    this.track(AnalyticsEventType.PUZZLE_COMPLETED, data);
+  }
 
+  /** @deprecated Use track(AnalyticsEventType.LEVEL_COMPLETED, data) instead */
   public sendLevelCompletedEvent(data: LevelCompletedEvent): void {
-    this.trackCustomEvent('level_completed', data);
+    this.track(AnalyticsEventType.LEVEL_COMPLETED, data);
   }
 
+  /** @deprecated This event type is deprecated. Consider using other tracking methods */
   public sendUserClickedOnPlayEvent(): void {
-    this.trackCustomEvent('user_clicked', {click: 'Click'});
+    this.track(AnalyticsEventType.USER_CLICKED, { 
+      json_version_number: '',
+      click: 'Click' 
+    });
   }
 
+  /** @deprecated Use track(AnalyticsEventType.DOWNLOAD_COMPLETED, data) instead */
   public sendDownloadCompletedEvent(data: DowloadPercentCompleted): void {
-    this.trackCustomEvent('download_completed', data);
+    this.track(AnalyticsEventType.DOWNLOAD_COMPLETED, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.DOWNLOAD_25, data) instead */
   public sendDownload25PercentCompletedEvent(
     data: DowloadPercentCompleted,
   ): void {
-    this.trackCustomEvent('download_25', data);
+    this.track(AnalyticsEventType.DOWNLOAD_25, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.DOWNLOAD_50, data) instead */
   public sendDownload50PercentCompletedEvent(
     data: DowloadPercentCompleted,
   ): void {
-    this.trackCustomEvent('download_50', data);
+    this.track(AnalyticsEventType.DOWNLOAD_50, data);
   }
 
+  /** @deprecated Use track(AnalyticsEventType.DOWNLOAD_75, data) instead */
   public sendDownload75PercentCompletedEvent(
     data: DowloadPercentCompleted,
   ): void {
-    this.trackCustomEvent('download_75', data);
+    this.track(AnalyticsEventType.DOWNLOAD_75, data);
   }
 }

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -3,7 +3,7 @@ import { getData, DataModal, customFonts } from "@data";
 import { SceneHandler } from "@sceneHandler/scene-handler";
 import { AUDIO_URL_PRELOAD, IsCached, PreviousPlayedLevel } from "@constants";
 import { Workbox } from "workbox-window";
-import { AnalyticsIntegration } from "./analytics/analytics-integration";
+import { AnalyticsIntegration, AnalyticsEventType } from "./Analytics/analytics-integration";
 import {
   Utils,
   VISIBILITY_CHANGE,
@@ -126,30 +126,23 @@ class App {
     });
   }
   private logDownloadPercentageComplete(percentage: number, timeDifferenceFromSessonStart: number) {
-    const downloadCompleteData = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: this.versionInfoElement.innerHTML,
+    const eventData = {
       json_version_number: this.getJsonVersionNumber(),
       ms_since_session_start: timeDifferenceFromSessonStart,
     };
 
-    switch (percentage) {
-      case 25:
-        this.analyticsIntegration.sendDownload25PercentCompletedEvent(downloadCompleteData);
-        break;
-      case 50:
-        this.analyticsIntegration.sendDownload50PercentCompletedEvent(downloadCompleteData);
-        break;
-      case 75:
-        this.analyticsIntegration.sendDownload75PercentCompletedEvent(downloadCompleteData);
-        break;
-      case 100:
-        this.analyticsIntegration.sendDownloadCompletedEvent(downloadCompleteData);
-        break;
-      default:
-        console.warn(`Unsupported progress percentage: ${percentage}`);
+    const eventMap = {
+      25: AnalyticsEventType.DOWNLOAD_25,
+      50: AnalyticsEventType.DOWNLOAD_50,
+      75: AnalyticsEventType.DOWNLOAD_75,
+      100: AnalyticsEventType.DOWNLOAD_COMPLETED,
+    };
+
+    const eventType = eventMap[percentage];
+    if (eventType) {
+      this.analyticsIntegration.track(eventType, eventData);
+    } else {
+      console.warn(`Unsupported progress percentage: ${percentage}`);
     }
     if ((percentage === 25 && this.logged25) ||
       (percentage === 50 && this.logged50) ||
@@ -169,34 +162,25 @@ class App {
     }
     const daysSinceLast = lastTime ? lastTime / (1000 * 60 * 60 * 24) : 0;
     const roundedDaysSinceLast = parseFloat(daysSinceLast.toFixed(3));
-    const sessionStartData: SessionStart = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: this.versionInfoElement.innerHTML,
-      json_version_number:
-        !!this.majVersion && !!this.minVersion
-          ? this.majVersion.toString() + "." + this.minVersion.toString()
-          : "",
-      days_since_last: roundedDaysSinceLast,
-    };
-    this.analyticsIntegration.sendSessionStartEvent(sessionStartData);
+    
+    this.analyticsIntegration.track(
+      AnalyticsEventType.SESSION_START,
+      {
+        json_version_number: this.getJsonVersionNumber(),
+        days_since_last: roundedDaysSinceLast,
+      }
+    );
   }
 
   private logSessionEndFirebaseEvent() {
-    const sessionEndData: SessionEnd = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: this.versionInfoElement.innerHTML,
-      json_version_number:
-        !!this.majVersion && !!this.minVersion
-          ? this.majVersion.toString() + "." + this.minVersion.toString()
-          : "",
-      duration: (new Date().getTime() - this.startSessionTime) / 1000,
-    };
+    this.analyticsIntegration.track(
+      AnalyticsEventType.SESSION_END,
+      {
+        json_version_number: this.getJsonVersionNumber(),
+        duration: (new Date().getTime() - this.startSessionTime) / 1000,
+      }
+    );
     localStorage.setItem("lastSessionEndTime", new Date().getTime().toString());
-    this.analyticsIntegration.sendSessionEndEvent(sessionEndData);
   }
 
   private initializeCachedData(): Map<string, boolean> {

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -3,7 +3,7 @@ import { getData, DataModal, customFonts } from "@data";
 import { SceneHandler } from "@sceneHandler/scene-handler";
 import { AUDIO_URL_PRELOAD, IsCached, PreviousPlayedLevel } from "@constants";
 import { Workbox } from "workbox-window";
-import { AnalyticsIntegration, AnalyticsEventType } from "./Analytics/analytics-integration";
+import { AnalyticsIntegration, AnalyticsEventType } from "./analytics/analytics-integration";
 import {
   Utils,
   VISIBILITY_CHANGE,

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -32,8 +32,8 @@ import { GameScore, DataModal } from "@data";
 import {
   LevelCompletedEvent,
   PuzzleCompletedEvent,
-} from "../../Analytics/analytics-event-interface";
-import { AnalyticsIntegration, AnalyticsEventType } from "../../Analytics/analytics-integration";
+} from "../../analytics/analytics-event-interface";
+import { AnalyticsIntegration, AnalyticsEventType } from "../../analytics/analytics-integration";
 import {
   SCENE_NAME_LEVEL_SELECT,
   SCENE_NAME_GAME_PLAY,

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -32,8 +32,8 @@ import { GameScore, DataModal } from "@data";
 import {
   LevelCompletedEvent,
   PuzzleCompletedEvent,
-} from "../../analytics/analytics-event-interface";
-import { AnalyticsIntegration } from "../../analytics/analytics-integration";
+} from "../../Analytics/analytics-event-interface";
+import { AnalyticsIntegration, AnalyticsEventType } from "../../Analytics/analytics-integration";
 import {
   SCENE_NAME_LEVEL_SELECT,
   SCENE_NAME_GAME_PLAY,
@@ -905,48 +905,41 @@ export class GameplayScene {
   }
 
   public logPuzzleEndFirebaseEvent(isCorrect: boolean, puzzleType?: string) {
-    let endTime = Date.now();
+    const endTime = Date.now();
     const droppedLetters = this.puzzleHandler.getWordPuzzleDroppedLetters();
-    const puzzleCompletedData: PuzzleCompletedEvent = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: document.getElementById("version-info-id").innerHTML,
-      json_version_number: this.jsonVersionNumber,
-      success_or_failure: isCorrect ? "success" : "failure",
-      level_number: this.levelData.levelMeta.levelNumber,
-      puzzle_number: this.counter,
-      item_selected:
-        puzzleType == "Word"
-          ? droppedLetters == null ||
-            droppedLetters == undefined
-            ? "TIMEOUT"
-            : droppedLetters
-          : this.pickedStone == null || this.pickedStone == undefined
-            ? "TIMEOUT"
-            : this.pickedStone?.text,
-      target: this.stoneHandler.getCorrectTargetStone(),
-      foils: this.stoneHandler.getFoilStones(),
-      response_time: (endTime - this.puzzleTime) / 1000,
-    };
-    this.analyticsIntegration.sendPuzzleCompletedEvent(puzzleCompletedData);
+    
+    this.analyticsIntegration.track(
+      AnalyticsEventType.PUZZLE_COMPLETED,
+      {
+        json_version_number: this.jsonVersionNumber,
+        success_or_failure: isCorrect ? "success" : "failure",
+        level_number: this.levelData.levelMeta.levelNumber,
+        puzzle_number: this.counter,
+        item_selected: puzzleType === "Word"
+          ? (droppedLetters ?? "TIMEOUT")
+          : (this.pickedStone?.text ?? "TIMEOUT"),
+        target: this.stoneHandler.getCorrectTargetStone(),
+        foils: Array.isArray(this.stoneHandler.getFoilStones()) 
+          ? this.stoneHandler.getFoilStones().join(',')
+          : this.stoneHandler.getFoilStones(),
+        response_time: (endTime - this.puzzleTime) / 1000,
+      }
+    );
   }
 
   public logLevelEndFirebaseEvent() {
-    let endTime = Date.now();
-    const levelCompletedData: LevelCompletedEvent = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: document.getElementById("version-info-id").innerHTML,
-      json_version_number: this.jsonVersionNumber,
-      success_or_failure:
-        GameScore.calculateStarCount(this.score) >= 3 ? "success" : "failure",
-      number_of_successful_puzzles: this.score / 100,
-      level_number: this.levelData.levelMeta.levelNumber,
-      duration: (endTime - this.startTime) / 1000,
-    };
-    this.analyticsIntegration.sendLevelCompletedEvent(levelCompletedData);
+    const endTime = Date.now();
+    
+    this.analyticsIntegration.track(
+      AnalyticsEventType.LEVEL_COMPLETED,
+      {
+        json_version_number: this.jsonVersionNumber,
+        success_or_failure: GameScore.calculateStarCount(this.score) >= 3 ? "success" : "failure",
+        number_of_successful_puzzles: this.score / 100,
+        level_number: this.levelData.levelMeta.levelNumber,
+        duration: (endTime - this.startTime) / 1000,
+      }
+    );
   }
 
   public startGameTime() {

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -6,8 +6,7 @@ import {
 } from "@common";
 import { AudioPlayer } from "@components";
 import { getData, GameScore } from "@data";
-import { SelectedLevel } from "../analytics/analytics-event-interface";
-import { AnalyticsIntegration } from "../analytics/analytics-integration";
+import { AnalyticsIntegration, AnalyticsEventType } from "../Analytics/analytics-integration";
 import {
   createBackground,
   levelSelectBgDrawing,
@@ -398,18 +397,15 @@ export class LevelSelectionScreen {
     gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_GAME_PLAY);
   }
   public logSelectedLevelEvent() {
-    const selectedLeveltData: SelectedLevel = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: document.getElementById("version-info-id").innerHTML,
-      json_version_number:
-        !!this.majVersion && !!this.minVersion
-          ? this.majVersion.toString() + "." + this.minVersion.toString()
+    this.analyticsIntegration.track(
+      AnalyticsEventType.SELECTED_LEVEL,
+      {
+        json_version_number: !!this.majVersion && !!this.minVersion
+          ? `${this.majVersion}.${this.minVersion}`
           : "",
-      level_selected: this.levelNumber,
-    };
-    this.analyticsIntegration.sendSelectedLevelEvent(selectedLeveltData);
+        level_selected: this.levelNumber,
+      }
+    );
   }
   public draw() {
     if (this.imagesLoaded) {

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -6,7 +6,7 @@ import {
 } from "@common";
 import { AudioPlayer } from "@components";
 import { getData, GameScore } from "@data";
-import { AnalyticsIntegration, AnalyticsEventType } from "../Analytics/analytics-integration";
+import { AnalyticsIntegration, AnalyticsEventType } from "../analytics/analytics-integration";
 import {
   createBackground,
   levelSelectBgDrawing,
@@ -406,6 +406,7 @@ export class LevelSelectionScreen {
         level_selected: this.levelNumber,
       }
     );
+    this.analyticsIntegration.track(AnalyticsEventType.LEVEL_END_BUTTON_CLICK
   }
   public draw() {
     if (this.imagesLoaded) {

--- a/src/scenes/level-selection-scene.ts
+++ b/src/scenes/level-selection-scene.ts
@@ -406,7 +406,6 @@ export class LevelSelectionScreen {
         level_selected: this.levelNumber,
       }
     );
-    this.analyticsIntegration.track(AnalyticsEventType.LEVEL_END_BUTTON_CLICK
   }
   public draw() {
     if (this.imagesLoaded) {

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -10,7 +10,7 @@ import {
   pseudoId,
   lang
 } from "@common";
-import { AnalyticsIntegration, AnalyticsEventType } from "../../Analytics/analytics-integration";
+import { AnalyticsIntegration, AnalyticsEventType } from "../../analytics/analytics-integration";
 import {
   SCENE_NAME_LEVEL_SELECT,
   FirebaseUserClicked,

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -10,8 +10,7 @@ import {
   pseudoId,
   lang
 } from "@common";
-import { AnalyticsIntegration } from "../../analytics/analytics-integration";
-import { TappedStart } from "../../analytics/analytics-event-interface";
+import { AnalyticsIntegration, AnalyticsEventType } from "../../Analytics/analytics-integration";
 import {
   SCENE_NAME_LEVEL_SELECT,
   FirebaseUserClicked,
@@ -188,7 +187,15 @@ export class StartScene {
 
   handleMouseClick = (event) => {
     event.preventDefault();
-    AnalyticsIntegration.getInstance().sendUserClickedOnPlayEvent();
+    AnalyticsIntegration.getInstance().track(
+      AnalyticsEventType.USER_CLICKED, 
+      { 
+        json_version_number: !!this.data.majVersion && !!this.data.minVersion 
+          ? `${this.data.majVersion}.${this.data.minVersion}` 
+          : "",
+        click: 'Click' 
+      }
+    );
     // @ts-ignore
     fbq("trackCustom", FirebaseUserClicked, {
       event: "click",
@@ -223,13 +230,15 @@ export class StartScene {
   };
 
   private logTappedStartFirebaseEvent() {
-    const tappedStartData: TappedStart = {
-      cr_user_id: pseudoId,
-      ftm_language: lang,
-      profile_number: 0,
-      version_number: document.getElementById("version-info-id").innerHTML,
-      json_version_number: !!this.data.majVersion && !!this.data.minVersion ? this.data.majVersion.toString() + "." + this.data.minVersion.toString() : "",
-    };
-    this.analyticsIntegration.sendTappedStartEvent(tappedStartData);
+    const jsonVersionNumber = !!this.data.majVersion && !!this.data.minVersion 
+      ? `${this.data.majVersion}.${this.data.minVersion}` 
+      : "";
+
+    this.analyticsIntegration.track(
+      AnalyticsEventType.TAPPED_START,
+      {
+        json_version_number: jsonVersionNumber,
+      }
+    );
   }
 }


### PR DESCRIPTION
# Changes
- Refactored analytics integration down to just one track method and factory event object creation which simplifies the object creation for the analytics event submissions and the actual sending part of it too

# How to test
- Got the data from BigQuery for both Prod and local dev builds of FTM and wrote a comparison script that showed no data alterations per each event, everything is functional
- Can be tested similarly, on both PROD and local builds from the AJ-391 branch, just play through couple of levels and watch the analytics data appear in BigQuery for your cr_user_id that you provide

Ref: [AJ-391](https://curiouslearning.atlassian.net/browse/AJ-391)
