### PR TITLE
Develop to test code merge with bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,9 +2650,9 @@
       }
     },
     "node_modules/@curiouslearning/features": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@curiouslearning/features/-/features-1.3.0.tgz",
-      "integrity": "sha512-DVwERTu1P791tR8ojQ7PgKf5b3g6vlFRgC9UyjlVv83+hy5FGiZPSGfjJ4dQFqSAe+A13HW7R7tYDGT9r/kPjA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/features/-/features-1.3.1.tgz",
+      "integrity": "sha512-OrCJM2I+o0xWBPQumaY/HhOzKRH8bme/hJvs0UPl2YazoKlp08unCh7CuJA4AyIdxlYTDVKkID0LODDZMclSSw==",
       "license": "ISC",
       "dependencies": {
         "@statsig/js-client": "^3.12.0"

--- a/src/assessment/assessment-survey-manager.spec.ts
+++ b/src/assessment/assessment-survey-manager.spec.ts
@@ -210,6 +210,25 @@ describe('AssessmentSurveyManager', () => {
     expect(playerElement?.getAttribute('data-key')).toBe('west-african-english-sightwords');
   });
 
+  it('should preserve explicit assessment data keys from Statsig config input', async () => {
+    window.history.pushState({}, '', '/?cr_lang=zulu');
+
+    setHeadResponseMap({
+      '/assessment-survey/data/french-lettersounds.json': true,
+    });
+
+    await manager.open({ dataKey: 'french-lettersounds' });
+
+    const overlay = document.getElementById('assessment-survey-overlay');
+    const playerElement = overlay?.querySelector('assessment-survey-player');
+
+    expect(playerElement?.getAttribute('data-key')).toBe('french-lettersounds');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/assessment-survey/data/french-lettersounds.json',
+      expect.objectContaining({ method: 'HEAD' })
+    );
+  });
+
   it('should use warmed key and avoid duplicate cache requests on open', async () => {
     setHeadResponseMap({
       '/assessment-survey/data/zulu-lettersounds.json': true,
@@ -242,6 +261,28 @@ describe('AssessmentSurveyManager', () => {
 
     await manager.open({ dataKey: 'lettersounds' });
     await manager.open({ dataKey: 'sightwords' });
+
+    expect(MockBroadcastChannel.postMessageCalls).toBe(2);
+  });
+
+  it('should warm explicit assessment data keys without adding the current language', async () => {
+    window.history.pushState({}, '', '/?cr_lang=zulu');
+
+    setHeadResponseMap({
+      '/assessment-survey/data/french-lettersounds.json': true,
+      '/assessment-survey/data/french-sightwords.json': true,
+    });
+
+    await manager.warmupAssessmentLanguageCaches([
+      'french-lettersounds',
+      'french-sightwords',
+      'french-lettersounds',
+    ]);
+
+    expect(MockBroadcastChannel.postMessageCalls).toBe(2);
+
+    await manager.open({ dataKey: 'french-lettersounds' });
+    await manager.open({ dataKey: 'french-sightwords' });
 
     expect(MockBroadcastChannel.postMessageCalls).toBe(2);
   });

--- a/src/assessment/config/assessment-level-config.spec.ts
+++ b/src/assessment/config/assessment-level-config.spec.ts
@@ -82,6 +82,33 @@ describe('AssessmentLevelConfig', () => {
     expect(config.getAssessmentTypeForLevel(2, 10)).toBe('sightwords');
   });
 
+  it('preserves explicit assessment data keys from Statsig config', () => {
+    const config = new AssessmentLevelConfig('assessmentlevels', () => ({
+      enabled: true,
+      mode: 'constant',
+      assessments: [
+        { assessmentType: 'French-LetterSounds', level: 2 },
+        { assessmentType: 'french-sightwords', level: 3 },
+      ],
+    }));
+
+    expect(config.refreshConfig()).toEqual({
+      enabled: true,
+      mode: 'constant',
+      assessments: [
+        { assessmentType: 'french-lettersounds', level: 2 },
+        { assessmentType: 'french-sightwords', level: 3 },
+      ],
+    });
+
+    expect(config.getTargetAssessments(10)).toEqual([
+      { levelIndex: 1, assessmentType: 'french-lettersounds' },
+      { levelIndex: 2, assessmentType: 'french-sightwords' },
+    ]);
+    expect(config.getAssessmentTypeForLevel(1, 10)).toBe('french-lettersounds');
+    expect(config.getAssessmentTypeForLevel(2, 10)).toBe('french-sightwords');
+  });
+
   it('returns disabled when enabled is false', () => {
     const config = new AssessmentLevelConfig('assessmentlevels', () => ({
       enabled: false,

--- a/src/assessment/config/assessment-level-config.ts
+++ b/src/assessment/config/assessment-level-config.ts
@@ -40,7 +40,7 @@ export class AssessmentLevelConfig {
   constructor(
     private readonly dynamicConfigKey: string = ASSESSMENT_LEVELS_CONFIG_KEY,
     private readonly configProvider: DynamicConfigProvider = (configKey: string) =>
-      featureFlagsService.getDynamicConfig(configKey)
+      featureFlagsService.getDynamicConfig(configKey, false)
   ) {}
 
   /**

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -232,8 +232,8 @@ class App {
         await navigator.serviceWorker.ready;
         await registration.update();
 
-        const configuredAssessmentTypes = this.getConfiguredAssessmentTypesForWarmup();
-        await assessmentSurveyManager.warmupAssessmentLanguageCaches(configuredAssessmentTypes);
+        const configuredAssessmentDataKeys = this.getConfiguredAssessmentDataKeysForWarmup();
+        await assessmentSurveyManager.warmupAssessmentLanguageCaches(configuredAssessmentDataKeys);
 
         if (!this.is_cached.has(this.lang)) {
           this.channel.postMessage({ command: "Cache", data: this.lang });
@@ -292,7 +292,7 @@ class App {
     }
   }
 
-  private getConfiguredAssessmentTypesForWarmup(): string[] {
+  private getConfiguredAssessmentDataKeysForWarmup(): string[] {
     const totalLevels = Array.isArray(this.dataModal?.levels)
       ? this.dataModal.levels.length
       : 0;
@@ -307,7 +307,7 @@ class App {
     return [...new Set(
       targetAssessments
         .map((targetAssessment) => targetAssessment.assessmentType)
-        .filter((assessmentType) => Boolean(assessmentType))
+        .filter((assessmentDataKey) => Boolean(assessmentDataKey))
     )];
   }
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
@@ -204,6 +204,25 @@ describe('GameplayFlowManager assessment integration', () => {
     manager.dispose();
   });
 
+  it('passes explicit assessment data keys through unchanged in gameplay', () => {
+    mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
+    mockAssessmentCoordinator.getAssessmentTypeForCurrentLevel.mockReturnValue('french-lettersounds');
+
+    (assessmentSurveyManager.open as jest.Mock).mockImplementation(async ({ onClose }) => {
+      onClose?.();
+    });
+
+    const { manager } = createFlowManager();
+
+    manager.determineNextStep(false, false);
+
+    expect(assessmentSurveyManager.open).toHaveBeenCalledWith(
+      expect.objectContaining({ dataKey: 'french-lettersounds' })
+    );
+
+    manager.dispose();
+  });
+
   it('resumes puzzle flow only after assessment closes', () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -102,7 +102,7 @@ export class GameplayFlowManager {
         console.log('[assessment-debug] gameplay level gate', {
             currentLevelIndex,
             configuredAssessmentLevels: this.assessmentFlowCoordinator.getConfiguredAssessmentLevelIndexes(),
-            assessmentTypeForCurrentLevel: this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel(),
+            assessmentDataKeyForCurrentLevel: this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel(),
             isAssessmentEligible: this.assessmentFlowCoordinator.isAssessmentEligibleForCurrentLevel(),
             assessmentPuzzleTrigger: this.assessmentFlowCoordinator.getAssessmentPuzzleTrigger(),
         });
@@ -172,7 +172,7 @@ export class GameplayFlowManager {
         this.assessmentFlowCoordinator.startAssessment();
 
         let hasResumed = false;
-        const assessmentTypeForCurrentLevel = this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel();
+        const assessmentDataKeyForCurrentLevel = this.assessmentFlowCoordinator.getAssessmentTypeForCurrentLevel();
         const resumeAfterClose = () => {
             if (hasResumed) {
                 return;
@@ -185,7 +185,7 @@ export class GameplayFlowManager {
 
         void assessmentSurveyManager
             .open({
-                dataKey: assessmentTypeForCurrentLevel || undefined,
+                dataKey: assessmentDataKeyForCurrentLevel || undefined,
                 onComplete: () => {
                     this.assessmentFlowCoordinator.handleAssessmentCompleted();
                 },

--- a/src/scenes/start-scene/start-scene.spec.ts
+++ b/src/scenes/start-scene/start-scene.spec.ts
@@ -4,6 +4,7 @@ import { AnalyticsIntegration } from "../../analytics/analytics-integration";
 import { AudioPlayer } from "../../components/audio-player";
 import gameStateService from '@gameStateService';
 import gameSettingsService from '@gameSettingsService';
+import { Debugger } from '@common';
 import { SCENE_NAME_LEVEL_SELECT } from "@constants";
 import { RiveMonsterComponent } from '@components/riveMonster/rive-monster-component';
 
@@ -54,7 +55,8 @@ jest.mock('@rive-app/canvas', () => ({
 
 jest.mock('@components/riveMonster/rive-monster-component', () => ({
   RiveMonsterComponent: jest.fn().mockImplementation(() => ({
-    Rive: jest.fn().mockImplementation(() => ({}))
+    Rive: jest.fn().mockImplementation(() => ({})),
+    dispose: jest.fn()
   })),
 }));
 
@@ -63,7 +65,8 @@ let mockAnalyticsInstance: any;
 
 jest.mock("../../components/audio-player", () => ({
   AudioPlayer: jest.fn().mockImplementation(() => ({
-    playButtonClickSound: jest.fn()
+    playButtonClickSound: jest.fn(),
+    stopAllAudios: jest.fn()
   })),
 }));
 jest.mock('@gameStateService', () => ({
@@ -101,6 +104,7 @@ describe('Start Scene Test', () => {
       <div>
         <div id="title-and-play-button"></div>
         <button id="toggle-btn" class="off">Dev</button>
+        <button id="dev-assessment-btn" style="display: none;">Assessment</button>
         <div id="loading-screen" style="display: none; z-index: -1;"></div>
         <div class="game-scene"></div>
         <div id="canvas"></div>
@@ -146,6 +150,8 @@ describe('Start Scene Test', () => {
 
     (gameSettingsService.getRiveCanvasValue as jest.Mock).mockReturnValue(mockRiveCanvas);
 
+    Debugger.DebugMode = false;
+
     // Create the startScene instance
     startScene = new StartScene();
 
@@ -153,6 +159,7 @@ describe('Start Scene Test', () => {
     startScene.titleTextElement = document.getElementById('title');
     startScene.handler = document.getElementById('start-scene-click-area');
     startScene.toggleBtn = document.getElementById('toggle-btn');
+    startScene.devAssessmentBtn = document.getElementById('dev-assessment-btn');
 
     // Ensure startScene uses the mock data
     startScene.analyticsIntegration = mockAnalytics;
@@ -163,6 +170,8 @@ describe('Start Scene Test', () => {
       onClick: jest.fn((callback) => {
         mockOnClickCallback = callback;
       }),
+      dispose: jest.fn(),
+      destroy: jest.fn(),
     } as unknown as jest.Mocked<PlayButtonHtml>;
 
     // Mock PlayButtonHtml to return the mocked button
@@ -200,6 +209,26 @@ describe('Start Scene Test', () => {
       startScene.generateGameTitle();
 
       expect(titleElement.classList.contains('title-long')).toBeFalsy();
+    });
+
+    it('Should keep the assessment button hidden when debug mode is off', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
+
+    it('Should show the assessment button only when the dev toggle is enabled', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      const toggleButton = document.getElementById('toggle-btn');
+
+      Debugger.DebugMode = true;
+      toggleButton.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+      expect(assessmentButton.style.display).toEqual('block');
+
+      toggleButton.classList.remove('on');
+      startScene.syncDevAssessmentButtonVisibility();
+      expect(assessmentButton.style.display).toEqual('none');
     });
   });
 
@@ -274,7 +303,33 @@ describe('Start Scene Test', () => {
       const devBtn = document.getElementById('toggle-btn');
 
       expect(devBtn.style.display).toEqual('none');
-    })
+    });
+
+    it('Should remove the assessment button.', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      Debugger.DebugMode = true;
+      startScene.toggleBtn.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+
+      if (mockOnClickCallback) {
+        mockOnClickCallback();
+      }
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
+  });
+
+  describe('When start scene is disposed', () => {
+    it('Should hide the assessment button', () => {
+      const assessmentButton = document.getElementById('dev-assessment-btn');
+      Debugger.DebugMode = true;
+      startScene.toggleBtn.classList.add('on');
+      startScene.syncDevAssessmentButtonVisibility();
+
+      startScene.dispose();
+
+      expect(assessmentButton.style.display).toEqual('none');
+    });
   });
 
 });

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -152,10 +152,7 @@ export class StartScene {
   private onDevAssessmentClick = () => {
     const config = new AssessmentLevelConfig();
     const parsed = config.refreshConfig();
-    const firstAssessmentType = parsed.assessments[0]?.assessmentType;
-    const dataKey = firstAssessmentType
-      ? `${lang}-${firstAssessmentType}`
-      : undefined;
+    const dataKey = parsed.assessments[0]?.assessmentType;
 
     console.log(`[dev] Opening assessment with dataKey: ${dataKey ?? '(default)'}`);
     assessmentSurveyManager.open({

--- a/src/scenes/start-scene/start-scene.ts
+++ b/src/scenes/start-scene/start-scene.ts
@@ -7,6 +7,7 @@ import { RiveMonsterComponent } from "@components/riveMonster/rive-monster-compo
 import { DataModal } from "@data";
 import {
   toggleDebugMode,
+  Debugger,
   pseudoId,
   lang
 } from "@common";
@@ -100,6 +101,7 @@ export class StartScene {
     this.handler = document.getElementById('start-scene-click-area') as HTMLBodyElement;
     this.toggleBtn.addEventListener("click", this.onToggleClick);
     this.devAssessmentBtn?.addEventListener("click", this.onDevAssessmentClick);
+    this.syncDevAssessmentButtonVisibility();
     this.createPlayButton();
     window.addEventListener("beforeinstallprompt", this.handlerInstallPrompt);
     this.setupBg();
@@ -144,8 +146,26 @@ export class StartScene {
 
   private onToggleClick = () => {
     toggleDebugMode(this.toggleBtn);
+    this.syncDevAssessmentButtonVisibility();
+  };
+
+  private syncDevAssessmentButtonVisibility = () => {
+    if (!this.devAssessmentBtn) {
+      return;
+    }
+
+    this.devAssessmentBtn.style.display = Debugger.DebugMode && this.toggleBtn.classList.contains("on")
+      ? "block"
+      : "none";
+  };
+
+  private hideStartSceneDevButtons = () => {
+    if (this.toggleBtn) {
+      this.toggleBtn.style.display = "none";
+    }
+
     if (this.devAssessmentBtn) {
-      this.devAssessmentBtn.style.display = this.toggleBtn.classList.contains("on") ? "block" : "none";
+      this.devAssessmentBtn.style.display = "none";
     }
   };
 
@@ -183,7 +203,7 @@ export class StartScene {
   createPlayButton() {
     this.playButton = new PlayButtonHtml({ targetId: 'title-and-play-button' });
     this.playButton.onClick(() => {
-      this.toggleBtn.style.display = "none";
+      this.hideStartSceneDevButtons();
       this.logTappedStartFirebaseEvent();
       this.audioPlayer.playButtonClickSound();
       gameStateService.publish(gameStateService.EVENTS.START_GAME, true);
@@ -212,12 +232,13 @@ export class StartScene {
     fbq("trackCustom", FirebaseUserClicked, {
       event: "click",
     });
-    this.toggleBtn.style.display = "none";
+    this.hideStartSceneDevButtons();
     this.audioPlayer.playButtonClickSound();
     gameStateService.publish(gameStateService.EVENTS.SWITCH_SCENE_EVENT, SCENE_NAME_LEVEL_SELECT);
   };
 
   dispose() {
+    this.hideStartSceneDevButtons();
     this.audioPlayer.stopAllAudios();
     this.handler.removeEventListener("click", this.handleMouseClick, false);
     this.toggleBtn.removeEventListener("click", this.onToggleClick);

--- a/src/sw-src.js
+++ b/src/sw-src.js
@@ -274,11 +274,7 @@ async function cacheFeedBackAudio(feedBackAudios, language) {
 }
 
 function normalizeAssessmentAudioName(data, itemName) {
-  const quizName = (data?.quizName || '').toLowerCase();
-  if (quizName.includes('luganda') || quizName.includes('west african english')) {
-    return itemName.toLowerCase().trim();
-  }
-  return itemName.trim();
+  return itemName.toLowerCase().trim();
 }
 
 function getAssessmentAssetPath(relativePath) {


### PR DESCRIPTION
# Changes
- Brings the latest assessment-survey package integration into FeedTheMonster, including embedded assessment overlay flow, host callback support, service worker assessment asset caching, and subpath-safe assessment asset resolution.
- Updates assessment runtime behavior so configured assessment data keys can be selected explicitly, assessment triggering stays within the intended gameplay windows, and dynamic assessment level config can refresh from network-first feature flags.
- Fixes assessment-related UX issues in FTM, including hiding dev-only assessment controls after leaving the start scene and normalizing assessment audio filename handling to match the packaged assessment assets.
- Includes supporting dependency and package updates for assessment and analytics integration.
- Syncs recent content/audio updates, including Dari fixes, Spanish audio/content updates, and the added Hadiyyisa language content.

# How to test
- In a build that has assessment enabled, verify the assessment loads from the correct data key, only appears on configured levels and allowed puzzle points, and still works when the app is served from a subpath such as /feed-the-monster/.
- In debug mode, confirm the start-scene assessment button only appears when dev mode is toggled on and is hidden again after starting or leaving the start scene.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved assessment data key normalization for more consistent assessment identification and loading
  * Enhanced audio file name normalization in service worker for consistent audio handling across language variants

* **Tests**
  * Added test coverage for assessment data key handling, configuration normalization, and assessment flow integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->