### PR TITLE
Fix:  fix for resetting the time on non tutorial levels (FM-822)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -422,12 +422,10 @@ export class GameplayScene {
     this.pauseGamePlay();
   }
 
-  private handleNextPuzzleLoad(): void {
-    this.isGameStarted = false;
-  }
-
   private handlePuzzleInit(): void {
     this.timerStartSFXPlayed = false;
+    this.time = 0;
+    this.isGameStarted = false;
     // Only reset drag and monster state if mini-game is not currently active
     // This prevents interrupting the mini-game flow
     if (!this.isActiveMiniGame) {
@@ -494,7 +492,6 @@ export class GameplayScene {
     this.addEventListener(GameplayUIManager.UI_POPUP_RESUME, this.handleUiPopupResume.bind(this));
     this.addEventListener(GameplayUIManager.UI_TIMER_ENDED, this.handleUITimerEnded.bind(this));
 
-    this.addEventListener(gameStateService.EVENTS.LOAD_NEXT_GAME_PUZZLE, this.handleNextPuzzleLoad.bind(this));
     this.addEventListener(GameplayFlowManager.PUZZLE_INIT, this.handlePuzzleInit.bind(this));
 
     // Track mini-game state


### PR DESCRIPTION
# Changes
- Added time reset for the tutorial on puzzle init

# How to test
- Play on non tutorial levels

Ref: [FM-822](https://curiouslearning.atlassian.net/browse/FM-822)


[FM-822]: https://curiouslearning.atlassian.net/browse/FM-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ