### PR TITLE
fix: [FM-882] hidden the assessment element while it is still loading

### DIFF
--- a/src/assessment/assessment-survey-manager.spec.ts
+++ b/src/assessment/assessment-survey-manager.spec.ts
@@ -348,6 +348,23 @@ describe('AssessmentSurveyManager', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('should keep the embedded assessment hidden until the player reports loaded', async () => {
+    setHeadResponseMap({
+      '/assessment-survey/data/zulu-lettersounds.json': true,
+    });
+
+    await manager.open({ dataKey: 'zulu-lettersounds' });
+
+    const overlay = document.getElementById('assessment-survey-overlay');
+    const playerElement = overlay?.querySelector('assessment-survey-player') as HTMLElement;
+
+    expect(playerElement.style.visibility).toBe('hidden');
+
+    subscribedHandlers.loaded?.forEach((handler) => handler());
+
+    expect(playerElement.style.visibility).toBe('visible');
+  });
+
   it('should forward analytics config to player element when env vars are set', async () => {
     const envSnapshot = snapshotFirebaseEnv();
 

--- a/src/assessment/ui/assessment-player-element.ts
+++ b/src/assessment/ui/assessment-player-element.ts
@@ -30,6 +30,7 @@ export function createAssessmentPlayerElement(options: AssessmentPlayerElementOp
   playerElement.style.display = 'block';
   playerElement.style.width = '100%';
   playerElement.style.height = '100%';
+  playerElement.style.visibility = 'hidden';
 
   playerElement.setAttribute('data-key', options.dataKey);
   playerElement.setAttribute('user-id', 'ftm-web-user');
@@ -45,6 +46,7 @@ export function createAssessmentPlayerElement(options: AssessmentPlayerElementOp
 
   if (options.onLoaded) {
     playerElement.subscribe(AssessmentSurveyPlayerElement.ONLOADED, () => {
+      playerElement.style.visibility = 'visible';
       options.onLoaded?.();
     });
   }


### PR DESCRIPTION
# Changes
- Keep the FTM assessment player hidden until the embedded assessment emits its loaded event.

# How to test
- Launch FTM with npm run dev, open the assessment flow, and verify the assessment appears without briefly showing the dev settings UI.

Ref: [FM-882](https://curiouslearning.atlassian.net/browse/FM-882)


[FM-882]: https://curiouslearning.atlassian.net/browse/FM-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment player elements now remain hidden during the loading process and automatically appear once content has finished loading, improving the loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->