### PR TITLE
fixed: Drag Tutorial Incorrectly Triggers for Repeated Letters in word puzzles (FM-643).

### DIFF
--- a/src/components/prompt-text/prompt-text.ts
+++ b/src/components/prompt-text/prompt-text.ts
@@ -156,8 +156,10 @@ export class PromptText extends BaseHTML {
         this.eventListeners.push(
             gameStateService.subscribe(
                 WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
-                (droppedLetterCount: number) => {
-                    this.currentActiveLetterIndex = droppedLetterCount;
+                ({ droppedLettersCount } : {
+                    droppedLettersCount: number
+                }) => {
+                    this.currentActiveLetterIndex = droppedLettersCount;
                     //Update the prompt text that reflects the next active letter.
                     if (this.isSpellSoundMatch()) {
                         this.generatePromptSlots();

--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -144,12 +144,17 @@ export default class StoneHandler {
       // Initialize stone with its configuration.
       stone.initialize();
       
-      //For letter puzzle tutorial
+      
+      // NOTE: foilStones[i] is guaranteed to match this.correctTargetStone exactly once
+      // in the first segment (segmentNumber === 0). This is a core game-level invariant —
+      // the correct target stone must exist for the game and tutorial to function properly. 
+      // If no match occurs here, the level data is invalid, and the game logic itself would fail.
       if (
         isTutorialSection &&
         !isWordPuzzle &&
-        foilStones[i] == this.correctTargetStone
+        foilStones[i] === this.correctTargetStone
       ) {
+        //For letter puzzle tutorial
         tutorialCorrectLetterAns = stone;
       }
 
@@ -161,8 +166,9 @@ export default class StoneHandler {
     this.activeStones = this.foilStones.filter(stone => stone && !stone.isDisposed);
   
     if (isTutorialSection) {
-      
-      const activeTutorialFoilStones = isWordPuzzle ? this.activeStones : [tutorialCorrectLetterAns];
+      // Always use an array; empty if no correct stone found.
+      const activeTutorialLetterStone = tutorialCorrectLetterAns ? [tutorialCorrectLetterAns] : [];
+      const activeTutorialFoilStones = isWordPuzzle ? this.activeStones : activeTutorialLetterStone;
 
       gameStateService.publish(gameStateService.EVENTS.CORRECT_STONE_POSITION, {
         isWordPuzzle,

--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -122,6 +122,8 @@ export default class StoneHandler {
 
     //Check if the level type is Word/Spelling; Used for flagging condition for publishing data to tutorial.
     const isWordPuzzle = this.levelData?.levelMeta?.levelType === 'Word';
+    const isTutorialSection = this.currentPuzzleData.segmentNumber === 0; //If Game level is at first segment.
+    let tutorialCorrectLetterAns = null;
 
     // Create a stone for each character in the foilStones array,
     // using a corresponding randomized position from the shuffled positions array.
@@ -141,33 +143,35 @@ export default class StoneHandler {
 
       // Initialize stone with its configuration.
       stone.initialize();
-
-      // Publish the correct stone's data for use in the tutorial (only at segment 0).
-      // This provides the exact coordinates, image, and level data to the tutorial system.
+      
+      //For letter puzzle tutorial
       if (
-        this.currentPuzzleData.segmentNumber === 0 &&
-        (
-          /* If isWordPuzzle is true, publish data to tutorial at last loop iteration.
-            Otherwise if the current index is the correct stone for non-word or spelling puzzle type.
-          */
-          isWordPuzzle && i === foilStones.length - 1 ||
-          foilStones[i] == this.correctTargetStone
-        )
+        isTutorialSection &&
+        !isWordPuzzle &&
+        foilStones[i] == this.correctTargetStone
       ) {
-        gameStateService.publish(gameStateService.EVENTS.CORRECT_STONE_POSITION, {
-          stonePosVal: positions[i], //single stone position for non word puzzles.
-          allStonePosVal: positions, //all stone positions.
-          img, //stone image as tutorial needs a copy of the image for rendering.
-          levelData: this.levelData
-        });
+        tutorialCorrectLetterAns = stone;
       }
 
       //Store the generated stone instance.
       this.foilStones.push(stone);
     }
-
+    
     //Filter only active (non-disposed) stones to track for rendering or interaction.
     this.activeStones = this.foilStones.filter(stone => stone && !stone.isDisposed);
+  
+    if (isTutorialSection) {
+      
+      const activeTutorialFoilStones = isWordPuzzle ? this.activeStones : [tutorialCorrectLetterAns];
+
+      gameStateService.publish(gameStateService.EVENTS.CORRECT_STONE_POSITION, {
+        isWordPuzzle,
+        activeTutorialFoilStones,
+        img, //stone image as tutorial needs a copy of the image for rendering.
+        levelData: this.levelData,
+        targetText: this.correctTargetStone, //correct target letter or word. 
+      });
+    }
   }
 
   /**

--- a/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
+++ b/src/gamepuzzles/puzzleHandler/puzzleHandler.ts
@@ -147,7 +147,10 @@ export default class PuzzleHandler {
 
       gameStateService.publish(
         gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
-        droppedLettersCount
+        {
+          droppedLettersCount, //Used for prompt highlight display text logic.
+          droppedHistory //Used for word puzzle tutorial.
+        }
       );
 
       ctx.lettersCountRef.value++;

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.spec.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.spec.ts
@@ -1,62 +1,70 @@
 import WordPuzzleTutorial from './WordPuzzleTutorial';
 import gameStateService from '@gameStateService';
+import { StoneConfig } from '@common';;
 
-describe('WordPuzzleTutorial', () => {
+describe('WordPuzzleTutorial.getNextLetterIndex', () => {
+  const context = {} as CanvasRenderingContext2D;
+  const stoneImg = {} as CanvasImageSource;
+
+  const stonePositions = [
+    { text: 'A' },
+    { text: 'P' },
+    { text: 'P' },
+    { text: 'L' },
+    { text: 'E' }
+  ] as any;
+
   let tutorial: WordPuzzleTutorial;
-  const mockContext = {} as CanvasRenderingContext2D;
-  const dummyStoneImg = new Image();
-  const stonePositions = [[10, 10], [20, 20], [30, 30]];
-  const levelData = {
-    puzzles: [
-      {
-        targetStones: ['A', 'B', 'C'],
-        foilStones: ['A', 'B', 'C']
-      }
-    ]
-  };
-
-  let capturedCallback: (count: number) => void;
 
   beforeEach(() => {
-    // Mock the gameStateService.subscribe function
-    jest.spyOn(gameStateService, 'subscribe').mockImplementation((event, cb) => {
-      if (event === gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT) {
-        capturedCallback = cb;
-      }
-      return jest.fn(); // return dummy unsubscribe
-    });
-
+    // Mock getHitBoxRanges so updateTargetStonePositions in constructor doesn't crash
     jest.spyOn(gameStateService, 'getHitBoxRanges').mockReturnValue({
       hitboxRangeX: { from: 100, to: 200 },
       hitboxRangeY: { from: 300, to: 400 }
     });
 
     tutorial = new WordPuzzleTutorial({
-      context: mockContext,
-      width: 300,
-      height: 300,
-      stoneImg: dummyStoneImg,
+      context,
+      width: 1080,
+      height: 1920,
+      stoneImg,
       stonePositions,
-      levelData
-    });
-
-    jest.spyOn(tutorial as any, 'updateTargetStonePositions').mockReturnValue({
-      animateImagePosVal: { x: 0, y: 0, dx: 1, dy: 1, absdx: 1, absdy: 1 },
-      startX: 0,
-      startY: 0,
-      endX: 100,
-      endY: 100,
-      monsterStoneDifference: 100
+      targetText: 'APPLE'
     });
   });
 
-  it('should reinitialize animation on WORD_PUZZLE_SUBMITTED_LETTERS_COUNT event', () => {
-    const spy = jest.spyOn(tutorial as any, 'initializeStoneAnimation');
+  it('returns first letter index when droppedHistory is empty', () => {
+    const index = (tutorial as any).getNextLetterIndex(
+      'APPLE',
+      stonePositions,
+      {}
+    );
 
-    // Simulate event trigger
-    capturedCallback(4); // 4 % 3 = 1
+    expect(index).toBe(0);
+  });
 
-    expect((tutorial as any).currentStoneIndex).toBe(1);
-    expect(spy).toHaveBeenCalledWith(1);
+  it('returns second P when one P is already dropped', () => {
+    const index = (tutorial as any).getNextLetterIndex(
+      'APPLE',
+      stonePositions,
+      { 1: 'P' }
+    );
+
+    expect(index).toBe(2);
+  });
+
+  it('returns last letter when previous letters are dropped', () => {
+    const index = (tutorial as any).getNextLetterIndex(
+      'APPLE',
+      stonePositions,
+      {
+        0: 'A',
+        1: 'P',
+        2: 'P',
+        3: 'L'
+      }
+    );
+
+    expect(index).toBe(4);
   });
 });

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.spec.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.spec.ts
@@ -1,6 +1,5 @@
 import WordPuzzleTutorial from './WordPuzzleTutorial';
 import gameStateService from '@gameStateService';
-import { StoneConfig } from '@common';;
 
 describe('WordPuzzleTutorial.getNextLetterIndex', () => {
   const context = {} as CanvasRenderingContext2D;

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -157,5 +157,8 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     this.nextLetterIndex = 0;
     this.pauseWordTutorialRendering = false;
     this.unsubscribeSubmittedLettersCountHandler();
+
+    //Call the base class dispose to remove hand pointer.
+    super.dispose();
   }
 }

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -44,14 +44,18 @@ export default class WordPuzzleTutorial extends TutorialComponent {
 
     this.unsubscribeSubmittedLettersCountHandler = gameStateService.subscribe(
       gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
-      ({ droppedHistory } : {
-        droppedHistory: { [key: number]: string }
-      }) => {
-        //Get the index of the next stone letter from stonePositions array.
-        this.nextLetterIndex = this.getNextLetterIndex(targetText, this.stonePositions, droppedHistory);
-        this.initializeStoneAnimation(this.stonePositions[this.nextLetterIndex]);
+      (eventData) => {
+        this.handleNextWordLetter(eventData);
       }
     )
+  }
+
+  private handleNextWordLetter({ droppedHistory } : {
+    droppedHistory: { [key: number]: string }
+  }): void {
+    //Get the index of the next stone letter from stonePositions array.
+    this.nextLetterIndex = this.getNextLetterIndex(this.targetText, this.stonePositions, droppedHistory);
+    this.initializeStoneAnimation(this.stonePositions[this.nextLetterIndex]);
   }
 
   private getNextLetterIndex(

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -59,19 +59,30 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     stonePositions: Array<StoneConfig>,
     droppedHistory: {} | { [key:number]: string }
   ): number {
-    // 1. Find the next letter in the word that hasn't been used yet
+    // 1. Determine the next letter index based on droppedHistory
     const nextIndex = Object.keys(droppedHistory).length;
     const nextChar = word[nextIndex];
 
-    // 2. Find the first unused array entry with that letter
+    // 2. Find the first unused stone that matches the next letter
     for (let stoneArrIndex = 0; stoneArrIndex < stonePositions.length; stoneArrIndex++) {
       if (stonePositions[stoneArrIndex].text === nextChar && !(stoneArrIndex in droppedHistory)) {
-
-        //Returns the array index of the next letter.
+        // Returns the array index of the next letter
         return stoneArrIndex;
       }
     }
+
+    /**
+     * NOTE: This should almost never happen. If reached, it indicates:
+     * - The wrong parameters were submitted, or
+     * - The word and stonePositions list are misaligned.
+     * 
+     * To keep the tutorial running safely, we return a default stone index (0).
+     * This prevents runtime crashes, but the underlying level configuration is likely invalid.
+     */
+    return 0; // safe default fallback
   }
+
+
 
   /**
    * Updates the animation frame specific to WordPuzzleTutorial
@@ -113,7 +124,7 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     }
   }
 
-  public initializeStoneAnimation(foilStoneObj: any): void {
+  public initializeStoneAnimation(foilStoneObj: StoneConfig): void {
     //Pause the tutorial guide animation.
     this.pauseWordTutorialRendering = true;
 

--- a/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
+++ b/src/tutorials/WordPuzzleTutorial/WordPuzzleTutorial.ts
@@ -1,15 +1,16 @@
 import TutorialComponent from '../base-tutorial/base-tutorial-component';
 import gameStateService from '@gameStateService';
+import { StoneConfig } from '@common';
 
 export default class WordPuzzleTutorial extends TutorialComponent {
   // Animation timing properties
   private animationDuration = 1500; // 1.5 second animation same with match letter puzzle
-  private stonePositions: number[][] = [];
-  private currentStoneIndex = 0;
+  private stonePositions: Array<StoneConfig>;
+  private nextLetterIndex = 0;
   // stoneImg is declared in the base class
   private imageSize: number;
   private pauseWordTutorialRendering: boolean = false; // Track if current stone animation is complete
-
+  private targetText: string;
   private unsubscribeSubmittedLettersCountHandler: () => void;
 
   constructor({
@@ -18,14 +19,14 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     height,
     stoneImg,
     stonePositions,
-    levelData = null
+    targetText
   }: {
     context: CanvasRenderingContext2D;
     width: number;
     height: number;
     stoneImg: CanvasImageSource;
-    stonePositions: number[][];
-    levelData?: any;
+    stonePositions: Array<StoneConfig>;
+    targetText: string;
   }) {
     super(context);
 
@@ -33,40 +34,42 @@ export default class WordPuzzleTutorial extends TutorialComponent {
     this.height = height;
     this.stoneImg = stoneImg;
     this.imageSize = height / 9.5;
-    this.getFoilAndStonesFromData(stonePositions, levelData);
-    this.initializeStoneAnimation(0);
-    this.currentStoneIndex = 0;
+    this.targetText = targetText;
+    this.stonePositions = stonePositions;
+    this.nextLetterIndex = this.getNextLetterIndex(targetText, stonePositions, {});
+    this.initializeStoneAnimation(this.stonePositions[this.nextLetterIndex]);
+    
     // Always inject hand pointer on creation
     this.injectHandPointer();
 
     this.unsubscribeSubmittedLettersCountHandler = gameStateService.subscribe(
       gameStateService.EVENTS.WORD_PUZZLE_SUBMITTED_LETTERS_COUNT,
-      (droppedLettersCount: number) => {
-        this.pauseWordTutorialRendering = true;
-        this.currentStoneIndex = droppedLettersCount % this.stonePositions.length;
-        this.initializeStoneAnimation(this.currentStoneIndex);
+      ({ droppedHistory } : {
+        droppedHistory: { [key: number]: string }
+      }) => {
+        //Get the index of the next stone letter from stonePositions array.
+        this.nextLetterIndex = this.getNextLetterIndex(targetText, this.stonePositions, droppedHistory);
+        this.initializeStoneAnimation(this.stonePositions[this.nextLetterIndex]);
       }
     )
   }
 
-  private getFoilAndStonesFromData(stonePositions, levelData) {
-    // Get target stones and foil stones from level data
-    if (levelData && stonePositions?.length > 0) {
-      const currentPuzzleData = levelData.puzzles[0]; // Tutorial is always for first puzzle
-      const targetStones = currentPuzzleData.targetStones || [];
+  private getNextLetterIndex(
+    word: string,
+    stonePositions: Array<StoneConfig>,
+    droppedHistory: {} | { [key:number]: string }
+  ): number {
+    // 1. Find the next letter in the word that hasn't been used yet
+    const nextIndex = Object.keys(droppedHistory).length;
+    const nextChar = word[nextIndex];
 
-      // Get foil stones from the puzzle data
-      // Clone the foil stones array to avoid modifying the original
-      const foilStones = [...currentPuzzleData.foilStones];
+    // 2. Find the first unused array entry with that letter
+    for (let stoneArrIndex = 0; stoneArrIndex < stonePositions.length; stoneArrIndex++) {
+      if (stonePositions[stoneArrIndex].text === nextChar && !(stoneArrIndex in droppedHistory)) {
 
-      // If we have both foil stones and target stones, calculate the correct positions
-      this.stonePositions = foilStones.length > 0 && targetStones.length > 0
-        // Find the correct positions for target stones, handling duplicates
-        ? this.findTargetStonePositions(targetStones, foilStones, stonePositions)
-        // Otherwise use the provided positions directly
-        : [ ...stonePositions ];
-    } else {
-      this.stonePositions = stonePositions?.length > 0 ? [...stonePositions] : [];
+        //Returns the array index of the next letter.
+        return stoneArrIndex;
+      }
     }
   }
 
@@ -104,27 +107,23 @@ export default class WordPuzzleTutorial extends TutorialComponent {
 
       // Check if stone has reached the monster (near the end position)
       if (finalPercentage < 15) {
-        this.pauseWordTutorialRendering = true;
         // Reset position to redo the dragging tutorial
-        this.initializeStoneAnimation(this.currentStoneIndex);
+        this.initializeStoneAnimation(this.stonePositions[this.nextLetterIndex]);
       }
     }
   }
 
+  public initializeStoneAnimation(foilStoneObj: any): void {
+    //Pause the tutorial guide animation.
+    this.pauseWordTutorialRendering = true;
 
-  public initializeStoneAnimation(stoneIndex: number): void {
-    if (!this.stonePositions?.length || stoneIndex < 0 || stoneIndex >= this.stonePositions.length) {
-      return;
-    }
-
-    const position = this.stonePositions[stoneIndex];
     // Reset animation state completely
     this.frame = 0;
     this.animationStartTime = 0;
-    this.currentStoneIndex = stoneIndex;
 
     // Set up new animation positions
-    this.stonePosDetailsType = this.updateTargetStonePositions(position);
+    const {x, y} = foilStoneObj;
+    this.stonePosDetailsType = this.updateTargetStonePositions([x, y]);
 
     if (this.stonePosDetailsType) {
       this.animateImagePosVal = this.stonePosDetailsType.animateImagePosVal;
@@ -132,39 +131,15 @@ export default class WordPuzzleTutorial extends TutorialComponent {
       this.y = this.animateImagePosVal.y;
     }
 
+    //Resume the tutorial guide animation.
     this.pauseWordTutorialRendering = false;
-  }
-
-  /**
-   * Clean up resources when the tutorial is no longer needed
-   */
-  /**
-   * Find the correct positions for target stones, handling duplicate letters
-   * @param targetStones Array of target stone characters
-   * @param foilStones Array of all stone characters including targets
-   * @param positions Array of positions for all stones
-   * @returns Array of positions for target stones in order
-   */
-  private findTargetStonePositions(targetStones: string[], foilStones: string[], positions: number[][]): number[][] {
-    const usedIndices = new Set<number>();
-    return targetStones.map(targetChar => {
-      // Find the index of the first unused occurrence of this character
-      const targetIndex = foilStones.findIndex((stone, index) => 
-        stone === targetChar && !usedIndices.has(index)
-      );
-      if (targetIndex !== -1) {
-        usedIndices.add(targetIndex); // Mark this index as used
-        return positions[targetIndex];
-      }
-      return null; // Handle case where character isn't found (shouldn't happen)
-    }).filter(position => position !== null); // Filter out any nulls
   }
 
   public dispose(): void {
     // Reset states
     this.frame = 0;
     this.animationStartTime = 0;
-    this.currentStoneIndex = 0;
+    this.nextLetterIndex = 0;
     this.pauseWordTutorialRendering = false;
     this.unsubscribeSubmittedLettersCountHandler();
   }

--- a/src/tutorials/base-tutorial/base-tutorial-component.ts
+++ b/src/tutorials/base-tutorial/base-tutorial-component.ts
@@ -475,6 +475,11 @@ export default class TutorialComponent {
 
   /**
    * Default dispose method for all tutorials. Subclasses can override for custom cleanup.
+    * Note:
+    * - For most tutorials (like Letter or Match Letter), this is the only dispose needed,
+    *   as they only handle simple animation rendering.
+    * - WordPuzzleTutorial must call `super.dispose()` in its override because it subscribes
+    *   to additional events that need proper cleanup, beyond just removing the hand-pointer DOM element.
    */
   public dispose() {
     this.removeHandPointer();

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -3,7 +3,7 @@ import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPu
 import WordPuzzleTutorial from './WordPuzzleTutorial/WordPuzzleTutorial';
 import AudioPuzzleTutorial from './AudioPuzzleTutorial/AudioPuzzleTutorial';
 import gameStateService from '@gameStateService';
-import { getGameTypeName, isGameTypeAudio, TimeoutRegistry } from '@common';
+import { getGameTypeName, isGameTypeAudio, TimeoutRegistry, StoneConfig } from '@common';
 import { TimerId } from '@services/scheduler';
 
 type TutorialInitParams = {
@@ -69,34 +69,43 @@ export default class TutorialHandler {
       this.unsubscribeStoneCreationEvent = gameStateService.subscribe(
         gameStateService.EVENTS.CORRECT_STONE_POSITION,
         (eventData: {
-          stonePosVal: number[], //single stone position for non-word puzzles.
-          allStonePosVal: number[][], //all stone positions.
+          isWordPuzzle: boolean,
+          activeTutorialFoilStones: Array<StoneConfig>,
+          targetText: string,
           img: any,
           levelData: any
         }) => {
-          this.isWordPuzzle = eventData.levelData?.levelMeta?.levelType === 'Word';
-
+          const {
+            isWordPuzzle, 
+            targetText,
+            levelData,
+            img,
+            activeTutorialFoilStones
+          } = eventData;
           // Get game type from level data
           const gameTypeName = getGameTypeName(
-            eventData.levelData.levelMeta.protoType,
-            eventData.levelData.levelMeta.levelType
+            levelData.levelMeta.protoType,
+            levelData.levelMeta.levelType
           );
           this.gameTypeName = gameTypeName; // Store for later use
 
           // Get the game level
-          const gameLevel = Number(eventData.levelData.levelNumber);
+          const gameLevel = Number(levelData.levelNumber);
 
           // Only create tutorial if the game type hasn't been cleared yet
           if (!this.gameTypesList[gameTypeName]?.isCleared) {
+
             //If this.isWordPuzzle is true, use the allStonePosVal; Otherwise use the stone poition value for non-word/spelling game types.
-            const stonePosVal = this.isWordPuzzle ? eventData.allStonePosVal : eventData.stonePosVal
+            const stonePosVal: any = isWordPuzzle 
+            ? activeTutorialFoilStones 
+            : this.getLetterCoordinates(activeTutorialFoilStones[0]); //Pass the first and single element of arr.
 
             this.activeTutorial = this.createTutorialInstance({
               gameLevel,
               stonePosVal,
-              img: eventData.img,
+              img,
               gameTypeName,
-              levelData: eventData.levelData
+              targetText
             });
           }
         }
@@ -115,6 +124,12 @@ export default class TutorialHandler {
           gameStateService.setClearedTutorial(this.gameTypeName);
       });
     }
+  }
+
+  private getLetterCoordinates(foilStone: StoneConfig): number[] {
+    const { x, y } = foilStone;
+
+    return [x, y];
   }
 
   /**
@@ -181,13 +196,20 @@ export default class TutorialHandler {
     this.tutorialElapsedTime = 0;
   }
 
-  private createTutorialInstance({ gameLevel, stonePosVal, img, gameTypeName, levelData = null }: {
+  private createTutorialInstance({
+    gameLevel,
+    stonePosVal,
+    img,
+    gameTypeName,
+    targetText
+  }: {
     gameLevel: number,
-    stonePosVal: number[] | number[][],
-    img: CanvasImageSource,
+    stonePosVal: number[] | Array<StoneConfig>,
+    img: any,
     gameTypeName: string,
-    levelData?: any
-  }) {
+    targetText: string
+  }
+) {
     // Create quick start tutorial
     this.quickTutorial = new QuickStartTutorial({ context: this.context });
     // Only create tutorial if this is the correct level for this game type
@@ -221,12 +243,12 @@ export default class TutorialHandler {
           width: this.width,
           height: this.height,
           stoneImg: img,
-          stonePositions: stonePosVal as number[][],
-          levelData: levelData
+          stonePositions: stonePosVal as Array<StoneConfig>,
+          targetText
         });
       }
 
-      //Add more if conditions here for new tutorial instances.
+      //Note: Add more if conditions here for new tutorial instances.
     }
 
     return null;

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -69,6 +69,8 @@ export default class TutorialHandler {
       this.unsubscribeStoneCreationEvent = gameStateService.subscribe(
         gameStateService.EVENTS.CORRECT_STONE_POSITION,
         (eventData) => {
+          // NOTE: This handler is invoked only once at the start of gameplay
+          // when the CORRECT_STONE_POSITION event is initially emitted.
           this.handleTutorialCreationOnCorrectStone(eventData);
         }
       );

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -75,6 +75,9 @@ export default class TutorialHandler {
           img: any,
           levelData: any
         }) => {
+          // Quick return if no stones available — prevents creating invalid tutorial
+          if (!eventData?.activeTutorialFoilStones || eventData?.activeTutorialFoilStones.length === 0) return;
+
           const {
             isWordPuzzle, 
             targetText,
@@ -82,6 +85,7 @@ export default class TutorialHandler {
             img,
             activeTutorialFoilStones
           } = eventData;
+          
           // Get game type from level data
           const gameTypeName = getGameTypeName(
             levelData.levelMeta.protoType,

--- a/src/tutorials/index.ts
+++ b/src/tutorials/index.ts
@@ -68,50 +68,8 @@ export default class TutorialHandler {
 
       this.unsubscribeStoneCreationEvent = gameStateService.subscribe(
         gameStateService.EVENTS.CORRECT_STONE_POSITION,
-        (eventData: {
-          isWordPuzzle: boolean,
-          activeTutorialFoilStones: Array<StoneConfig>,
-          targetText: string,
-          img: any,
-          levelData: any
-        }) => {
-          // Quick return if no stones available — prevents creating invalid tutorial
-          if (!eventData?.activeTutorialFoilStones || eventData?.activeTutorialFoilStones.length === 0) return;
-
-          const {
-            isWordPuzzle, 
-            targetText,
-            levelData,
-            img,
-            activeTutorialFoilStones
-          } = eventData;
-          
-          // Get game type from level data
-          const gameTypeName = getGameTypeName(
-            levelData.levelMeta.protoType,
-            levelData.levelMeta.levelType
-          );
-          this.gameTypeName = gameTypeName; // Store for later use
-
-          // Get the game level
-          const gameLevel = Number(levelData.levelNumber);
-
-          // Only create tutorial if the game type hasn't been cleared yet
-          if (!this.gameTypesList[gameTypeName]?.isCleared) {
-
-            //If this.isWordPuzzle is true, use the allStonePosVal; Otherwise use the stone poition value for non-word/spelling game types.
-            const stonePosVal: any = isWordPuzzle 
-            ? activeTutorialFoilStones 
-            : this.getLetterCoordinates(activeTutorialFoilStones[0]); //Pass the first and single element of arr.
-
-            this.activeTutorial = this.createTutorialInstance({
-              gameLevel,
-              stonePosVal,
-              img,
-              gameTypeName,
-              targetText
-            });
-          }
+        (eventData) => {
+          this.handleTutorialCreationOnCorrectStone(eventData);
         }
       );
 
@@ -134,6 +92,52 @@ export default class TutorialHandler {
     const { x, y } = foilStone;
 
     return [x, y];
+  }
+
+  private handleTutorialCreationOnCorrectStone(eventData: {
+    isWordPuzzle: boolean,
+    activeTutorialFoilStones: Array<StoneConfig>,
+    targetText: string,
+    img: any,
+    levelData: any
+  }): void {
+    // Quick return if no stones available — prevents creating invalid tutorial
+    if (!eventData?.activeTutorialFoilStones || eventData?.activeTutorialFoilStones.length === 0) return;
+    
+    const {
+      isWordPuzzle, 
+      targetText,
+      levelData,
+      img,
+      activeTutorialFoilStones
+    } = eventData;
+          
+    // Get game type from level data
+    const gameTypeName = getGameTypeName(
+      levelData.levelMeta.protoType,
+      levelData.levelMeta.levelType
+    );
+    this.gameTypeName = gameTypeName; // Store for later use
+
+    // Get the game level
+    const gameLevel = Number(levelData.levelNumber);
+
+    // Only create tutorial if the game type hasn't been cleared yet
+    if (!this.gameTypesList[gameTypeName]?.isCleared) {
+
+      //If this.isWordPuzzle is true, use the allStonePosVal; Otherwise use the stone poition value for non-word/spelling game types.
+      const stonePosVal: any = isWordPuzzle 
+        ? activeTutorialFoilStones 
+        : this.getLetterCoordinates(activeTutorialFoilStones[0]); //Pass the first and single element of arr.
+
+      this.activeTutorial = this.createTutorialInstance({
+        gameLevel,
+        stonePosVal,
+        img,
+        gameTypeName,
+        targetText
+      });
+    }
   }
 
   /**

--- a/src/tutorials/tutorial-handler.spec.ts
+++ b/src/tutorials/tutorial-handler.spec.ts
@@ -1,107 +1,107 @@
-// import TutorialHandler from './index';
-// import QuickStartTutorial from './QuickStartTutorial/QuickStartTutorial';
-// import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial';
-// import gameStateService from '@gameStateService';
+import TutorialHandler from './index';
+import QuickStartTutorial from './QuickStartTutorial/QuickStartTutorial';
+import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial';
+import gameStateService from '@gameStateService';
 
-// jest.mock('./QuickStartTutorial/QuickStartTutorial');
-// jest.mock('./MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial');
-// jest.mock('@gameStateService', () => ({
-//   EVENTS: {
-//     CORRECT_STONE_POSITION: 'correctStone',
-//     GAME_PAUSE_STATUS_EVENT: 'pauseStatus'
-//   },
-//   subscribe: jest.fn(),
-//   getGameTypeList: jest.fn(() => ({
-//     LetterInWord: 0,
-//     LetterOnly: 1,
-//     SoundLetterOnly: 2,
-//     Word: 3
-//   }))
-// }));
+jest.mock('./QuickStartTutorial/QuickStartTutorial');
+jest.mock('./MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial');
+jest.mock('@gameStateService', () => ({
+  EVENTS: {
+    CORRECT_STONE_POSITION: 'correctStone',
+    GAME_PAUSE_STATUS_EVENT: 'pauseStatus'
+  },
+  subscribe: jest.fn(),
+  getGameTypeList: jest.fn(() => ({
+    LetterInWord: 0,
+    LetterOnly: 1,
+    SoundLetterOnly: 2,
+    Word: 3
+  }))
+}));
 
-// describe('TutorialHandler', () => {
-//   const mockContext = {} as CanvasRenderingContext2D;
+describe('TutorialHandler', () => {
+  const mockContext = {} as CanvasRenderingContext2D;
 
-//   beforeEach(() => {
-//     jest.clearAllMocks();
-//   });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
-//   it('should initialize and subscribe to events if puzzleLevel is 0 and shouldHaveTutorial is true', () => {
-//     const handler = new TutorialHandler({
-//       context: mockContext,
-//       width: 800,
-//       height: 600,
-//       puzzleLevel: 0,
-//       shouldHaveTutorial: true // <-- Important
-//     });
+  it('should initialize and subscribe to events if puzzleLevel is 0 and shouldHaveTutorial is true', () => {
+    const handler = new TutorialHandler({
+      context: mockContext,
+      width: 800,
+      height: 600,
+      puzzleLevel: 0,
+      shouldHaveTutorial: true // <-- Important
+    });
 
-//     expect(gameStateService.subscribe).toHaveBeenCalledTimes(3);
-//     expect(gameStateService.getGameTypeList).toHaveBeenCalled();
-//   });
+    expect(gameStateService.subscribe).toHaveBeenCalledTimes(3);
+    expect(gameStateService.getGameTypeList).toHaveBeenCalled();
+  });
 
-//   it('should not subscribe if puzzleLevel is not 0', () => {
-//     const handler = new TutorialHandler({
-//       context: mockContext,
-//       width: 800,
-//       height: 600,
-//       puzzleLevel: 2
-//     });
+  it('should not subscribe if puzzleLevel is not 0', () => {
+    const handler = new TutorialHandler({
+      context: mockContext,
+      width: 800,
+      height: 600,
+      puzzleLevel: 2
+    });
 
-//     expect(gameStateService.subscribe).not.toHaveBeenCalled();
-//   });
+    expect(gameStateService.subscribe).not.toHaveBeenCalled();
+  });
 
-//   it('should hide tutorial and increment puzzleLevel', () => {
-//     const handler = new TutorialHandler({
-//       context: mockContext,
-//       width: 800,
-//       height: 600,
-//       puzzleLevel: 0
-//     });
+  it('should hide tutorial and increment puzzleLevel', () => {
+    const handler = new TutorialHandler({
+      context: mockContext,
+      width: 800,
+      height: 600,
+      puzzleLevel: 0
+    });
 
-//     (handler as any).activeTutorial = {
-//       dispose: jest.fn()
-//     } as unknown as MatchLetterPuzzleTutorial;
-//     handler.hideTutorial();
+    (handler as any).activeTutorial = {
+      dispose: jest.fn()
+    } as unknown as MatchLetterPuzzleTutorial;
+    handler.hideTutorial();
 
-//     expect((handler as any).activeTutorial).toBeNull();
-//     expect((handler as any).puzzleLevel).toBe(1);
-//   });
+    expect((handler as any).activeTutorial).toBeNull();
+    expect((handler as any).puzzleLevel).toBe(1);
+  });
 
-//   it('should draw quick start if game hasn’t started', () => {
-//     const handler = new TutorialHandler({
-//       context: mockContext,
-//       width: 800,
-//       height: 600,
-//       puzzleLevel: 0
-//     });
+  it('should draw quick start if game hasn’t started', () => {
+    const handler = new TutorialHandler({
+      context: mockContext,
+      width: 800,
+      height: 600,
+      puzzleLevel: 0
+    });
 
-//     const quickTutorialInstance = {
-//       quickStartTutorial: jest.fn()
-//     };
-//     (handler as any).quickTutorial = quickTutorialInstance;
+    const quickTutorialInstance = {
+      quickStartTutorial: jest.fn()
+    };
+    (handler as any).quickTutorial = quickTutorialInstance;
 
-//     handler.drawQuickStart(0.16, false);
+    handler.drawQuickStart(0.16, false);
 
-//     expect(quickTutorialInstance.quickStartTutorial).toHaveBeenCalled();
-//   });
+    expect(quickTutorialInstance.quickStartTutorial).toHaveBeenCalled();
+  });
 
-//   it('should draw active tutorial if game has started and not paused', () => {
-//     const drawMock = jest.fn();
-//     const handler = new TutorialHandler({
-//       context: mockContext,
-//       width: 800,
-//       height: 600,
-//       puzzleLevel: 0
-//     });
+  it('should draw active tutorial if game has started and not paused', () => {
+    const drawMock = jest.fn();
+    const handler = new TutorialHandler({
+      context: mockContext,
+      width: 800,
+      height: 600,
+      puzzleLevel: 0
+    });
 
-//     (handler as any).activeTutorial = {
-//       drawTutorial: drawMock
-//     };
-//     (handler as any).isGameOnPause = false;
-//     (handler as any).hasGameEnded = false;
+    (handler as any).activeTutorial = {
+      drawTutorial: drawMock
+    };
+    (handler as any).isGameOnPause = false;
+    (handler as any).hasGameEnded = false;
 
-//     handler.draw(0.16, true);
+    handler.draw(0.16, true);
 
-//     expect(drawMock).toHaveBeenCalledWith(0.16);
-//   });
-// });
+    expect(drawMock).toHaveBeenCalledWith(0.16);
+  });
+});

--- a/src/tutorials/tutorial-handler.spec.ts
+++ b/src/tutorials/tutorial-handler.spec.ts
@@ -1,107 +1,107 @@
-import TutorialHandler from './index';
-import QuickStartTutorial from './QuickStartTutorial/QuickStartTutorial';
-import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial';
-import gameStateService from '@gameStateService';
+// import TutorialHandler from './index';
+// import QuickStartTutorial from './QuickStartTutorial/QuickStartTutorial';
+// import MatchLetterPuzzleTutorial from './MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial';
+// import gameStateService from '@gameStateService';
 
-jest.mock('./QuickStartTutorial/QuickStartTutorial');
-jest.mock('./MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial');
-jest.mock('@gameStateService', () => ({
-  EVENTS: {
-    CORRECT_STONE_POSITION: 'correctStone',
-    GAME_PAUSE_STATUS_EVENT: 'pauseStatus'
-  },
-  subscribe: jest.fn(),
-  getGameTypeList: jest.fn(() => ({
-    LetterInWord: 0,
-    LetterOnly: 1,
-    SoundLetterOnly: 2,
-    Word: 3
-  }))
-}));
+// jest.mock('./QuickStartTutorial/QuickStartTutorial');
+// jest.mock('./MatchLetterPuzzleTutorial/MatchLetterPuzzleTutorial');
+// jest.mock('@gameStateService', () => ({
+//   EVENTS: {
+//     CORRECT_STONE_POSITION: 'correctStone',
+//     GAME_PAUSE_STATUS_EVENT: 'pauseStatus'
+//   },
+//   subscribe: jest.fn(),
+//   getGameTypeList: jest.fn(() => ({
+//     LetterInWord: 0,
+//     LetterOnly: 1,
+//     SoundLetterOnly: 2,
+//     Word: 3
+//   }))
+// }));
 
-describe('TutorialHandler', () => {
-  const mockContext = {} as CanvasRenderingContext2D;
+// describe('TutorialHandler', () => {
+//   const mockContext = {} as CanvasRenderingContext2D;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+//   beforeEach(() => {
+//     jest.clearAllMocks();
+//   });
 
-  it('should initialize and subscribe to events if puzzleLevel is 0 and shouldHaveTutorial is true', () => {
-    const handler = new TutorialHandler({
-      context: mockContext,
-      width: 800,
-      height: 600,
-      puzzleLevel: 0,
-      shouldHaveTutorial: true // <-- Important
-    });
+//   it('should initialize and subscribe to events if puzzleLevel is 0 and shouldHaveTutorial is true', () => {
+//     const handler = new TutorialHandler({
+//       context: mockContext,
+//       width: 800,
+//       height: 600,
+//       puzzleLevel: 0,
+//       shouldHaveTutorial: true // <-- Important
+//     });
 
-    expect(gameStateService.subscribe).toHaveBeenCalledTimes(3);
-    expect(gameStateService.getGameTypeList).toHaveBeenCalled();
-  });
+//     expect(gameStateService.subscribe).toHaveBeenCalledTimes(3);
+//     expect(gameStateService.getGameTypeList).toHaveBeenCalled();
+//   });
 
-  it('should not subscribe if puzzleLevel is not 0', () => {
-    const handler = new TutorialHandler({
-      context: mockContext,
-      width: 800,
-      height: 600,
-      puzzleLevel: 2
-    });
+//   it('should not subscribe if puzzleLevel is not 0', () => {
+//     const handler = new TutorialHandler({
+//       context: mockContext,
+//       width: 800,
+//       height: 600,
+//       puzzleLevel: 2
+//     });
 
-    expect(gameStateService.subscribe).not.toHaveBeenCalled();
-  });
+//     expect(gameStateService.subscribe).not.toHaveBeenCalled();
+//   });
 
-  it('should hide tutorial and increment puzzleLevel', () => {
-    const handler = new TutorialHandler({
-      context: mockContext,
-      width: 800,
-      height: 600,
-      puzzleLevel: 0
-    });
+//   it('should hide tutorial and increment puzzleLevel', () => {
+//     const handler = new TutorialHandler({
+//       context: mockContext,
+//       width: 800,
+//       height: 600,
+//       puzzleLevel: 0
+//     });
 
-    (handler as any).activeTutorial = {
-      dispose: jest.fn()
-    } as unknown as MatchLetterPuzzleTutorial;
-    handler.hideTutorial();
+//     (handler as any).activeTutorial = {
+//       dispose: jest.fn()
+//     } as unknown as MatchLetterPuzzleTutorial;
+//     handler.hideTutorial();
 
-    expect((handler as any).activeTutorial).toBeNull();
-    expect((handler as any).puzzleLevel).toBe(1);
-  });
+//     expect((handler as any).activeTutorial).toBeNull();
+//     expect((handler as any).puzzleLevel).toBe(1);
+//   });
 
-  it('should draw quick start if game hasn’t started', () => {
-    const handler = new TutorialHandler({
-      context: mockContext,
-      width: 800,
-      height: 600,
-      puzzleLevel: 0
-    });
+//   it('should draw quick start if game hasn’t started', () => {
+//     const handler = new TutorialHandler({
+//       context: mockContext,
+//       width: 800,
+//       height: 600,
+//       puzzleLevel: 0
+//     });
 
-    const quickTutorialInstance = {
-      quickStartTutorial: jest.fn()
-    };
-    (handler as any).quickTutorial = quickTutorialInstance;
+//     const quickTutorialInstance = {
+//       quickStartTutorial: jest.fn()
+//     };
+//     (handler as any).quickTutorial = quickTutorialInstance;
 
-    handler.drawQuickStart(0.16, false);
+//     handler.drawQuickStart(0.16, false);
 
-    expect(quickTutorialInstance.quickStartTutorial).toHaveBeenCalled();
-  });
+//     expect(quickTutorialInstance.quickStartTutorial).toHaveBeenCalled();
+//   });
 
-  it('should draw active tutorial if game has started and not paused', () => {
-    const drawMock = jest.fn();
-    const handler = new TutorialHandler({
-      context: mockContext,
-      width: 800,
-      height: 600,
-      puzzleLevel: 0
-    });
+//   it('should draw active tutorial if game has started and not paused', () => {
+//     const drawMock = jest.fn();
+//     const handler = new TutorialHandler({
+//       context: mockContext,
+//       width: 800,
+//       height: 600,
+//       puzzleLevel: 0
+//     });
 
-    (handler as any).activeTutorial = {
-      drawTutorial: drawMock
-    };
-    (handler as any).isGameOnPause = false;
-    (handler as any).hasGameEnded = false;
+//     (handler as any).activeTutorial = {
+//       drawTutorial: drawMock
+//     };
+//     (handler as any).isGameOnPause = false;
+//     (handler as any).hasGameEnded = false;
 
-    handler.draw(0.16, true);
+//     handler.draw(0.16, true);
 
-    expect(drawMock).toHaveBeenCalledWith(0.16);
-  });
-});
+//     expect(drawMock).toHaveBeenCalledWith(0.16);
+//   });
+// });


### PR DESCRIPTION
# Changes
- Updated stone-handler.ts to pass the full foil stone objects to the tutorial instead of just coordinate arrays, allowing each stone to have a unique identifier.
- Refactored the Word Puzzle tutorial logic: it now accepts the foil stone objects and properly tracks dropped letters using the `droppedHistory` object. This ensures the correct letter is animated, even for duplicates, and preserves the fixed ordered sequence.
- Added `droppedHistory` tracking for the WORD_PUZZLE_SUBMITTED_LETTERS_COUNT event in `puzzle-handler.ts`.


# How to test
- Run `npm run build` then followed by `npm run dev`
- In the local URL add `/?cr_lang=Azerbaijani`
- After the FTM loads up; enable dev and press anywhere on the start screen.
- Select level 10 for word puzzle  or 12 for sound word puzzle.
- In the first segment of the level, tutorial would show a guide which letter to drag.
- If there are duplicate letters of the word, the tutorial should still be able to show the unused letter for the dragging animation.

Ref: [FM-643](https://curiouslearning.atlassian.net/browse/FM-643)


[FM-643]: https://curiouslearning.atlassian.net/browse/FM-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved prompt highlighting to reflect submitted letters and history more accurately.

* **Bug Fixes**
  * Enhanced tutorial guidance and consistent correct-stone highlighting for word and non-word puzzles.
  * Fixed tutorial timing so cues are published after stones are created, reducing inconsistent behavior.

* **Tests**
  * Updated tutorial unit tests to cover next-letter selection and dropped-history scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->