### PR TITLE
fix: FM-880 Assessment Triggering Outside Allowed Puzzles (After Puzz…

### DIFF
--- a/src/assessment/assessment-flow-coordinator.spec.ts
+++ b/src/assessment/assessment-flow-coordinator.spec.ts
@@ -30,7 +30,7 @@ class MockAssessmentLevelState {
 }
 
 describe('AssessmentFlowCoordinator', () => {
-  it('uses mini-game segment when mini-game exists inside the assessment window', () => {
+  it('uses mini-game segment when mini-game exists', () => {
     const coordinator = new AssessmentFlowCoordinator(
       {
         currentLevelIndex: 2,
@@ -70,7 +70,7 @@ describe('AssessmentFlowCoordinator', () => {
     expect(coordinator.getAssessmentPuzzleTrigger()).toBe(3);
   });
 
-  it('uses random segment from puzzles 2 through 4 when mini-game is outside the assessment window', () => {
+  it('uses mini-game segment when mini-game is outside the random assessment window', () => {
     const coordinator = new AssessmentFlowCoordinator(
       {
         currentLevelIndex: 2,
@@ -85,9 +85,29 @@ describe('AssessmentFlowCoordinator', () => {
       }
     );
 
-    expect(coordinator.getAssessmentPuzzleTrigger()).toBe(4);
-    expect(coordinator.shouldStartAssessmentAtPuzzle(4)).toBe(true);
-    expect(coordinator.shouldStartAssessmentAtPuzzle(5)).toBe(false);
+    expect(coordinator.getAssessmentPuzzleTrigger()).toBe(5);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(5)).toBe(true);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(4)).toBe(false);
+  });
+
+  it('uses mini-game segment when mini-game is on the first puzzle', () => {
+    const coordinator = new AssessmentFlowCoordinator(
+      {
+        currentLevelIndex: 2,
+        totalLevels: 20,
+        puzzleCount: 5,
+        miniGamePuzzleSegment: 1,
+        randomFn: () => 0.999,
+      },
+      {
+        levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'sightwords']])),
+        levelState: new MockAssessmentLevelState(),
+      }
+    );
+
+    expect(coordinator.getAssessmentPuzzleTrigger()).toBe(1);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(1)).toBe(true);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(2)).toBe(false);
   });
 
   it('opens assessment once per level run', () => {
@@ -119,7 +139,7 @@ describe('AssessmentFlowCoordinator', () => {
         currentLevelIndex: 2,
         totalLevels: 20,
         puzzleCount: 5,
-        miniGamePuzzleSegment: 2,
+        miniGamePuzzleSegment: 1,
       },
       {
         levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'lettersounds']])),
@@ -127,7 +147,7 @@ describe('AssessmentFlowCoordinator', () => {
       }
     );
 
-    expect(firstRun.shouldStartAssessmentAtPuzzle(2)).toBe(true);
+    expect(firstRun.shouldStartAssessmentAtPuzzle(1)).toBe(true);
 
     firstRun.startAssessment();
     firstRun.handleAssessmentCompleted();
@@ -137,7 +157,7 @@ describe('AssessmentFlowCoordinator', () => {
         currentLevelIndex: 2,
         totalLevels: 20,
         puzzleCount: 5,
-        miniGamePuzzleSegment: 2,
+        miniGamePuzzleSegment: 1,
       },
       {
         levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'lettersounds']])),
@@ -146,8 +166,8 @@ describe('AssessmentFlowCoordinator', () => {
     );
 
     expect(replayRun.isAssessmentEligibleForCurrentLevel()).toBe(true);
-    expect(replayRun.getAssessmentPuzzleTrigger()).toBe(2);
-    expect(replayRun.shouldStartAssessmentAtPuzzle(2)).toBe(true);
+    expect(replayRun.getAssessmentPuzzleTrigger()).toBe(1);
+    expect(replayRun.shouldStartAssessmentAtPuzzle(1)).toBe(true);
   });
 
   it('explicit blocked state prevents reopening', () => {

--- a/src/assessment/assessment-flow-coordinator.spec.ts
+++ b/src/assessment/assessment-flow-coordinator.spec.ts
@@ -30,7 +30,7 @@ class MockAssessmentLevelState {
 }
 
 describe('AssessmentFlowCoordinator', () => {
-  it('uses mini-game segment when mini-game exists', () => {
+  it('uses mini-game segment when mini-game exists inside the assessment window', () => {
     const coordinator = new AssessmentFlowCoordinator(
       {
         currentLevelIndex: 2,
@@ -51,7 +51,7 @@ describe('AssessmentFlowCoordinator', () => {
     expect(coordinator.shouldStartAssessmentAtPuzzle(3)).toBe(false);
   });
 
-  it('uses random segment when mini-game does not exist', () => {
+  it('uses random segment from puzzles 2 through 4 when mini-game does not exist', () => {
     const coordinator = new AssessmentFlowCoordinator(
       {
         currentLevelIndex: 2,
@@ -67,7 +67,27 @@ describe('AssessmentFlowCoordinator', () => {
     );
 
     expect(coordinator.getAssessmentTypeForCurrentLevel()).toBe('sightwords');
+    expect(coordinator.getAssessmentPuzzleTrigger()).toBe(3);
+  });
+
+  it('uses random segment from puzzles 2 through 4 when mini-game is outside the assessment window', () => {
+    const coordinator = new AssessmentFlowCoordinator(
+      {
+        currentLevelIndex: 2,
+        totalLevels: 20,
+        puzzleCount: 5,
+        miniGamePuzzleSegment: 5,
+        randomFn: () => 0.999,
+      },
+      {
+        levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'sightwords']])),
+        levelState: new MockAssessmentLevelState(),
+      }
+    );
+
     expect(coordinator.getAssessmentPuzzleTrigger()).toBe(4);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(4)).toBe(true);
+    expect(coordinator.shouldStartAssessmentAtPuzzle(5)).toBe(false);
   });
 
   it('opens assessment once per level run', () => {
@@ -99,7 +119,7 @@ describe('AssessmentFlowCoordinator', () => {
         currentLevelIndex: 2,
         totalLevels: 20,
         puzzleCount: 5,
-        miniGamePuzzleSegment: 1,
+        miniGamePuzzleSegment: 2,
       },
       {
         levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'lettersounds']])),
@@ -107,7 +127,7 @@ describe('AssessmentFlowCoordinator', () => {
       }
     );
 
-    expect(firstRun.shouldStartAssessmentAtPuzzle(1)).toBe(true);
+    expect(firstRun.shouldStartAssessmentAtPuzzle(2)).toBe(true);
 
     firstRun.startAssessment();
     firstRun.handleAssessmentCompleted();
@@ -117,7 +137,7 @@ describe('AssessmentFlowCoordinator', () => {
         currentLevelIndex: 2,
         totalLevels: 20,
         puzzleCount: 5,
-        miniGamePuzzleSegment: 1,
+        miniGamePuzzleSegment: 2,
       },
       {
         levelConfig: new MockAssessmentLevelConfig(new Map([[2, 'lettersounds']])),
@@ -126,8 +146,8 @@ describe('AssessmentFlowCoordinator', () => {
     );
 
     expect(replayRun.isAssessmentEligibleForCurrentLevel()).toBe(true);
-    expect(replayRun.getAssessmentPuzzleTrigger()).toBe(1);
-    expect(replayRun.shouldStartAssessmentAtPuzzle(1)).toBe(true);
+    expect(replayRun.getAssessmentPuzzleTrigger()).toBe(2);
+    expect(replayRun.shouldStartAssessmentAtPuzzle(2)).toBe(true);
   });
 
   it('explicit blocked state prevents reopening', () => {

--- a/src/assessment/assessment-flow-coordinator.ts
+++ b/src/assessment/assessment-flow-coordinator.ts
@@ -164,6 +164,14 @@ export class AssessmentFlowCoordinator {
       return 0;
     }
 
+    if (
+      Number.isInteger(this.miniGamePuzzleSegment)
+      && this.miniGamePuzzleSegment >= 1
+      && this.miniGamePuzzleSegment <= this.puzzleCount
+    ) {
+      return this.miniGamePuzzleSegment;
+    }
+
     const firstAssessmentPuzzleSegment = Math.min(
       MIN_ASSESSMENT_PUZZLE_SEGMENT,
       this.puzzleCount
@@ -172,14 +180,6 @@ export class AssessmentFlowCoordinator {
       MAX_ASSESSMENT_PUZZLE_SEGMENT,
       this.puzzleCount
     );
-
-    if (
-      Number.isInteger(this.miniGamePuzzleSegment)
-      && this.miniGamePuzzleSegment >= firstAssessmentPuzzleSegment
-      && this.miniGamePuzzleSegment <= lastAssessmentPuzzleSegment
-    ) {
-      return this.miniGamePuzzleSegment;
-    }
 
     const boundedRandom = Math.min(0.999999, Math.max(0, this.randomFn()));
     const assessmentPuzzleRange =

--- a/src/assessment/assessment-flow-coordinator.ts
+++ b/src/assessment/assessment-flow-coordinator.ts
@@ -3,6 +3,9 @@ import { AssessmentLevelState } from './assessment-level-state';
 
 type RandomFn = () => number;
 
+const MIN_ASSESSMENT_PUZZLE_SEGMENT = 2;
+const MAX_ASSESSMENT_PUZZLE_SEGMENT = 4;
+
 interface AssessmentLevelConfigLike {
   shouldShowAtLevel(levelIndex: number, totalLevels: number, refresh?: boolean): boolean;
   getTargetLevelIndexes?(totalLevels: number, refresh?: boolean): number[];
@@ -161,16 +164,28 @@ export class AssessmentFlowCoordinator {
       return 0;
     }
 
+    const firstAssessmentPuzzleSegment = Math.min(
+      MIN_ASSESSMENT_PUZZLE_SEGMENT,
+      this.puzzleCount
+    );
+    const lastAssessmentPuzzleSegment = Math.min(
+      MAX_ASSESSMENT_PUZZLE_SEGMENT,
+      this.puzzleCount
+    );
+
     if (
       Number.isInteger(this.miniGamePuzzleSegment)
-      && this.miniGamePuzzleSegment >= 1
-      && this.miniGamePuzzleSegment <= this.puzzleCount
+      && this.miniGamePuzzleSegment >= firstAssessmentPuzzleSegment
+      && this.miniGamePuzzleSegment <= lastAssessmentPuzzleSegment
     ) {
       return this.miniGamePuzzleSegment;
     }
 
     const boundedRandom = Math.min(0.999999, Math.max(0, this.randomFn()));
-    return Math.floor(boundedRandom * this.puzzleCount) + 1;
+    const assessmentPuzzleRange =
+      lastAssessmentPuzzleSegment - firstAssessmentPuzzleSegment + 1;
+
+    return Math.floor(boundedRandom * assessmentPuzzleRange) + firstAssessmentPuzzleSegment;
   }
 
   private resolveConfiguredAssessmentLevelIndexes(): number[] {


### PR DESCRIPTION
…le 5)

# Changes
- Changed the random triggering level in between 2- 4 

# How to test
- Navigate to the 3rd level and play the level in french language, try to replay by pausing after assessment is displayed.
- Here we can observe the Assessment appearing after the 5th puzzle is answered.

Ref: [FM-880](https://curiouslearning.atlassian.net/browse/FM-880)


[FM-880]: https://curiouslearning.atlassian.net/browse/FM-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assessment puzzle selection so randomized triggers and fallback choices align with the intended puzzle window, preventing off-by-one and out-of-range selections.
* **Tests**
  * Expanded and corrected test coverage for assessment puzzle trigger behavior across edge cases (mini-game placement at start, outside, and within the random window).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->