### PR TITLE
fix: [FM-890] support explicit assessment data keys for FTM assessments

### DIFF
--- a/src/assessment/assessment-survey-manager.spec.ts
+++ b/src/assessment/assessment-survey-manager.spec.ts
@@ -210,6 +210,25 @@ describe('AssessmentSurveyManager', () => {
     expect(playerElement?.getAttribute('data-key')).toBe('west-african-english-sightwords');
   });
 
+  it('should preserve explicit assessment data keys from Statsig config input', async () => {
+    window.history.pushState({}, '', '/?cr_lang=zulu');
+
+    setHeadResponseMap({
+      '/assessment-survey/data/french-lettersounds.json': true,
+    });
+
+    await manager.open({ dataKey: 'french-lettersounds' });
+
+    const overlay = document.getElementById('assessment-survey-overlay');
+    const playerElement = overlay?.querySelector('assessment-survey-player');
+
+    expect(playerElement?.getAttribute('data-key')).toBe('french-lettersounds');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/assessment-survey/data/french-lettersounds.json',
+      expect.objectContaining({ method: 'HEAD' })
+    );
+  });
+
   it('should use warmed key and avoid duplicate cache requests on open', async () => {
     setHeadResponseMap({
       '/assessment-survey/data/zulu-lettersounds.json': true,
@@ -242,6 +261,28 @@ describe('AssessmentSurveyManager', () => {
 
     await manager.open({ dataKey: 'lettersounds' });
     await manager.open({ dataKey: 'sightwords' });
+
+    expect(MockBroadcastChannel.postMessageCalls).toBe(2);
+  });
+
+  it('should warm explicit assessment data keys without adding the current language', async () => {
+    window.history.pushState({}, '', '/?cr_lang=zulu');
+
+    setHeadResponseMap({
+      '/assessment-survey/data/french-lettersounds.json': true,
+      '/assessment-survey/data/french-sightwords.json': true,
+    });
+
+    await manager.warmupAssessmentLanguageCaches([
+      'french-lettersounds',
+      'french-sightwords',
+      'french-lettersounds',
+    ]);
+
+    expect(MockBroadcastChannel.postMessageCalls).toBe(2);
+
+    await manager.open({ dataKey: 'french-lettersounds' });
+    await manager.open({ dataKey: 'french-sightwords' });
 
     expect(MockBroadcastChannel.postMessageCalls).toBe(2);
   });

--- a/src/assessment/config/assessment-level-config.spec.ts
+++ b/src/assessment/config/assessment-level-config.spec.ts
@@ -82,6 +82,33 @@ describe('AssessmentLevelConfig', () => {
     expect(config.getAssessmentTypeForLevel(2, 10)).toBe('sightwords');
   });
 
+  it('preserves explicit assessment data keys from Statsig config', () => {
+    const config = new AssessmentLevelConfig('assessmentlevels', () => ({
+      enabled: true,
+      mode: 'constant',
+      assessments: [
+        { assessmentType: 'French-LetterSounds', level: 2 },
+        { assessmentType: 'french-sightwords', level: 3 },
+      ],
+    }));
+
+    expect(config.refreshConfig()).toEqual({
+      enabled: true,
+      mode: 'constant',
+      assessments: [
+        { assessmentType: 'french-lettersounds', level: 2 },
+        { assessmentType: 'french-sightwords', level: 3 },
+      ],
+    });
+
+    expect(config.getTargetAssessments(10)).toEqual([
+      { levelIndex: 1, assessmentType: 'french-lettersounds' },
+      { levelIndex: 2, assessmentType: 'french-sightwords' },
+    ]);
+    expect(config.getAssessmentTypeForLevel(1, 10)).toBe('french-lettersounds');
+    expect(config.getAssessmentTypeForLevel(2, 10)).toBe('french-sightwords');
+  });
+
   it('returns disabled when enabled is false', () => {
     const config = new AssessmentLevelConfig('assessmentlevels', () => ({
       enabled: false,

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -232,8 +232,8 @@ class App {
         await navigator.serviceWorker.ready;
         await registration.update();
 
-        const configuredAssessmentTypes = this.getConfiguredAssessmentTypesForWarmup();
-        await assessmentSurveyManager.warmupAssessmentLanguageCaches(configuredAssessmentTypes);
+        const configuredAssessmentDataKeys = this.getConfiguredAssessmentDataKeysForWarmup();
+        await assessmentSurveyManager.warmupAssessmentLanguageCaches(configuredAssessmentDataKeys);
 
         if (!this.is_cached.has(this.lang)) {
           this.channel.postMessage({ command: "Cache", data: this.lang });
@@ -292,7 +292,7 @@ class App {
     }
   }
 
-  private getConfiguredAssessmentTypesForWarmup(): string[] {
+  private getConfiguredAssessmentDataKeysForWarmup(): string[] {
     const totalLevels = Array.isArray(this.dataModal?.levels)
       ? this.dataModal.levels.length
       : 0;
@@ -307,7 +307,7 @@ class App {
     return [...new Set(
       targetAssessments
         .map((targetAssessment) => targetAssessment.assessmentType)
-        .filter((assessmentType) => Boolean(assessmentType))
+        .filter((assessmentDataKey) => Boolean(assessmentDataKey))
     )];
   }
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
@@ -204,6 +204,25 @@ describe('GameplayFlowManager assessment integration', () => {
     manager.dispose();
   });
 
+  it('passes explicit assessment data keys through unchanged in gameplay', () => {
+    mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
+    mockAssessmentCoordinator.getAssessmentTypeForCurrentLevel.mockReturnValue('french-lettersounds');
+
+    (assessmentSurveyManager.open as jest.Mock).mockImplementation(async ({ onClose }) => {
+      onClose?.();
+    });
+
+    const { manager } = createFlowManager();
+
+    manager.determineNextStep(false, false);
+
+    expect(assessmentSurveyManager.open).toHaveBeenCalledWith(
+      expect.objectContaining({ dataKey: 'french-lettersounds' })
+    );
+
+    manager.dispose();
+  });
+
   it('resumes puzzle flow only after assessment closes', () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -102,7 +102,7 @@ export class GameplayFlowManager {
         console.log('[assessment-debug] gameplay level gate', {
             currentLevelIndex,
             configuredAssessmentLevels: this.assessmentFlowCoordinator.getConfiguredAssessmentLevelIndexes(),
-            assessmentTypeForCurrentLevel: this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel(),
+            assessmentDataKeyForCurrentLevel: this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel(),
             isAssessmentEligible: this.assessmentFlowCoordinator.isAssessmentEligibleForCurrentLevel(),
             assessmentPuzzleTrigger: this.assessmentFlowCoordinator.getAssessmentPuzzleTrigger(),
         });
@@ -172,7 +172,7 @@ export class GameplayFlowManager {
         this.assessmentFlowCoordinator.startAssessment();
 
         let hasResumed = false;
-        const assessmentTypeForCurrentLevel = this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel();
+        const assessmentDataKeyForCurrentLevel = this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel();
         const resumeAfterClose = () => {
             if (hasResumed) {
                 return;
@@ -185,7 +185,7 @@ export class GameplayFlowManager {
 
         void assessmentSurveyManager
             .open({
-                dataKey: assessmentTypeForCurrentLevel || undefined,
+                dataKey: assessmentDataKeyForCurrentLevel || undefined,
                 onComplete: () => {
                     this.assessmentFlowCoordinator.handleAssessmentCompleted();
                 },

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -152,10 +152,7 @@ export class StartScene {
   private onDevAssessmentClick = () => {
     const config = new AssessmentLevelConfig();
     const parsed = config.refreshConfig();
-    const firstAssessmentType = parsed.assessments[0]?.assessmentType;
-    const dataKey = firstAssessmentType
-      ? `${lang}-${firstAssessmentType}`
-      : undefined;
+    const dataKey = parsed.assessments[0]?.assessmentType;
 
     console.log(`[dev] Opening assessment with dataKey: ${dataKey ?? '(default)'}`);
     assessmentSurveyManager.open({


### PR DESCRIPTION
# Changes
- Treat Statsig-configured assessment entries as explicit assessment data keys, so values like french-lettersounds are passed through directly instead of being treated as language-relative types.
- Keep assessment cache warmup aligned with the new contract by warming the configured data keys before assessment launch.
- Keep gameplay and the dev assessment launcher opening the exact configured assessment data key.
- Add test coverage for config parsing, assessment cache warmup, and gameplay launch with explicit data keys.

# How to test
- Verify the assessment cache warmup requests french-lettersounds and french-sightwords directly, and verify gameplay opens the configured assessment JSON basename without adding the current language prefix.

Ref: [FM-890](https://curiouslearning.atlassian.net/browse/FM-890)


[FM-890]: https://curiouslearning.atlassian.net/browse/FM-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ