### PR TITLE
fix: Setting up monster evolution api!

### DIFF
--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -20,6 +20,7 @@ import {
 import { URL } from "@data";
 import './styles/main.scss';
 import { FeatureFlagsService } from '@curiouslearning/features';
+import gameStateService from "./gameStateService";
 
 const featureFlagService = new FeatureFlagsService({
   metaData: { userId: pseudoId }
@@ -317,8 +318,33 @@ class App {
   private globalInitialization(data: any) {
     globalThis.aboutCompany = data.aboutCompany;
     globalThis.descriptionText = data.descriptionText;
+      this.setupMonsterEvolutionStateAPI();
   }
+ private setupMonsterEvolutionStateAPI(): void {
+    // Feed The Monster (FTM)
+    // Using arrow function to preserve 'this' context and access module-level gameStateService
+    window.getMonsterEvolutionState = () => {
+      try {
+        const monsterPhase = gameStateService.checkMonsterPhaseUpdation();
+        const successStars = gameStateService.getSuccessStarsCount();
 
+        return {
+          app: "feed_the_monster",
+          monsterPhase: monsterPhase,
+          successStars: successStars,
+          timestamp: Date.now()
+        };
+      } catch (e) {
+        return {
+          app: "feed_the_monster",
+          monsterPhase: 0,
+          successStars: 0,
+          error: "STATE_NOT_READY",
+          timestamp: Date.now()
+        };
+      }
+    };
+  }
   private handleResize(dataModal: DataModal): void {
     if (this.is_cached.has(this.lang)) {
       this.updateVersionInfoElement(dataModal);


### PR DESCRIPTION
# Changes
- Setting up monster evolution api!

# note
- These are changes for implementing monster evolution api to send monster phase number to cr-container app, for the effort of visually enhancing our android app!

Ref: [AJ-493](https://curiouslearning.atlassian.net/browse/AJ-493)


[AJ-493]: https://curiouslearning.atlassian.net/browse/AJ-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ