### PR TITLE
fix: fix for pressing the prompt when the tutorial has been finished from that level (FM-826)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -395,8 +395,10 @@ export class GameplayScene {
   }
 
   private handleUiPromptClick(): void {
-    this.tutorial.shouldShowQuickStartTutorial = true;
-    this.tutorial.quickStartTutorialReady = true;
+    if (this.tutorial.showHandPointerInAudioPuzzle(this.levelData)) {
+      this.tutorial.shouldShowQuickStartTutorial = true;
+      this.tutorial.quickStartTutorialReady = true;
+    }
   }
 
   private handleUiPopupRestart(): void {


### PR DESCRIPTION
# Changes
- Added condition when pressing prompt for tutorial

# How to test
- Play a level with tutorial and then replay it. Press the prompt before it starts the stones.

Ref: [FM-826](https://curiouslearning.atlassian.net/browse/FM-826)


[FM-826]: https://curiouslearning.atlassian.net/browse/FM-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ