### PR TITLE
optimized: Separated chest and stone animation from treasure chest mini game (FM-683)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -126,6 +126,7 @@ export const POPUP_BG_IMG = "./assets/images/popup_bg_v01.svg";
 export const CLOSED_CHEST = "./assets/images/closedchest.svg";
 export const OPEN_CHEST = "./assets/images/chest.svg";  
 export const STONE_BLUE = "./assets/images/stone_blue.svg";
+export const BURN_EFFECT_IMG = (ctr) => `./assets/images/stone_burn_export_${ctr}.png`
 
 
 //Background Group Images

--- a/src/miniGame/miniGames/treasureChest/treasure-stones.ts
+++ b/src/miniGame/miniGames/treasureChest/treasure-stones.ts
@@ -1,0 +1,219 @@
+import { STONE_BLUE, BURN_EFFECT_IMG } from '@constants';
+
+/**
+ * Type definition for a stone object that can be spawned,
+ * animated, clicked, and destroyed.
+ */
+type Stone = {
+  x: number; // Current X position
+  y: number; // Current Y position
+  radius: number; // Collision radius
+  dx: number; // Horizontal velocity
+  dy: number; // Vertical velocity
+  opacity: number; // Transparency for fade-out effect
+  active: boolean; // Whether the stone is still active/visible
+  lifetime: number; // Remaining lifetime in frames/ticks
+  img: HTMLImageElement; // Sprite image for the stone
+  size: number; // Rendered size
+  burning?: boolean; // Whether the stone is in burning state
+  burnStartTime?: number; // Timestamp when burning started
+  burnFrameIndex?: number; // Current burn frame index
+};
+
+/**
+ * TreasureStones manages the spawning, animation, interaction,
+ * and burning effect of collectible stones that burst out of the chest.
+ */
+export default class TreasureStones {
+  private stoneImg: HTMLImageElement; // Base stone image (blue stone)
+  private stones: Stone[] = []; // Collection of active stones
+  private burnImg: HTMLImageElement; // Placeholder for burn effect image
+  private burnFrames: HTMLImageElement[] = []; // Preloaded burn animation frames
+  private ctx: CanvasRenderingContext2D; // Canvas rendering context
+
+  /**
+   * @param ctx - Canvas rendering context for drawing stones
+   */
+  constructor(ctx: CanvasRenderingContext2D) {
+    this.ctx = ctx;
+    this.stones = [];
+    this.stoneImg = new Image();
+    this.stoneImg.src = STONE_BLUE; // Default blue stone sprite
+    this.burnImg = new Image();
+
+    // Preload burn animation frames (4-frame sprite)
+    for (let i = 1; i <= 4; i++) {
+      const burnImg = new Image();
+      burnImg.src = BURN_EFFECT_IMG(i);
+      this.burnFrames.push(burnImg);
+    }
+  }
+
+  /**
+   * Updates stone state and renders them on canvas.
+   * Should be called each frame during animation loop.
+   * @param width - Canvas width
+   * @param height - Canvas height
+   */
+  public stoneBurstAnimation(width: number, height: number): void {
+    this.updateStones(width);
+    this.cleanupStones();
+    this.maintainStones(width, height);
+  }
+
+  /**
+   * Ensures a minimum number of stones are present on screen.
+   * Randomly chooses a target between 6 and 12 stones.
+   */
+  private maintainStones(width: number, height: number) {
+    const maxStones = Math.floor(Math.random() * (12 - 6 + 1)) + 6;
+    while (this.stones.length < maxStones) {
+      console.log('maintainStones treasure')
+      this.stones.push(this.spawnStone(width, height));
+    }
+  }
+
+  /**
+   * Spawns a new stone near the chest and gives it randomized velocity/size.
+   * @param width - Canvas width
+   * @param height - Canvas height
+   */
+  private spawnStone(width: number, height: number): Stone {
+    const chestX = width / 2 - 40;
+    const chestY = height - 200;
+
+    const radius = 8 + Math.random() * 6;
+    const baseAngle = Math.PI / 2;
+    const spread = (Math.random() - 0.5) * (Math.PI / 3);
+    let angle = baseAngle + spread;
+
+    // Clamp angle to shoot upward
+    if (angle < Math.PI / 2) {
+      angle = baseAngle - Math.abs(spread);
+    } else {
+      angle = baseAngle + Math.abs(spread);
+    }
+
+    const speed = 2 + Math.random() * 2;  // Randomized speed
+
+    const stone: Stone = {
+      x: chestX + 50,
+      y: chestY + 50,
+      radius,
+      dx: Math.cos(angle) * speed,
+      dy: -Math.sin(angle) * speed,
+      opacity: 1,
+      active: true,
+      lifetime: 300, // ~5s lifetime if 60fps
+      img: this.stoneImg,
+      size: 100,
+    };
+
+    return stone;
+  }
+
+  /**
+   * Removes inactive stones from the list.
+   */
+  private cleanupStones(): void {
+    this.stones = this.stones.filter(stone => stone.active);
+  }
+
+  /**
+   * Updates movement and burning state for each stone.
+   * Also renders stones to the canvas.
+   * @param width - Canvas width
+   */
+  private updateStones(width: number): void {
+    for (const stone of this.stones) {
+      if (!stone.active) continue;
+      stone.burning ? this.updateBurningStone(stone) : this.updateMovingStone(stone, width);
+      this.drawStone(stone);
+    }
+  }
+
+  /**
+   * Handles click interactions with stones.
+   * If a stone is clicked, it enters burning state.
+   * @param x - Mouse click X coordinate
+   * @param y - Mouse click Y coordinate
+   * @returns true if a stone was clicked and triggered
+   */
+  public onClickEvent(x: number, y: number): boolean {
+    for (const stone of this.stones) {
+      if (!stone.active) continue;
+
+      // Check if click is inside stone bounds
+      const dx = x - stone.x;
+      const dy = y - stone.y;
+      if (Math.sqrt(dx * dx + dy * dy) <= stone.size / 2) {
+        // Freeze stone when clicked
+        stone.dx = 0;
+        stone.dy = 0;
+        if (stone.burning || !stone.active) {
+          continue;
+        }
+        // Trigger burn sequence
+        stone.burning = true;
+        stone.burnStartTime = performance.now();
+        stone.burnFrameIndex = 0;
+
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Updates a burning stone by cycling through burn animation frames.
+   * Marks the stone inactive once the animation finishes.
+   */
+  private updateBurningStone(stone: Stone): void {
+    const elapsed = performance.now() - (stone.burnStartTime || 0);
+    stone.burnFrameIndex = Math.floor(elapsed / 75);
+    if (stone.burnFrameIndex >= this.burnFrames.length) stone.active = false;
+  }
+
+  /**
+   * Updates position, lifetime, and opacity of a moving stone.
+   * Marks stone inactive when it goes out of bounds or expires.
+   */
+  private updateMovingStone(stone: Stone, width: number): void {
+    stone.x += stone.dx;
+    stone.y += stone.dy;
+    stone.lifetime--;
+
+    // Gradually fade out near the end of lifetime
+    if (stone.lifetime < 60) stone.opacity -= 0.002;
+
+    // Deactivate if out of bounds or expired
+    if (
+        stone.lifetime <= 0 ||
+        stone.y < 0 ||
+        stone.x < -stone.size ||
+        stone.x > width + stone.size
+      ) {
+      stone.active = false;
+    }
+  }
+
+  /**
+   * Draws a stone and its burn animation (if burning).
+   */
+  private drawStone(stone: Stone): void {
+    if (!stone.active) return;
+    this.ctx.globalAlpha = stone.opacity;
+    this.ctx.drawImage(stone.img, stone.x - stone.size / 2, stone.y - stone.size / 2, stone.size, stone.size);
+    this.ctx.globalAlpha = 1.0;
+
+    // Draw burn effect overlay if in burning state
+    if (stone.burning && stone.burnFrameIndex! < this.burnFrames.length) {
+      this.ctx.drawImage(
+        this.burnFrames[stone.burnFrameIndex!],
+        stone.x - stone.size / 2,
+        stone.y - stone.size / 2,
+        stone.size,
+        stone.size
+      );
+    }
+  }
+}

--- a/src/miniGame/miniGames/treasureChest/treasureChest.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChest.ts
@@ -1,0 +1,95 @@
+import { CLOSED_CHEST, OPEN_CHEST } from '@constants';
+
+/**
+ * TreasureChest class handles rendering of the closed and open chest
+ * images along with basic animations such as shaking and pulsing.
+ */
+export default class TreasureChest {
+  private closedChestImg: HTMLImageElement; // Image for closed chest state
+  private openChestImg: HTMLImageElement; // Image for open chest state
+  private ctx: CanvasRenderingContext2D; // Canvas context used for drawing
+  private lastSpawnTime: number; // Timestamp of the last chest spawn
+  private shakeDuration: number = 1000; // 1s; Default seconds of shaking animation.
+
+  /**
+   * @param ctx - Canvas rendering context to draw the chest
+   * @param lastSpawnTime - The time when the chest was spawned (used for animations)
+   */
+  constructor(ctx: CanvasRenderingContext2D, lastSpawnTime: number) {
+    this.ctx = ctx;
+    this.lastSpawnTime = lastSpawnTime;
+    // Load chest images
+    this.closedChestImg = new Image();
+    this.closedChestImg.src = CLOSED_CHEST; // Path to closed chest asset
+
+    this.openChestImg = new Image();
+    this.openChestImg.src = OPEN_CHEST; // Path to open chest asset
+  }
+
+  /**
+  * Draws the closed chest with animations (scale, rotation, shaking)
+  * @param time - Current timestamp
+  * @param stateStartTime - Timestamp when chest entered "closed" state
+  * @param width - Canvas width
+  * @param height - Canvas height
+  */
+  public drawClosedChest(
+    time: number,
+    stateStartTime: number,
+    width: number,
+    height: number,
+  ): void {
+    const chestW = 250, chestH = 230;
+    const chestX = width / 2 - chestW / 2;
+    const chestY = height - chestH - 20;
+
+    // Pulse/rotate chest if just spawned (< 1s old)
+    const elapsed = time - this.lastSpawnTime;
+    let scale = 1;
+    let rotation = 0;
+    if (elapsed < 1000) {
+      scale = 1 + Math.sin((elapsed / 1000) * Math.PI * 4) * 0.05;
+      rotation = Math.sin((elapsed / 1000) * Math.PI * 6) * 0.1;
+    }
+
+    this.ctx.save();
+    this.ctx.translate(chestX + chestW / 2, chestY + chestH / 2);
+    this.ctx.rotate(rotation);
+    this.ctx.scale(scale, scale);
+
+    // Apply shake offset for chest-hit animation
+    const offset = this.getShakeOffset(time, stateStartTime);
+    this.ctx.drawImage(this.closedChestImg, -chestW / 2 + offset, -chestH / 2, chestW, chestH);
+    this.ctx.restore();
+  }
+
+  /**
+   * Draws the open chest without animation.
+   * @param width - Canvas width
+   * @param height - Canvas height
+   */
+  public drawOpenChest(width: number, height: number): void {
+    const chestW = 250, chestH = 230;
+    const chestX = width / 2 - chestW / 2;
+    const chestY = height - chestH - 20;
+    this.ctx.drawImage(this.openChestImg, chestX, chestY, chestW, chestH);
+  }
+
+  /**
+   * Calculates horizontal shake offset based on elapsed animation time.
+   * Produces a left-right jitter effect for a limited duration.
+   * @param now - Current timestamp
+   * @param stateStartTime - Timestamp when chest entered shaking state
+   * @returns number - Offset in pixels to apply
+   */
+  private getShakeOffset(now: number, stateStartTime: number): number {
+    const elapsed = now - stateStartTime;
+    if (elapsed > this.shakeDuration) return 0; // Stop shaking after duration
+
+    const progress = elapsed / this.shakeDuration;
+    const cycle = Math.floor(progress * 6);  // Divide into 6 "half-shakes"
+    const amplitude = [20, -20, 15, -15, 8, -8][cycle] || 0; // Amplitude sequence
+    return amplitude;
+  }
+
+}

--- a/src/miniGame/miniGames/treasureChest/treasureChestAnimation.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChestAnimation.ts
@@ -1,103 +1,101 @@
-import { CLOSED_CHEST, OPEN_CHEST, STONE_BLUE } from '@constants';
 import gameSettingsServiceInstance from '@gameSettingsService/index';
+import TreasureStones from './treasure-stones';
+import TreasureChest from './treasureChest';
 
+/**
+ * Represents the different phases of the chest animation sequence.
+ */
 enum TreasureChestState {
-  FadeIn,
-  ClosedChest,
-  OpenedChest,
-  FadeOut
+  FadeIn, // Chest fading into view
+  ClosedChest, // Chest visible, shaking before opening
+  OpenedChest, // Chest open, stones burst out
+  FadeOut // Chest fading out of view
 }
 
-type Stone = {
-  x: number;
-  y: number;
-  radius: number;
-  dx: number;
-  dy: number;
-  opacity: number;
-  active: boolean;
-  lifetime: number;
-  img: HTMLImageElement;
-  size: number;
-  burning?: boolean;
-  burnStartTime?: number;
-  burnFrameIndex?: number;
-};
-
+/**
+ * Manages the entire treasure chest animation sequence:
+ * - Handles fade in/out transitions
+ * - Draws closed and open chest states
+ * - Spawns & animates stones
+ * - Handles click/tap interactions on stones
+ */
 export class TreasureChestAnimation {
-  private canvas: HTMLCanvasElement;
-  private ctx: CanvasRenderingContext2D;
-  private closedChestImg: HTMLImageElement;
-  private openChestImg: HTMLImageElement;
-  private stoneImg: HTMLImageElement;
-  private stones: Stone[] = [];
-  private animationFrameId: number | null = null;
-  private isVisible: boolean = false;
-  private lastSpawnTime: number;
-  private shakeDuration: number = 1000; // 1s
-  private callback: () => void; //Callback method to parent to trigger scoring / tapping of stones.
-  private burnFrames: HTMLImageElement[] = [];
-  private lastTapTime = 0;
-  private fadeInStart: number | null = null;
-  private fadeOutStart: number | null = null;
-  private fadeInDuration = 300;
-  private fadeOutDuration = 400;
-  private onFadeComplete?: () => void;
-  private state: TreasureChestState = TreasureChestState.FadeIn;
-  private stateStartTime: number = 0;
-  public dpr: number;
+  private canvas: HTMLCanvasElement; // Canvas element used for drawing
+  private ctx: CanvasRenderingContext2D; // 2D rendering context
+  private animationFrameId: number | null = null; // requestAnimationFrame id for cancelling loop
+  private isVisible: boolean = false; // Whether the animation is currently active
+  private shakeDuration: number = 1000; // Chest shaking duration (ms)
+  private callback: () => void; // Callback triggered when a stone is clicked
+  private lastTapTime = 0; // Used to prevent duplicate clicks on mobile
+  private fadeInStart: number | null = null; // Fade-in start timestamp
+  private fadeOutStart: number | null = null; // Fade-out start timestamp
+  private fadeInDuration = 300; // Fade-in time (ms)
+  private fadeOutDuration = 400; // Fade-out time (ms)
+  private onFadeComplete?: () => void; // Callback after fade-out completes
+  private state: TreasureChestState = TreasureChestState.FadeIn; // Current chest animation state
+  private stateStartTime: number = 0; // Timestamp when current state started
+  public dpr: number; // Device pixel ratio scaling
+
+  private treasureChest: TreasureChest; // Handles chest drawing
+  private treasureStone: TreasureStones;  // Handles stone drawing & animations
+
+  /**
+   * @param width - Canvas width in CSS pixels
+   * @param height - Canvas height in CSS pixels
+   * @param callback - Called when a stone is clicked
+   */
   constructor(
     private width: number,
     private height: number,
     callback: () => void,
   ) {
+    // Scale canvas to device pixel ratio for crisp rendering
     this.canvas = document.getElementById("treasurecanvas") as HTMLCanvasElement;
     this.dpr = gameSettingsServiceInstance.getDevicePixelRatioValue();
     this.canvas.width = this.width * this.dpr;
     this.canvas.height = this.height * this.dpr;
     this.canvas.style.width = `${this.width}px`;
     this.canvas.style.height = `${this.height}px`;
+
+    // Position overlay on top of game screen
     this.canvas.style.position = "absolute";
     this.canvas.style.top = "0";
     this.canvas.style.left = "0";
     this.canvas.style.display = "none";
     this.canvas.style.zIndex = "11";
     this.canvas.style.pointerEvents = "auto";
+
+    // Input handlers for both mouse & touch
     this.canvas.addEventListener("click", this.handleClick);
     this.canvas.addEventListener("touchstart", this.handleClick);
-    this.lastSpawnTime = performance.now();
     this.callback = callback;
 
+    // Setup rendering context
     const context = this.canvas.getContext("2d");
     if (!context) throw new Error("Canvas not supported");
     this.ctx = context;
     this.ctx.scale(this.dpr, this.dpr); // scale at init
-    // load chest and stone images
-    this.closedChestImg = new Image();
-    this.closedChestImg.src = CLOSED_CHEST; // closed chest
 
-    this.openChestImg = new Image();
-    this.openChestImg.src = OPEN_CHEST; // open chest
-
-    this.stoneImg = new Image();
-    this.stoneImg.src = STONE_BLUE; // blue stone
-    // load burn frames
-    for (let i = 1; i <= 4; i++) {
-      const burnImg = new Image();
-      burnImg.src = `./assets/images/stone_burn_export_${i}.png`;
-      this.burnFrames.push(burnImg);
-    }
+    // Initialize chest and stone managers
+    this.treasureChest = new TreasureChest(this.ctx, performance.now());
+    this.treasureStone = new TreasureStones(this.ctx);
   }
 
+  /**
+   * Handles user input clicks/taps and checks if a stone was tapped.
+   * Prevents duplicate events from touch devices (touchstart + synthetic click).
+   */
   private handleClick = (e: MouseEvent | TouchEvent) => {
     // Prevent double trigger on touch devices
     if (e.type === "touchstart") {
       this.lastTapTime = Date.now();
     } else if (e.type === "click") {
       if (Date.now() - this.lastTapTime < 500) {
-        return; // skip synthetic click
+        return; // Skip duplicate synthetic click
       }
     }
+
+    // Normalize input coordinates to canvas space
     let clientX: number, clientY: number;
     if (e instanceof MouseEvent) {
       clientX = e.clientX;
@@ -113,43 +111,25 @@ export class TreasureChestAnimation {
     const x = (clientX - rect.left) * scaleX;
     const y = (clientY - rect.top) * scaleY;
 
-    for (const stone of this.stones) {
-      if (!stone.active) continue;
+    const isStoneClicked = this.treasureStone.onClickEvent(x, y);
 
-      // Check if click is inside stone bounds
-      const dx = x - stone.x;
-      const dy = y - stone.y;
-      if (Math.sqrt(dx * dx + dy * dy) <= stone.size / 2) {
-        // Freeze stone
-        stone.dx = 0;
-        stone.dy = 0;
-        if (stone.burning || !stone.active) {
-          continue;
-        }
-        // Trigger burn sequence
-        stone.burning = true;
-        stone.burnStartTime = performance.now();
-        stone.burnFrameIndex = 0;
-
-        this.callback(); // notify MiniGame
-        break;
-      }
+    if (isStoneClicked) {
+      this.callback(); // Notify parent/minigame logic
     }
   };
 
 
-  /** Starts the mini chest animation */
+  /** Starts the animation and displays the canvas overlay. */
   public show(onComplete?: () => void) {
     this.canvas.style.display = "block";
     this.isVisible = true;
-    this.stones = [];
     this.onFadeComplete = onComplete;
     this.state = TreasureChestState.FadeIn;
     this.stateStartTime = performance.now();
     this.loop();
   }
 
-  /** Stops & hides */
+  /** Stops animation, hides canvas, and cleans up listeners. */
   public hide() {
     this.canvas.style.display = "none";
     this.canvas.removeEventListener("click", this.handleClick);
@@ -161,52 +141,10 @@ export class TreasureChestAnimation {
     }
   }
 
-  /** Shake offset calc */
-  private getShakeOffset(now: number): number {
-    const elapsed = now - this.stateStartTime;
-    if (elapsed > this.shakeDuration) return 0;
-
-    const progress = elapsed / this.shakeDuration;
-    const cycle = Math.floor(progress * 6); // 6 half-shakes
-    const amplitude = [20, -20, 15, -15, 8, -8][cycle] || 0;
-    return amplitude;
-  }
-
-  /** Spawn stone from chest */
-  private spawnStone(): Stone {
-    const chestX = this.width / 2 - 40;
-    const chestY = this.height - 200;
-
-    const radius = 8 + Math.random() * 6;
-    const baseAngle = Math.PI / 2;
-    const spread = (Math.random() - 0.5) * (Math.PI / 3);
-    let angle = baseAngle + spread;
-
-    if (angle < Math.PI / 2) {
-      angle = baseAngle - Math.abs(spread);
-    } else {
-      angle = baseAngle + Math.abs(spread);
-    }
-
-    const speed = 2 + Math.random() * 2;
-
-    const stone: Stone = {
-      x: chestX + 50,
-      y: chestY + 50,
-      radius,
-      dx: Math.cos(angle) * speed,
-      dy: -Math.sin(angle) * speed,
-      opacity: 1,
-      active: true,
-      lifetime: 300,
-      img: this.stoneImg,
-      size: 100,
-    };
-
-    return stone;
-  }
-
-  /** Main loop */
+  /**
+   * Main animation loop.
+   * Runs via requestAnimationFrame while visible.
+   */
   private loop = (time: number = 0) => {
     if (!this.isVisible) return;
 
@@ -219,7 +157,12 @@ export class TreasureChestAnimation {
         const elapsed = performance.now() - this.stateStartTime;
         const alpha = Math.min(1, elapsed / this.fadeInDuration);
         this.ctx.globalAlpha = alpha;
-        this.drawClosedChest(time);
+        this.treasureChest.drawClosedChest(
+          time,
+          this.stateStartTime,
+          this.width,
+          this.height
+        );
         if (alpha >= 1) {
           this.state = TreasureChestState.ClosedChest;
           this.stateStartTime = performance.now();
@@ -228,7 +171,12 @@ export class TreasureChestAnimation {
       }
       case TreasureChestState.ClosedChest: {
         this.ctx.globalAlpha = 1;
-        this.drawClosedChest(time);
+        this.treasureChest.drawClosedChest(
+          time,
+          this.stateStartTime,
+          this.width,
+          this.height
+        );
         const elapsed = performance.now() - this.stateStartTime;
         if (elapsed >= this.shakeDuration) {
           this.state = TreasureChestState.OpenedChest;
@@ -238,12 +186,10 @@ export class TreasureChestAnimation {
       }
       case TreasureChestState.OpenedChest: {
         this.ctx.globalAlpha = 1;
-        this.drawOpenChest(time);
-        this.updateStones();
-        this.cleanupStones();
-        this.maintainStones();
+        this.treasureChest.drawOpenChest(this.width, this.height);
+        this.treasureStone.stoneBurstAnimation(this.width, this.height);
         const elapsed = performance.now() - this.stateStartTime;
-        if (elapsed >= 12000) { // 12s for chest open
+        if (elapsed >= 12000) { // Keep chest open for 12 seconds
           this.state = TreasureChestState.FadeOut;
           this.stateStartTime = performance.now();
         }
@@ -253,15 +199,13 @@ export class TreasureChestAnimation {
         const elapsed = performance.now() - this.stateStartTime;
         const alpha = Math.max(0, 1 - elapsed / this.fadeOutDuration);
         this.ctx.globalAlpha = alpha;
-        this.drawOpenChest(time);
-        this.updateStones();
-        this.cleanupStones();
-        this.maintainStones();
+        this.treasureChest.drawOpenChest(this.width, this.height);
+        this.treasureStone.stoneBurstAnimation(this.width, this.height);
         if (alpha === 0) {
           this.hide();
           this.onFadeComplete?.();
           this.onFadeComplete = undefined;
-          return;
+          return; // Stop loop after fade-out
         }
         break;
       }
@@ -271,6 +215,7 @@ export class TreasureChestAnimation {
     this.animationFrameId = requestAnimationFrame(this.loop);
   };
 
+  /** Handles fade-in alpha calculation (unused alternative). */
   private handleFadeIn(): boolean {
     if (!this.fadeInStart) return false;
 
@@ -285,6 +230,7 @@ export class TreasureChestAnimation {
     return true;
   }
 
+  /** Handles fade-out alpha calculation (unused alternative). */
   private handleFadeOut(): boolean {
     if (!this.fadeOutStart) return false;
     const elapsed = performance.now() - this.fadeOutStart;
@@ -301,84 +247,10 @@ export class TreasureChestAnimation {
     return true;
   }
 
+  /** Draws a semi-transparent black overlay behind chest/stones. */
   private drawOverlay() {
     this.ctx.fillStyle = "rgba(0,0,0,0.7)";
     this.ctx.fillRect(0, 0, this.width, this.height);
   }
-
-  private drawClosedChest(time: number) {
-    const chestW = 250, chestH = 230;
-    const chestX = this.width / 2 - chestW / 2;
-    const chestY = this.height - chestH - 20;
-
-    const elapsed = time - this.lastSpawnTime;
-    let scale = 1;
-    let rotation = 0;
-    if (elapsed < 1000) {
-      scale = 1 + Math.sin((elapsed / 1000) * Math.PI * 4) * 0.05;
-      rotation = Math.sin((elapsed / 1000) * Math.PI * 6) * 0.1;
-    }
-
-    this.ctx.save();
-    this.ctx.translate(chestX + chestW / 2, chestY + chestH / 2);
-    this.ctx.rotate(rotation);
-    this.ctx.scale(scale, scale);
-    const offset = this.getShakeOffset(time);
-    this.ctx.drawImage(this.closedChestImg, -chestW / 2 + offset, -chestH / 2, chestW, chestH);
-    this.ctx.restore();
-  }
-
-  private drawOpenChest(time: number) {
-    const chestW = 250, chestH = 230;
-    const chestX = this.width / 2 - chestW / 2;
-    const chestY = this.height - chestH - 20;
-    this.ctx.drawImage(this.openChestImg, chestX, chestY, chestW, chestH);
-  }
-
-  private updateStones() {
-    for (const stone of this.stones) {
-      if (!stone.active) continue;
-      stone.burning ? this.updateBurningStone(stone) : this.updateMovingStone(stone);
-      this.drawStone(stone);
-    }
-  }
-
-  private updateMovingStone(stone: Stone) {
-    stone.x += stone.dx;
-    stone.y += stone.dy;
-    stone.lifetime--;
-    if (stone.lifetime < 60) stone.opacity -= 0.002;
-    if (stone.lifetime <= 0 || stone.y < 0 || stone.x < -stone.size || stone.x > this.width + stone.size) {
-      stone.active = false;
-    }
-  }
-
-  private updateBurningStone(stone: Stone) {
-    const elapsed = performance.now() - (stone.burnStartTime || 0);
-    stone.burnFrameIndex = Math.floor(elapsed / 75);
-    if (stone.burnFrameIndex >= this.burnFrames.length) stone.active = false;
-  }
-
-  private drawStone(stone: Stone) {
-    if (!stone.active) return;
-    this.ctx.globalAlpha = stone.opacity;
-    this.ctx.drawImage(stone.img, stone.x - stone.size / 2, stone.y - stone.size / 2, stone.size, stone.size);
-    this.ctx.globalAlpha = 1.0;
-    if (stone.burning && stone.burnFrameIndex! < this.burnFrames.length) {
-      this.ctx.drawImage(this.burnFrames[stone.burnFrameIndex!], stone.x - stone.size / 2, stone.y - stone.size / 2, stone.size, stone.size);
-    }
-  }
-
-  private cleanupStones() {
-    this.stones = this.stones.filter(stone => stone.active);
-  }
-
-  private maintainStones() {
-    const maxStones = Math.floor(Math.random() * (12 - 6 + 1)) + 6;
-    while (this.stones.length < maxStones) {
-      this.stones.push(this.spawnStone());
-    }
-  }
-
 
 }


### PR DESCRIPTION
# Changes
- Separated stone and chest animation from `TreasureChestAnimation` class.
- Created two new classes designated for animating only the relating object; `TreasureChest` and `TreasureStones `.
- Updated the flow and added comments to fully understand the logic of each classes.

# How to test
- Run FTM app
- Select levels 2, 5, 15, 25, or so on
- Play the game level and expect that the treasure chest mini game is working as is.

Ref: [FM-683](https://curiouslearning.atlassian.net/browse/FM-683)
