### PR TITLE
fix: normalized the filename of the audio assets from assessment to a…

### DIFF
--- a/src/sw-src.js
+++ b/src/sw-src.js
@@ -274,11 +274,7 @@ async function cacheFeedBackAudio(feedBackAudios, language) {
 }
 
 function normalizeAssessmentAudioName(data, itemName) {
-  const quizName = (data?.quizName || '').toLowerCase();
-  if (quizName.includes('luganda') || quizName.includes('west african english')) {
-    return itemName.toLowerCase().trim();
-  }
-  return itemName.trim();
+  return itemName.toLowerCase().trim();
 }
 
 function getAssessmentAssetPath(relativePath) {


### PR DESCRIPTION
…lways be lowercase the same with how assessment handle the filenames there

# Changes
- Fixed assessment audio files not being available offline for most languages (e.g., French) by removing the Luganda/West-African-English-only lowercase condition in the service worker's normalizeAssessmentAudioName() audio filenames are now always lowercased, matching how the assessment component requests them at runtime

# How to test
- Test FTM in offline mode

Ref: [FM-883](https://curiouslearning.atlassian.net/browse/FM-883)


[FM-883]: https://curiouslearning.atlassian.net/browse/FM-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assessment audio file handling to work consistently across all quiz types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->