### PR TITLE
feat: [FM-886] force network-first dynamic config for assessment levels with offline fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,9 +2650,9 @@
       }
     },
     "node_modules/@curiouslearning/features": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@curiouslearning/features/-/features-1.3.0.tgz",
-      "integrity": "sha512-DVwERTu1P791tR8ojQ7PgKf5b3g6vlFRgC9UyjlVv83+hy5FGiZPSGfjJ4dQFqSAe+A13HW7R7tYDGT9r/kPjA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/features/-/features-1.3.1.tgz",
+      "integrity": "sha512-OrCJM2I+o0xWBPQumaY/HhOzKRH8bme/hJvs0UPl2YazoKlp08unCh7CuJA4AyIdxlYTDVKkID0LODDZMclSSw==",
       "license": "ISC",
       "dependencies": {
         "@statsig/js-client": "^3.12.0"

--- a/src/assessment/config/assessment-level-config.ts
+++ b/src/assessment/config/assessment-level-config.ts
@@ -40,7 +40,7 @@ export class AssessmentLevelConfig {
   constructor(
     private readonly dynamicConfigKey: string = ASSESSMENT_LEVELS_CONFIG_KEY,
     private readonly configProvider: DynamicConfigProvider = (configKey: string) =>
-      featureFlagsService.getDynamicConfig(configKey)
+      featureFlagsService.getDynamicConfig(configKey, false)
   ) {}
 
   /**


### PR DESCRIPTION
# Changes
- Updated @curiouslearning/features from 1.3.0 to 1.3.1
- Assessment level config now calls getDynamicConfig(configKey, false) to bypass cache and always fetch fresh config from the network
- If the device is offline, the updated package (1.3.1) automatically falls back to the last cached value instead of returning an empty object

# How to test
- Manual: load the app online, trigger an assessment level check (config gets cached), then go offline and confirm the assessment config still resolves correctly instead of returning disabled/empty

Ref: [FM-886](https://curiouslearning.atlassian.net/browse/FM-886)


[FM-886]: https://curiouslearning.atlassian.net/browse/FM-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes v1.5.0

* **New Features**
  * Added assessment survey system with language-specific data caching for improved load performance.
  * Added assessment button to developer tools for testing.
  * Implemented audio pause/resume controls for better gameplay state management.

* **Improvements**
  * Enhanced animation timing with delta-time based system for smoother frame control.
  * Improved tutorial flow for letter-based puzzles with better stone position tracking.
  * Added service worker support for assessment data prefetching and caching.
  * Optimized game state transitions and pause/resume behavior.

* **Tests**
  * Added comprehensive test coverage for assessment and scheduler systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->