### PR TITLE
fix: [FM-882] hide the dev assessment button outside the start screen

### DIFF
--- a/src/scenes/start-scene/start-scene.spec.ts
+++ b/src/scenes/start-scene/start-scene.spec.ts
@@ -4,6 +4,7 @@ import { AnalyticsIntegration } from "../../analytics/analytics-integration";
 import { AudioPlayer } from "../../components/audio-player";
 import gameStateService from '@gameStateService';
 import gameSettingsService from '@gameSettingsService';
+import { Debugger } from '@common';
 import { SCENE_NAME_LEVEL_SELECT } from "@constants";
 import { RiveMonsterComponent } from '@components/riveMonster/rive-monster-component';
 
@@ -54,7 +55,8 @@ jest.mock('@rive-app/canvas', () => ({
 
 jest.mock('@components/riveMonster/rive-monster-component', () => ({
   RiveMonsterComponent: jest.fn().mockImplementation(() => ({
-    Rive: jest.fn().mockImplementation(() => ({}))
+    Rive: jest.fn().mockImplementation(() => ({})),
+    dispose: jest.fn()
   })),
 }));
 
@@ -63,7 +65,8 @@ let mockAnalyticsInstance: any;
 
 jest.mock("../../components/audio-player", () => ({
   AudioPlayer: jest.fn().mockImplementation(() => ({
-    playButtonClickSound: jest.fn()
+    playButtonClickSound: jest.fn(),
+    stopAllAudios: jest.fn()
   })),
 }));
 jest.mock('@gameStateService', () => ({
@@ -101,6 +104,7 @@ describe('Start Scene Test', () => {
       <div>
         <div id="title-and-play-button"></div>
         <button id="toggle-btn" class="off">Dev</button>
+        <button id="dev-assessment-btn" style="display: none;">Assessment</button>
         <div id="loading-screen" style="display: none; z-index: -1;"></div>
         <div class="game-scene"></div>
         <div id="canvas"></div>
@@ -146,6 +150,8 @@ describe('Start Scene Test', () => {
 
     (gameSettingsService.getRiveCanvasValue as jest.Mock).mockReturnValue(mockRiveCanvas);
 
+    Debugger.DebugMode = false;
+
     // Create the startScene instance
     startScene = new StartScene();
 
@@ -153,6 +159,7 @@ describe('Start Scene Test', () => {
     startScene.titleTextElement = document.getElementById('title');
     startScene.handler = document.getElementById('start-scene-click-area');
     startScene.toggleBtn = document.getElementById('toggle-btn');
+    startScene.devAssessmentBtn = document.getElementById('dev-assessment-btn');
 
     // Ensure startScene uses the mock data
     startScene.analyticsIntegration = mockAnalytics;
@@ -163,6 +170,8 @@ describe('Start Scene Test', () => {
       onClick: jest.fn((callback) => {
         mockOnClickCallback = callback;
       }),
+      dispose: jest.fn(),
+      destroy: jest.fn(),
     } as unknown as jest.Mocked<PlayButtonHtml>;
 
     // Mock PlayButtonHtml to return the mocked button
@@ -200,6 +209,26 @@ describe('Start Scene Test', () => {
       startScene.generateGameTitle();
 
       expect(titleElement.classList.contains('title-long')).toBeFalsy();
+    });
+
+    it('Should keep the assessment button hidden when debug mode is off', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
+
+    it('Should show the assessment button only when the dev toggle is enabled', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      const toggleButton = document.getElementById('toggle-btn');
+
+      Debugger.DebugMode = true;
+      toggleButton.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+      expect(assessmentButton.style.display).toEqual('block');
+
+      toggleButton.classList.remove('on');
+      startScene.syncDevAssessmentButtonVisibility();
+      expect(assessmentButton.style.display).toEqual('none');
     });
   });
 
@@ -274,7 +303,33 @@ describe('Start Scene Test', () => {
       const devBtn = document.getElementById('toggle-btn');
 
       expect(devBtn.style.display).toEqual('none');
-    })
+    });
+
+    it('Should remove the assessment button.', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      Debugger.DebugMode = true;
+      startScene.toggleBtn.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+
+      if (mockOnClickCallback) {
+        mockOnClickCallback();
+      }
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
+  });
+
+  describe('When start scene is disposed', () => {
+    it('Should hide the assessment button', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      Debugger.DebugMode = true;
+      startScene.toggleBtn.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+
+      startScene.dispose();
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
   });
 
 });

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -7,6 +7,7 @@ import { RiveMonsterComponent } from "@components/riveMonster/rive-monster-compo
 import { DataModal } from "@data";
 import {
   toggleDebugMode,
+  Debugger,
   pseudoId,
   lang
 } from "@common";
@@ -100,6 +101,7 @@ export class StartScene {
     this.handler = document.getElementById('start-scene-click-area') as HTMLBodyElement;
     this.toggleBtn.addEventListener("click", this.onToggleClick);
     this.devAssessmentBtn?.addEventListener("click", this.onDevAssessmentClick);
+    this.syncDevAssessmentButtonVisibility();
     this.createPlayButton();
     window.addEventListener("beforeinstallprompt", this.handlerInstallPrompt);
     this.setupBg();
@@ -144,8 +146,26 @@ export class StartScene {
 
   private onToggleClick = () => {
     toggleDebugMode(this.toggleBtn);
+    this.syncDevAssessmentButtonVisibility();
+  };
+
+  private syncDevAssessmentButtonVisibility = () => {
+    if (!this.devAssessmentBtn) {
+      return;
+    }
+
+    this.devAssessmentBtn.style.display = Debugger.DebugMode && this.toggleBtn.classList.contains("on")
+      ? "block"
+      : "none";
+  };
+
+  private hideStartSceneDevButtons = () => {
+    if (this.toggleBtn) {
+      this.toggleBtn.style.display = "none";
+    }
+
     if (this.devAssessmentBtn) {
-      this.devAssessmentBtn.style.display = this.toggleBtn.classList.contains("on") ? "block" : "none";
+      this.devAssessmentBtn.style.display = "none";
     }
   };
 
@@ -183,7 +203,7 @@ export class StartScene {
   createPlayButton() {
     this.playButton = new PlayButtonHtml({ targetId: 'title-and-play-button' });
     this.playButton.onClick(() => {
-      this.toggleBtn.style.display = "none";
+      this.hideStartSceneDevButtons();
       this.logTappedStartFirebaseEvent();
       this.audioPlayer.playButtonClickSound();
       gameStateService.publish(gameStateService.EVENTS.START_GAME, true);
@@ -212,12 +232,13 @@ export class StartScene {
     fbq("trackCustom", FirebaseUserClicked, {
       event: "click",
     });
-    this.toggleBtn.style.display = "none";
+    this.hideStartSceneDevButtons();
     this.audioPlayer.playButtonClickSound();
     gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_LEVEL_SELECT);
   };
 
   dispose() {
+    this.hideStartSceneDevButtons();
     this.audioPlayer.stopAllAudios();
     this.handler.removeEventListener("click", this.handleMouseClick, false);
     this.toggleBtn.removeEventListener("click", this.onToggleClick);


### PR DESCRIPTION

# Changes
- Keep the dev assessment button scoped to the start screen instead of letting it remain visible after navigating away.

# How to test
- Launch the app, enable Dev mode on the startup screen, verify the assessment button appears there, then navigate to another screen and confirm the assessment button is no longer visible.

Ref: [FM-882](https://curiouslearning.atlassian.net/browse/FM-882)


[FM-882]: https://curiouslearning.atlassian.net/browse/FM-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ