### PR TITLE
fix: FM-690 Fixed Level Replay Issues: Premature Level-End Screen and  Gameplay Not Paused During Mini-Game

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -895,7 +895,7 @@ export class GameplayScene {
     if (this.unsubscribeEvent) {
       this.unsubscribeEvent();
       this.unsubscribeMiniGameEvent();
-      this.unsubscribeLoadGamePuzzle;
+      this.unsubscribeLoadGamePuzzle();
       this.unsubscribeEvent = null;
     }
 


### PR DESCRIPTION
# Changes
-Fixed Level Replay Issues: Premature Level-End Screen and  Gameplay Not Paused During Mini-Game

# How to test
- Go to the level selection screen and select a level (any level)
- Start the level and play 2 to 3 puzzles and pause the gameplay and click on replay button.
- When we replay the game we can observe the issues mentioned above.
- If we fail to clear the level and if the click on replay in the level end then also we can see these issues few time which is now fixed.

Ref: [FM-690](https://curiouslearning.atlassian.net/browse/FM-690)


[FM-690]: https://curiouslearning.atlassian.net/browse/FM-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ