### PR TITLE
fix: [FM-875] Fix assessment asset paths for FTM subpath deployments

### DIFF
--- a/src/assessment/assessment-asset-path.ts
+++ b/src/assessment/assessment-asset-path.ts
@@ -1,0 +1,36 @@
+const ASSESSMENT_ASSET_DIRECTORY = 'assessment-survey';
+
+function normalizeAppBasePath(pathname: string): string {
+  const normalizedPathname = (pathname || '/').trim() || '/';
+
+  if (normalizedPathname === '/') {
+    return '/';
+  }
+
+  if (normalizedPathname.endsWith('/')) {
+    return normalizedPathname;
+  }
+
+  if (/\.[a-z0-9]+$/i.test(normalizedPathname)) {
+    return normalizedPathname.replace(/[^/]*$/, '');
+  }
+
+  return `${normalizedPathname}/`;
+}
+
+function joinPath(basePath: string, relativePath: string): string {
+  const normalizedBasePath = basePath === '/' ? '' : basePath.replace(/\/+$/, '');
+  const normalizedRelativePath = relativePath.replace(/^\/+/, '');
+  return `${normalizedBasePath}/${normalizedRelativePath}`;
+}
+
+export function getAssessmentBasePath(pathname: string = window.location.pathname): string {
+  return joinPath(normalizeAppBasePath(pathname), ASSESSMENT_ASSET_DIRECTORY);
+}
+
+export function buildAssessmentAssetPath(
+  relativePath: string,
+  pathname: string = window.location.pathname
+): string {
+  return joinPath(getAssessmentBasePath(pathname), relativePath);
+}

--- a/src/assessment/assessment-data-key.ts
+++ b/src/assessment/assessment-data-key.ts
@@ -1,3 +1,5 @@
+import { buildAssessmentAssetPath } from './assessment-asset-path';
+
 const DEFAULT_ASSESSMENT_DATA_KEY = 'zulu-lettersounds';
 
 const languageAliasMap: Record<string, string> = {
@@ -53,7 +55,7 @@ export function deriveAssessmentDataKeyFromUrl(search: string): string {
 
 export async function hasAssessmentData(dataKey: string): Promise<boolean> {
   try {
-    const response = await fetch(`/assessment-survey/data/${dataKey}.json`, {
+    const response = await fetch(buildAssessmentAssetPath(`data/${dataKey}.json`), {
       method: 'HEAD',
       cache: 'no-store',
     });

--- a/src/assessment/assessment-survey-manager.spec.ts
+++ b/src/assessment/assessment-survey-manager.spec.ts
@@ -145,6 +145,26 @@ describe('AssessmentSurveyManager', () => {
     expect(MockBroadcastChannel.postMessageCalls).toBe(1);
   });
 
+  it('should scope assessment asset urls to the deployed app base path', async () => {
+    window.history.pushState({}, '', '/feed-the-monster/index.html?cr_lang=englishwestafrican&assessment_type=words');
+
+    setHeadResponseMap({
+      '/feed-the-monster/assessment-survey/data/west-african-english-words.json': true,
+    });
+
+    await manager.open({});
+
+    const overlay = document.getElementById('assessment-survey-overlay');
+    const playerElement = overlay?.querySelector('assessment-survey-player');
+
+    expect(playerElement?.getAttribute('asset-base-url')).toBe('/feed-the-monster/assessment-survey');
+    expect(playerElement?.getAttribute('data-base-url')).toBe('/feed-the-monster/assessment-survey');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/feed-the-monster/assessment-survey/data/west-african-english-words.json',
+      expect.objectContaining({ method: 'HEAD' })
+    );
+  });
+
   it('should fallback to default assessment key when requested data key is unavailable', async () => {
     setHeadResponseMap({
       '/assessment-survey/data/missing-data-key.json': false,

--- a/src/assessment/ui/assessment-player-element.ts
+++ b/src/assessment/ui/assessment-player-element.ts
@@ -1,6 +1,7 @@
 import '@curiouslearning/assessment-survey/register';
 import { AssessmentSurveyPlayerElement, AnalyticsConfig } from '@curiouslearning/assessment-survey';
 import { ASSESSMENT_SKIP_BTN } from '@constants';
+import { getAssessmentBasePath } from '../assessment-asset-path';
 
 export interface AssessmentPlayerElementOptions {
   playerTag: string;
@@ -23,6 +24,8 @@ export interface AssessmentSkipButtonOptions {
 
 export function createAssessmentPlayerElement(options: AssessmentPlayerElementOptions): AssessmentSurveyPlayerElement {
   const playerElement = document.createElement(options.playerTag) as AssessmentSurveyPlayerElement;
+  const assessmentBasePath = getAssessmentBasePath();
+
   playerElement.style.display = 'block';
   playerElement.style.width = '100%';
   playerElement.style.height = '100%';
@@ -30,8 +33,8 @@ export function createAssessmentPlayerElement(options: AssessmentPlayerElementOp
   playerElement.setAttribute('data-key', options.dataKey);
   playerElement.setAttribute('user-id', 'ftm-web-user');
   playerElement.setAttribute('user-source', 'feed-the-monster-web');
-  playerElement.setAttribute('asset-base-url', '/assessment-survey');
-  playerElement.setAttribute('data-base-url', '/assessment-survey');
+  playerElement.setAttribute('asset-base-url', assessmentBasePath);
+  playerElement.setAttribute('data-base-url', assessmentBasePath);
   playerElement.setAttribute('embed-mode', 'true');
   playerElement.setAttribute('host-theme', 'ftm-dim');
 

--- a/src/sw-src.js
+++ b/src/sw-src.js
@@ -281,13 +281,23 @@ function normalizeAssessmentAudioName(data, itemName) {
   return itemName.trim();
 }
 
+function getAssessmentAssetPath(relativePath) {
+  const scopePath = self.registration?.scope
+    ? new URL(self.registration.scope).pathname
+    : self.location.pathname.replace(/[^/]*$/, '/');
+  const normalizedScopePath = scopePath.endsWith('/') ? scopePath : `${scopePath}/`;
+  const normalizedRelativePath = relativePath.replace(/^\/+/, '');
+
+  return `${normalizedScopePath}assessment-survey/${normalizedRelativePath}`;
+}
+
 async function cacheAssessmentLanguage(dataKey) {
   if (!dataKey) {
     return false;
   }
 
   const cacheName = `assessment-${dataKey}`;
-  const dataUrl = `/assessment-survey/data/${dataKey}.json`;
+  const dataUrl = getAssessmentAssetPath(`data/${dataKey}.json`);
 
   try {
     const response = await fetch(dataUrl, {
@@ -317,12 +327,12 @@ async function cacheAssessmentLanguage(dataKey) {
           if (!itemName) {
             continue;
           }
-          urlsToCache.add(`/assessment-survey/audio/${dataKey}/${itemName}.mp3`);
+          urlsToCache.add(getAssessmentAssetPath(`audio/${dataKey}/${itemName}.mp3`));
         }
       }
     }
 
-    urlsToCache.add(`/assessment-survey/audio/${dataKey}/answer_feedback.mp3`);
+    urlsToCache.add(getAssessmentAssetPath(`audio/${dataKey}/answer_feedback.mp3`));
 
     const cache = await caches.open(cacheName);
     const cacheResults = await Promise.all([...urlsToCache].map(async (url) => {
@@ -357,7 +367,7 @@ self.addEventListener("fetch", function (event) {
     requestUrl.pathname.endsWith('.json') &&
     (event.request.method === 'GET' || event.request.method === 'HEAD')
   ) {
-    const aliasedRequest = new Request(`/assessment-survey${requestUrl.pathname}${requestUrl.search}`, {
+    const aliasedRequest = new Request(getAssessmentAssetPath(`${requestUrl.pathname}${requestUrl.search}`), {
       method: event.request.method,
       headers: event.request.headers,
       mode: event.request.mode,


### PR DESCRIPTION
# Changes
- Resolve assessment asset and cache paths from the FTM app base path so embedded assessments load correctly under /feed-the-monster/.

# How to test
- Run the assessment in FTM from a simulated subpath deployment at http://127.0.0.1:8081/feed-the-monster/index.html and verify it loads successfully with requests going to /feed-the-monster/assessment-survey/....

Ref: [FM-875](https://curiouslearning.atlassian.net/browse/FM-875)


[FM-875]: https://curiouslearning.atlassian.net/browse/FM-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes (v1.5.0)

* **New Features**
  * Added assessment survey system with language-aware data caching and lifecycle management
  * Added pause/resume controls for game audio and animations
  * Added dev assessment testing button (debug mode only)

* **Bug Fixes**
  * Improved audio playback management with separate UI and gameplay audio tracks
  * Enhanced timeout and animation timing with deltaTime-based system

* **Chores**
  * Updated application version to v1.5.0
  * Configured service worker caching for assessment assets
  * Extended build tooling for assessment survey integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->