### PR TITLE
feat: implemented a timeout-registry for the scheduler handling of the timers disposal

### DIFF
--- a/new_ftm_language_creation/normalize_audio_filenames.py
+++ b/new_ftm_language_creation/normalize_audio_filenames.py
@@ -1,5 +1,8 @@
+import argparse
 import os
+import sys
 import unicodedata
+from pathlib import Path
 
 def normalize_unicode(text):
     """Normalize Unicode strings to NFC form (composed characters)"""
@@ -61,6 +64,10 @@ def normalize_audio_filenames(language, root_folder):
     
     for actual_filename in actual_files:
         normalized_filename = normalize_unicode(actual_filename)
+
+        # Only normalize files expected by the JSON list.
+        if normalized_filename not in expected_normalized:
+            continue
         
         # Check if normalization changed the filename
         if actual_filename != normalized_filename:
@@ -85,11 +92,23 @@ def normalize_audio_filenames(language, root_folder):
         print(f"\nTotal files renamed: {renamed_count}")
 
 if __name__ == "__main__":
-    root_folder = r"C:\CuriousLearning\FeedTheMonsterJS\lang"
-    
+    parser = argparse.ArgumentParser(description="Normalize audio filenames to NFC.")
+    parser.add_argument(
+        "--root-folder",
+        help="Path to the lang folder. Defaults to ../lang relative to this script.",
+    )
+    args = parser.parse_args()
+
+    default_root = Path(__file__).resolve().parents[1] / "lang"
+    root_folder = Path(args.root_folder).resolve() if args.root_folder else default_root
+
+    if not root_folder.exists() or not root_folder.is_dir():
+        print(f"Lang folder does not exist: {root_folder}")
+        sys.exit(1)
+
     language = input("Enter the language: ")
-    
+
     print(f"\nNormalizing audio filenames for: {language}")
     print("-" * 50)
-    normalize_audio_filenames(language, root_folder)
+    normalize_audio_filenames(language, str(root_folder))
     print("\nDone!")

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,6 +11,7 @@ import {
   isGameTypeAudio,
   unsubscribeAll
 } from "./utils";
+import { TimeoutRegistry } from "./timeout-registry";
 import { Debugger, lang, font, pseudoId, Window, source, campaign_id } from "./global-variables";
 import {
   CLICK,
@@ -53,5 +54,6 @@ export {
   hideElement,
   getGameTypeName,
   isGameTypeAudio,
-  unsubscribeAll
+  unsubscribeAll,
+  TimeoutRegistry
 };

--- a/src/common/timeout-registry.spec.ts
+++ b/src/common/timeout-registry.spec.ts
@@ -1,0 +1,57 @@
+import scheduler from "@services/scheduler";
+import { TimeoutRegistry } from "@common";
+
+describe("TimeoutRegistry", () => {
+  afterEach(() => {
+    scheduler.destroy();
+    jest.restoreAllMocks();
+  });
+
+  test("setTimeout schedules and removes after execution", () => {
+    const registry = new TimeoutRegistry();
+    const callback = jest.fn();
+
+    registry.setTimeout(callback, 10);
+    scheduler.update(9);
+    expect(callback).not.toHaveBeenCalled();
+
+    scheduler.update(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    const cancelSpy = jest.spyOn(scheduler, "cancelTimeout");
+    registry.cancelAll();
+    expect(cancelSpy).not.toHaveBeenCalled();
+  });
+
+  test("cancel prevents scheduled callback", () => {
+    const registry = new TimeoutRegistry();
+    const callback = jest.fn();
+
+    const timerId = registry.setTimeout(callback, 5);
+    registry.cancel(timerId);
+    scheduler.update(10);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("cancel ignores null and undefined", () => {
+    const registry = new TimeoutRegistry();
+
+    expect(() => registry.cancel(null)).not.toThrow();
+    expect(() => registry.cancel(undefined)).not.toThrow();
+  });
+
+  test("cancelAll clears all scheduled callbacks", () => {
+    const registry = new TimeoutRegistry();
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+
+    registry.setTimeout(callbackA, 5);
+    registry.setTimeout(callbackB, 10);
+    registry.cancelAll();
+
+    scheduler.update(20);
+    expect(callbackA).not.toHaveBeenCalled();
+    expect(callbackB).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/timeout-registry.ts
+++ b/src/common/timeout-registry.ts
@@ -21,7 +21,9 @@ export class TimeoutRegistry {
   }
 
   cancelAll(): void {
-    this.timeouts.forEach((timerId) => scheduler.cancelTimeout(timerId));
+    for (const timerId of this.timeouts) {
+      scheduler.cancelTimeout(timerId);
+    }
     this.timeouts.clear();
   }
 }

--- a/src/common/timeout-registry.ts
+++ b/src/common/timeout-registry.ts
@@ -1,0 +1,27 @@
+import scheduler, { TimerId } from "@services/scheduler";
+
+export class TimeoutRegistry {
+  private timeouts: Set<TimerId> = new Set();
+
+  setTimeout(callback: () => void, delay: number): TimerId {
+    const timerId = scheduler.setTimeout(() => {
+      this.timeouts.delete(timerId);
+      callback();
+    }, delay);
+    this.timeouts.add(timerId);
+    return timerId;
+  }
+
+  cancel(timerId: TimerId | null | undefined): void {
+    if (timerId === null || timerId === undefined) {
+      return;
+    }
+    scheduler.cancelTimeout(timerId);
+    this.timeouts.delete(timerId);
+  }
+
+  cancelAll(): void {
+    this.timeouts.forEach((timerId) => scheduler.cancelTimeout(timerId));
+    this.timeouts.clear();
+  }
+}

--- a/src/components/audio-player.ts
+++ b/src/components/audio-player.ts
@@ -1,6 +1,6 @@
-import { Window } from "@common";
+import { TimeoutRegistry, Window } from "@common";
 import { AUDIO_PATH_BTN_CLICK } from "@constants";
-import scheduler from "@services/scheduler";
+import { TimerId } from "@services/scheduler";
 
 
 /**
@@ -21,8 +21,9 @@ export class AudioPlayer {
   private static audioBuffers: Map<string, AudioBuffer> = new Map();
   public audioSourcs: Array<AudioBufferSourceNode> = [];
   private isClickSoundLoaded: boolean;
-  private playAudioTimeoutId: any;
+  private playAudioTimeoutId: TimerId | null;
   private isPromptAudioPlaying: boolean;
+  private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
 
   constructor() {
     if( AudioPlayer.instance )
@@ -35,6 +36,7 @@ export class AudioPlayer {
     this.clickSoundBuffer = null; // Initialize the clickSoundBuffer
     this.isClickSoundLoaded = false; // Initialize as false
     this.isPromptAudioPlaying = false;
+    this.playAudioTimeoutId = null;
 
   }
 
@@ -285,11 +287,12 @@ export class AudioPlayer {
 
       if (this.playAudioTimeoutId) {
         this.isPromptAudioPlaying = true;
-        clearTimeout(this.playAudioTimeoutId);
+        this.timeoutRegistry.cancel(this.playAudioTimeoutId);
+        this.playAudioTimeoutId = null;
       }
 
       // Schedule the next audio play after current one ends
-      this.playAudioTimeoutId = scheduler.setTimeout(() => {
+      this.playAudioTimeoutId = this.timeoutRegistry.setTimeout(() => {
         //Call playPromptAudio with a callback for onended method to call.
         this.playPromptAudio(() => {
           this.isPromptAudioPlaying = false;

--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -4,7 +4,7 @@ import { PROMPT_TEXT_BG, AUDIO_PLAY_BUTTON } from "@constants";
 import { BaseHTML, BaseHtmlOptions } from "../baseHTML/base-html";
 import './prompt-text.scss';
 import gameStateService from '@gameStateService';
-import scheduler from "@services/scheduler";
+import { TimeoutRegistry } from "@common";
 
 
 // Default selectors for the prompt text component
@@ -79,6 +79,7 @@ export class PromptText extends BaseHTML {
     public isAppForeground: boolean = true;
     public AUTO_PROMPT_INITIAL_DELAY_MS: number;
     private isAutoPromptPlaying: boolean = false;
+    private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
     private isLevelHaveTutorial: boolean = false;
 
     // HTML elements for the prompt
@@ -232,7 +233,7 @@ export class PromptText extends BaseHTML {
     }
 
     private runAfterInitialAudioDelay(delayMs: number, callback: () => void) {
-        scheduler.setTimeout(callback, delayMs);
+        this.timeoutRegistry.setTimeout(callback, delayMs);
     }
 
     private schedulePromptAndPulseUpdate() {
@@ -538,12 +539,11 @@ export class PromptText extends BaseHTML {
     }
 
     private handleAutoPromptPlay() {
-        scheduler.setTimeout(() => {
+        this.runAfterInitialAudioDelay(this.AUTO_PROMPT_INITIAL_DELAY_MS, () => {
             if (!this.isAutoPromptPlaying) {
                 this.audioPlayer.handlePlayPromptAudioClickEvent();
             }
-
-        }, this.AUTO_PROMPT_INITIAL_DELAY_MS);
+        });
     }
 
     private resetSpellSoundSlots() {
@@ -605,6 +605,7 @@ export class PromptText extends BaseHTML {
     public dispose() {
         document.removeEventListener(VISIBILITY_CHANGE, this.handleVisibilityChange, false);
         this.eventListeners = unsubscribeAll(this.eventListeners); //unsubscribe to gameStateService event.
+        this.timeoutRegistry.cancelAll();
         // Use BaseHTML's destroy method to remove the element
         super.destroy();
     }

--- a/src/components/timer-ticking.ts
+++ b/src/components/timer-ticking.ts
@@ -1,9 +1,8 @@
-import { loadImages } from "@common";
+import { loadImages, TimeoutRegistry } from "@common";
 import { AudioPlayer } from "@components";
 import { TIMER_EMPTY, ROTATING_CLOCK, AUDIO_TIMEOUT } from "@constants";
 import './timerHtml/timerHtml.scss';
 import TimerHTMLComponent from './timerHtml/timerHtml';
-import scheduler from "@services/scheduler";
 import gameStateService from '@gameStateService';
 import { unsubscribeAll } from '@common';
 
@@ -31,6 +30,7 @@ export default class TimerTicking {
     public timerFullContainer: HTMLElement | null = null;
     public timerHtmlComponent: TimerHTMLComponent;
     private eventListeners: Function[] = [];
+    private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
 
     constructor(width: number, height: number, callback: Function) {
         this.width = width;
@@ -51,7 +51,7 @@ export default class TimerTicking {
         this.timerHtmlComponent = new TimerHTMLComponent('timer-ticking');
         // Reference the container element for the "full timer" image
         // Verify and cache the DOM element after rendering
-        scheduler.setTimeout(() => {
+        this.timeoutRegistry.setTimeout(() => {
             this.timerFullContainer = document.getElementById("timer-full-container");
             if (this.timerFullContainer) this.timerFullContainer.style.width = "100%";
         }, 0);
@@ -163,6 +163,7 @@ export default class TimerTicking {
     public destroy(): void {
         this.eventListeners = unsubscribeAll(this.eventListeners);
         this.stopTimer();
+        this.timeoutRegistry.cancelAll();
         this.timerHtmlComponent?.destroy();
     }
 }

--- a/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.spec.ts
+++ b/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.spec.ts
@@ -21,6 +21,11 @@ jest.mock('@common', () => ({
   Utils: {
     getRandomNumber: jest.fn().mockReturnValue(2),
     getConvertedDevProdURL: jest.fn(url => url)
+  },
+  TimeoutRegistry: class {
+    setTimeout = jest.fn(() => 1);
+    cancel = jest.fn();
+    cancelAll = jest.fn();
   }
 }));
 

--- a/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.ts
+++ b/src/gamepuzzles/feedbackAudioHandler/feedbackAudioHandler.ts
@@ -4,10 +4,9 @@ import {
   AUDIO_PATH_CHEERING_FUNC,
   AUDIO_PATH_CORRECT_STONE
 } from '@constants';
-import { Utils } from '@common';
+import { TimeoutRegistry, Utils } from '@common';
 import gameStateService from '@gameStateService';
 import { RiveMonsterComponent } from '@components/riveMonster/rive-monster-component';
-import scheduler from "@services/scheduler";
 
 /**
  * Feedback type enum for different feedback scenarios
@@ -26,6 +25,7 @@ export default class FeedbackAudioHandler {
   private audioPlayer: AudioPlayer;
   private feedbackAudios: string[];
   private correctStoneAudio: HTMLAudioElement;
+  private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
 
   constructor(feedbackAudios: any) {
     this.audioPlayer = new AudioPlayer();
@@ -72,8 +72,7 @@ export default class FeedbackAudioHandler {
    * Plays audio for an incorrect answer
    */
   private playIncorrectFeedbackSound(): void {
-
-    scheduler.setTimeout(() => {
+    this.timeoutRegistry.setTimeout(() => {
         this.audioEndCallback();
     }, 1700); // 1700ms is tailored to handleStoneDropEnd 1000 delay of isSpit animation
   }
@@ -95,11 +94,11 @@ export default class FeedbackAudioHandler {
           Utils.getConvertedDevProdURL(this.feedbackAudios[feedBackIndex])
         )
       ]);
-      scheduler.setTimeout(() => {
+      this.timeoutRegistry.setTimeout(() => {
         this.audioEndCallback(); // Callback after audios finish playing
       }, 4000);
     } catch (error) {
-      scheduler.setTimeout(() => {
+      this.timeoutRegistry.setTimeout(() => {
         this.audioEndCallback(); // Ensure callback is called even if audio fails
       }, 4000); 
       console.warn('Audio playback failed:', error);
@@ -134,6 +133,7 @@ export default class FeedbackAudioHandler {
    */
   public dispose(): void {
     this.audioPlayer.stopAllAudios();
+    this.timeoutRegistry.cancelAll();
     if (this.correctStoneAudio) {
       this.correctStoneAudio.pause();
       this.correctStoneAudio.src = '';

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -1,9 +1,9 @@
 import LetterPuzzleLogic from '../letterPuzzleLogic/letterPuzzleLogic';
 import WordPuzzleLogic from '../wordPuzzleLogic/wordPuzzleLogic';
 import { FeedbackTextEffects } from '@components/feedback-text';
+import { TimeoutRegistry } from '@common';
 import { FeedbackAudioHandler, FeedbackType } from '@gamepuzzles';
 import gameStateService from '@gameStateService';
-import scheduler from "@services/scheduler";
 
 
 /**
@@ -34,6 +34,7 @@ export default class PuzzleHandler {
   private letterPuzzleLogic: LetterPuzzleLogic | null = null;
   private feedbackAudioHandler: FeedbackAudioHandler;
   private feedbackTextEffects: FeedbackTextEffects
+  private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
 
   constructor(levelData: any, counter: number = 0, feedbackAudios?: any) {
     // Initialize feedback audio handler if audio resources are provided
@@ -275,7 +276,7 @@ export default class PuzzleHandler {
 
     // Hide feedback text after audio finishes
     const totalAudioDuration = 4500; // Approximate duration of feedback audio
-    scheduler.setTimeout(() => {
+    this.timeoutRegistry.setTimeout(() => {
       this.feedbackTextEffects.hideText();
     }, totalAudioDuration);
   }
@@ -299,5 +300,6 @@ export default class PuzzleHandler {
     if(this.feedbackTextEffects) {
       this.feedbackTextEffects.hideText();
     }
+    this.timeoutRegistry.cancelAll();
   }
 }

--- a/src/sceneHandler/scene-handler.ts
+++ b/src/sceneHandler/scene-handler.ts
@@ -138,7 +138,7 @@ export class SceneHandler {
 
   private cleanupScene() {
     this.activeScene['scene'] && this.activeScene['scene']?.dispose();
-    AudioPlayer.instance.resumeAllAudios();
+    AudioPlayer.instance?.resumeAllAudios();
     scheduler.destroy();
   }
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -4,6 +4,7 @@ import {
     STONEDROP,
     Debugger,
     lang,
+    TimeoutRegistry,
 } from "@common";
 import {
     SCENE_NAME_LEVEL_SELECT,
@@ -22,7 +23,6 @@ import PuzzleHandler from "@gamepuzzles/puzzleHandler/puzzleHandler";
 import { StoneHandler, AudioPlayer } from "@components";
 import { MiniGameHandler } from '@miniGames/miniGameHandler';
 import TutorialHandler from '@tutorials';
-import scheduler from "@services/scheduler";
 
 export class GameplayFlowManager {
 
@@ -52,6 +52,7 @@ export class GameplayFlowManager {
     private miniGameHandler: MiniGameHandler;
     private tutorial: TutorialHandler;
     private analyticsIntegration: AnalyticsIntegration;
+    private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
     // #endregion
 
     constructor(
@@ -118,7 +119,7 @@ export class GameplayFlowManager {
         } else {
             // For incorrect answers only; Start loading the next puzzle with 2 seconds delay to let the audios play.
             const delay = this.isCorrect || isTimeOver ? 0 : 2000;
-            scheduler.setTimeout(() => {
+            this.timeoutRegistry.setTimeout(() => {
                 this.loadPuzzle(isTimeOver, loadPuzzleDelay);
             }, delay);
         }
@@ -224,7 +225,7 @@ export class GameplayFlowManager {
         // Update the stars level indicator.
         this.uiManager.updateStars(this.currentPuzzleIndex, this.isCorrect);
 
-        scheduler.setTimeout(() => {
+        this.timeoutRegistry.setTimeout(() => {
             this.logLevelEndFirebaseEvent();
             const starsCount = GameScore.calculateStarCount(this.score);
             const levelEndData = {
@@ -260,7 +261,7 @@ export class GameplayFlowManager {
             }
         }
 
-        scheduler.setTimeout(() => {
+        this.timeoutRegistry.setTimeout(() => {
             if (!this.isDisposing) {
                 this.initNewPuzzle(loadPuzzleEvent);
                 this.uiManager.startTimer(); // Start the timer for the new puzzle
@@ -363,6 +364,7 @@ export class GameplayFlowManager {
         this.isDisposing = true;
         this.eventListeners.forEach(unsubscribe => unsubscribe());
         this.eventListeners = [];
+        this.timeoutRegistry.cancelAll();
     }
     
     public get currentPuzzleIndexValue(): number {

--- a/src/scenes/gameplay-scene/monster-controller.ts
+++ b/src/scenes/gameplay-scene/monster-controller.ts
@@ -3,7 +3,7 @@ import { RiveMonsterComponent } from '@components/riveMonster/rive-monster-compo
 import gameSettingsService from '@gameSettingsService';
 import gameStateService from '@gameStateService';
 import { GameplayInputManager } from "./gameplay-input-manager";
-import scheduler from "@services/scheduler";
+import { TimeoutRegistry } from "@common";
 
 export class MonsterController {
   // #region Properties
@@ -13,6 +13,7 @@ export class MonsterController {
   private hitboxRangeX: { from: number; to: number };
   private hitboxRangeY: { from: number; to: number };
   private unsubscribeAnimationRequest: () => void;
+  private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
 
   private animationDelays = [
     { backToIdle: 350, isChewing: 0, isHappy: 1700, isSpit: 1500, isSad: 3000 },
@@ -63,6 +64,8 @@ export class MonsterController {
       this.monster = null;
     }
 
+    this.timeoutRegistry.cancelAll();
+
     if (this.unsubscribeAnimationRequest) {
       this.unsubscribeAnimationRequest();
       this.unsubscribeAnimationRequest = null;
@@ -85,7 +88,7 @@ export class MonsterController {
   public triggerMonsterAnimation(animationName: string): void {
     const delay = this.animationDelays[this.monsterPhaseNumber]?.[animationName] ?? 0;
     if (delay > 0) {
-      scheduler.setTimeout(() => this.monster?.triggerInput(animationName), delay);
+      this.timeoutRegistry.setTimeout(() => this.monster?.triggerInput(animationName), delay);
     } else {
       this.monster?.triggerInput(animationName);
     }

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -74,7 +74,9 @@ class Scheduler {
    * @param delta The time elapsed since the last update in milliseconds.
    */
   update(delta: number): void {
-    for (const timer of this.timers.values()) {
+    const snapshot = [...this.timers.values()];
+    for (const timer of snapshot) {
+      if (!this.timers.has(timer.id)) continue; // already cancelled
       timer.remaining -= delta;
       if (timer.remaining <= 0) {
         try {

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -3,8 +3,8 @@ import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPu
 import WordPuzzleTutorial from './WordPuzzleTutorial/WordPuzzleTutorial';
 import AudioPuzzleTutorial from './AudioPuzzleTutorial/AudioPuzzleTutorial';
 import gameStateService from '@gameStateService';
-import { getGameTypeName, isGameTypeAudio } from '@common';
-import scheduler, { TimerId } from '@services/scheduler';
+import { getGameTypeName, isGameTypeAudio, TimeoutRegistry } from '@common';
+import { TimerId } from '@services/scheduler';
 
 type TutorialInitParams = {
   context: CanvasRenderingContext2D;
@@ -15,6 +15,7 @@ type TutorialInitParams = {
 };
 export default class TutorialHandler {
   private quickStartTutorialTimerId: TimerId | null = null;
+  private timeoutRegistry: TimeoutRegistry = new TimeoutRegistry();
   public quickStartTutorialReady: boolean = false;
   public shouldShowQuickStartTutorial: boolean = false; // Set externally as needed
   private width: number;
@@ -270,6 +271,7 @@ export default class TutorialHandler {
 
   dispose() {
     //Clear canvas tutorials and reset values;
+    this.timeoutRegistry.cancelAll();
     if (this.hasEstablishedSubscriptions) {
       this.activeTutorial?.dispose();
       this.isGameOnPause = false;
@@ -324,13 +326,13 @@ export default class TutorialHandler {
   public resetQuickStartTutorialDelay() {
     // Always clear any previous timer to avoid overlap
     if (this.quickStartTutorialTimerId !== null) {
-      scheduler.cancelTimeout(this.quickStartTutorialTimerId);
+      this.timeoutRegistry.cancel(this.quickStartTutorialTimerId);
       this.quickStartTutorialTimerId = null;
     }
     this.quickStartTutorialReady = false;
     // Only start the timer if the tutorial should be shown
     if (this.shouldShowQuickStartTutorial) {
-      this.quickStartTutorialTimerId = scheduler.setTimeout(() => {
+      this.quickStartTutorialTimerId = this.timeoutRegistry.setTimeout(() => {
         this.quickStartTutorialReady = true;
       }, 6000); // 6 seconds
     }


### PR DESCRIPTION
# Changes
- Added timeout-registry for scheduler handling

# How to test
- Scheduler should still work the same

Ref: [FM-806](https://curiouslearning.atlassian.net/browse/FM-806)


[FM-806]: https://curiouslearning.atlassian.net/browse/FM-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to normalize and validate audio filenames before processing.

* **Bug Fixes**
  * Improved audio filename filtering to avoid unintended renames and handle name collisions.
  * Guarded an audio resume call to avoid errors in edge cases.

* **Improvements**
  * Centralized timeout handling across the app for more reliable scheduling and cleanup.

* **Tests**
  * Added unit tests covering the new timeout management utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->