### PR TITLE
fix: Fixed FM-816 Stones Become Non-Interactive After Dropping/ hover…

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -81,6 +81,7 @@ export class GameplayScene {
   private miniGameHandler: MiniGameHandler;
   private backgroundGenerator: PhasesBackground;
   private timerStartSFXPlayed: boolean;
+  private isActiveMiniGame: boolean = false;
   public isDisposing: boolean = false;
   
   // Event Management
@@ -428,7 +429,15 @@ export class GameplayScene {
 
   private handlePuzzleInit(): void {
     this.timerStartSFXPlayed = false;
-
+    // Only reset drag and monster state if mini-game is not currently active
+    // This prevents interrupting the mini-game flow
+    if (!this.isActiveMiniGame) {
+      // Reset drag state when a new puzzle is initialized
+      this.inputManager.resetDragState();
+      // Reset monster animation state to close mouth and return to idle
+      this.monsterController.triggerMonsterAnimation('isMouthClosed');
+      this.monsterController.triggerMonsterAnimation('backToIdle');
+    }
   }
   // #endregion
 
@@ -483,6 +492,20 @@ export class GameplayScene {
 
     this.addEventListener(gameStateService.EVENTS.LOAD_NEXT_GAME_PUZZLE, this.handleNextPuzzleLoad.bind(this));
     this.addEventListener(GameplayFlowManager.PUZZLE_INIT, this.handlePuzzleInit.bind(this));
+
+    // Track mini-game state
+    this.eventListenersAdded.push(
+      miniGameStateService.subscribe(
+        miniGameStateService.EVENTS.MINI_GAME_WILL_START,
+        () => { this.isActiveMiniGame = true; }
+      )
+    );
+    this.eventListenersAdded.push(
+      miniGameStateService.subscribe(
+        miniGameStateService.EVENTS.IS_MINI_GAME_DONE,
+        () => { this.isActiveMiniGame = false; }
+      )
+    );
 
     this.unsubscribeEvent = gameStateService.subscribe(
       gameStateService.EVENTS.GAME_PAUSE_STATUS_EVENT,


### PR DESCRIPTION
…ing When Timer Expires. (#1893)

* Chore: Removed and replaced EventManager with game state service (FM-809).

* chore: Updated test case for level-indicator (FM-809)

* chore: Code clean up (FM-809)

* chore: Removed excess and unused  event in prompt(FM-809)

* chore: Added event list clearing (FM-809).

* chore: modified util unsubscribe all to return empty array (FM-809)

* fix: FM-816  Fixed Stones Become Non-Interactive After Dropping/ hovering When Timer Expires.
chore: Added check if minigame loads wait for initpuzzle to play in the background

