### PR TITLE
feat: Trigger treasure chest mini game mechanics implementation (FM-594)

### DIFF
--- a/src/data/game-score.ts
+++ b/src/data/game-score.ts
@@ -3,25 +3,32 @@ import { Debugger, lang } from "@common";
 export class GameScore {
   public static currentlanguage: string = lang;
 
-  public static setGameLevelScore(currentLevelInfo, score) {
+  public static setGameLevelScore(currentLevelInfo, score, treasureChestMiniGameScore) {
     let starsGained = this.calculateStarCount(score);
     let levelPlayedInfo = {
       levelName: currentLevelInfo.levelMeta.levelType,
       levelNumber: currentLevelInfo.levelMeta.levelNumber,
       score: score,
       starCount: starsGained,
+      treasureChestMiniGameScore,
     };
     let allGameLevelInfo = this.getAllGameLevelInfo();
     let index = allGameLevelInfo.findIndex(
       (level) => level.levelNumber === levelPlayedInfo.levelNumber
     );
 
+    //If there are data found in local storage, cross check the scores.
     if (index !== -1) {
-      // Update only if the new score is higher
-      if (levelPlayedInfo.score > allGameLevelInfo[index].score) {
+      //Check if the new scores are higher.
+      const isNewScoreHigher = score > allGameLevelInfo[index].score;
+      const isNewMiniGameScoreHigher = treasureChestMiniGameScore > allGameLevelInfo[index].treasureChestMiniGameScore;
+
+      // Update only if the new score is higher either from mini game or actual game score.
+      if (isNewScoreHigher || isNewMiniGameScoreHigher) {
         allGameLevelInfo[index] = levelPlayedInfo;
       }
     } else {
+      // If the game level is newly cleared.
       allGameLevelInfo.push(levelPlayedInfo);
     }
 

--- a/src/miniGame/miniGameStateService/miniGameStateService.ts
+++ b/src/miniGame/miniGameStateService/miniGameStateService.ts
@@ -1,9 +1,15 @@
 import { PubSub } from '../../events/pub-sub-events';
+import { GameScore } from "@data";
 
+type MiniGameMap = {
+  [key: number]: { isMiniGameComplete: boolean };
+};
 export class MiniGameStateService extends PubSub {
   public EVENTS: {
     IS_MINI_GAME_DONE: string;
   }
+
+  private treasureChestCompletedLevel: MiniGameMap;
 
   constructor() {
     super();
@@ -11,16 +17,81 @@ export class MiniGameStateService extends PubSub {
       IS_MINI_GAME_DONE: 'IS_MINI_GAME_DONE'
     };
     //Add states here needed for mini games
-
+    this.treasureChestCompletedLevel = {};
     this.initListeners();
+    this.initMiniGameLevelList();
   }
 
   private initListeners() {
     /* Listeners to update mini game state values or trigger certain logics. */
+    this.subscribe(this.EVENTS.IS_MINI_GAME_DONE, ({ miniGameScore, gameLevel }: {
+      miniGameScore: number,
+      gameLevel: number,
+    }) => {
+      //Plus one to match the expected level as game level starts at 0 whereas business logic starts at 1.
+      const adjustGameLevelValue = gameLevel + 1;
+      //Update treasure chest completed level list; Set to 'true for completion if star score is 1.
+      this.treasureChestCompletedLevel[adjustGameLevelValue].isMiniGameComplete = miniGameScore === 1;
+    });
   }
 
-  selectLevelAtRandom(levelSegmentLength: number) {
+  //Creates levels of completed list of treasure chest minigame.
+  private initMiniGameLevelList() {
+    const completedLevel: MiniGameMap = {
+      2: { isMiniGameComplete: false }, //starting level for mini game as per FM-594; not a special level.
+    }
+    let startingSpecialLevel = 5;
+
+    while (startingSpecialLevel < 200) {
+      completedLevel[startingSpecialLevel] = { isMiniGameComplete: false }; //Set false by default
+      startingSpecialLevel += 10;
+    }
+
+    //Get saved game level information from local storage.
+    const gameLevelsInfo = GameScore.getAllGameLevelInfo();
+
+    //If there are saved data found, update the completedLevel to reflect the data saved form local storage.
+    if (gameLevelsInfo.length) {
+      //Update values of each levels in completedLevel based on what is saved in local storage.
+      //A separate array is required as GameScore array doesn save in sequence things in sequences so inaccurate to relay on index.
+      gameLevelsInfo.forEach((gameLevelResult: {
+        levelName: string;
+        levelNumber: number;
+        score: number;
+        starCount: number;
+        treasureChestMiniGameScore: number;
+      }) => {
+        const levelNumber = gameLevelResult.levelNumber + 1;
+        //If treasureChestMiniGameScore is one, level is complete with mini game treasure chest.
+        if (completedLevel[levelNumber]) {
+          completedLevel[levelNumber] = {
+            isMiniGameComplete: gameLevelResult?.treasureChestMiniGameScore === 1 // 1 is the expected star count for a completed treasure chest mini game.
+          };
+        }
+      });
+    }
+    //Assigned the completed level list to state treasureChestCompletedLevel.
+    this.treasureChestCompletedLevel = completedLevel;
+  }
+
+  private selectLevelAtRandom(levelSegmentLength: number) {
     return Math.floor(Math.random() * levelSegmentLength) + 1;
   }
-}
 
+  public shouldShowMiniGame({
+    gameLevel, levelSegmentLength
+  }: {
+    gameLevel: number, levelSegmentLength: number
+  }) {
+    //Plus one to match the expected level as game level starts at 0 whereas business logic starts at 1.
+    const adjustGameLevelValue = gameLevel + 1;
+
+    //Check if game level is completed or if the game level on the treasue chest list.
+    const treasureChestMiniGameLevel = this.treasureChestCompletedLevel[adjustGameLevelValue];
+
+    return treasureChestMiniGameLevel && !treasureChestMiniGameLevel?.isMiniGameComplete
+      ? this.selectLevelAtRandom(levelSegmentLength)
+      : 0; //Returns 0 to not show any treasure chest minigame.
+  }
+
+}

--- a/src/miniGame/miniGames/miniGameHandler.ts
+++ b/src/miniGame/miniGames/miniGameHandler.ts
@@ -24,9 +24,11 @@ import { TreasureChestMiniGame } from './treasureChest/treasureChestMiniGame';
  */
 export class MiniGameHandler {
   public activeMiniGame: TreasureChestMiniGame | null; //Any for now as default.
+  public gameLevel: number;
 
-  constructor() {
+  constructor(gameLevel: number) {
     this.activeMiniGame = null;
+    this.gameLevel = gameLevel;
     this.createMiniGameInstance();
   }
 
@@ -46,7 +48,9 @@ export class MiniGameHandler {
     //Since we only have one mini game instance we will just assigned treasure chest mini game.
     //Update and add logic here to handle loading of different mini game.
 
-    this.activeMiniGame = new TreasureChestMiniGame(this.handleMiniGameComplete);
+    this.activeMiniGame = new TreasureChestMiniGame((earnedStarCount: number) => {
+      this.handleMiniGameComplete(earnedStarCount);
+    });
   }
 
   /**
@@ -71,8 +75,11 @@ export class MiniGameHandler {
     // ADD logic here relating to star count.
     // For example relating to game score to reflext the correct star count for monster evolution with GameScore @data class.
 
-    //Communicate to GamePlay-Scene that the mini game is done to trigger the load puzzle method.
-    miniGameStateService.publish(miniGameStateService.EVENTS.IS_MINI_GAME_DONE, true);
+    //Communicate to MiniGameStateService and GamePlay-Scene that the mini game is done to trigger the load puzzle method.
+    miniGameStateService.publish(miniGameStateService.EVENTS.IS_MINI_GAME_DONE, {
+      miniGameScore: earnedStarCount,
+      gameLevel: this.gameLevel
+    });
   }
 
   /**

--- a/src/miniGame/miniGames/treasureChest/treasureChestMiniGame.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChestMiniGame.ts
@@ -13,7 +13,7 @@ export class TreasureChestMiniGame {
   private callback: any;
   public miniGameStatus: boolean = false;
   private treasureAnimation: TreasureChestAnimation;
-  private clickedCount = 0;
+
   constructor(miniGameCompleteCallback) {
     this.earnedStarCount = 0;
     this.collectedStones = 0;
@@ -26,27 +26,18 @@ export class TreasureChestMiniGame {
   }
 
   public tapStoneCallback() {
-    this.clickedCount++;
-    // this.updateCollectedStone();
-    // this.processStoneCollection();
-  }
-
-  private updateCollectedStone() {
     this.collectedStones++;
   }
 
   private processStoneCollection() {
-    if (this.collectedStones >= 3) {
-      this.earnedStarCount = 1;
+    //Convert collection stones from tapping into a star value; Max of 1 star.
+    this.earnedStarCount = this.collectedStones >= 3 ? 1 : 0;
 
-      //Add more logic here relating to animation or anything tied after collecting 1 star.
+    //Set miniGameStatus to TRUE for minigame handler. Draw will be disabled.
+    this.miniGameStatus = true;
 
-      //Set miniGameStatus to TRUE for minigame handler. Draw will be disabled.
-      this.miniGameStatus = true;
-
-      //Trigger callback from parent miniGameHandler when the treasure chest mini game is complete.
-      this.callback(this.earnedStarCount);
-    }
+    //Trigger callback from parent miniGameHandler when the treasure chest mini game is complete.
+    this.callback(this.earnedStarCount);
   }
 
   //Draw logic for treasure chest minigame. Called by mini game handler.
@@ -57,11 +48,8 @@ export class TreasureChestMiniGame {
         // Animation complete callback
         console.log("Treasure Chest Animation Completed");
 
-        
-      // If player didn't collect enough stones, still call parent
-      if (!this.miniGameStatus) {
-        this.callback(this.earnedStarCount);
-      }
+        //Convert collectedStones into a star after the treasure chest animation.
+        this.processStoneCollection();
       });
     }
 

--- a/src/scenes/gameplay-scene/gameplay-scene.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.spec.ts
@@ -309,7 +309,7 @@ jest.mock('@miniGameStateService', () => ({
     EVENTS: {
       IS_MINI_GAME_DONE: 'IS_MINI_GAME_DONE',
     },
-    selectLevelAtRandom: jest.fn(),
+    shouldShowMiniGame: jest.fn(),
   }
 }));
 


### PR DESCRIPTION
# Changes
- Created logic that determines the list of game levels to where mini game would show up.
- Updated logic in triggering mini games by adding the level checking from the list of game levels for mini game along side with randomizer for game level, level segments. Now checks if mini game is cleared.
- Updated Game Score logic to save mini game score.
- Code clean up and updated test case.

# How to test
- Run FTM app.
- On game levels 2, 5, 15, 25.. the mini game should trigger.
- Mini game will appear randomly within the game level segment.
- Scores should be visible in the local app storage.

Ref: [FM-594](https://curiouslearning.atlassian.net/browse/FM-594)
