### PR TITLE
[Fixed] Fixed Pause Popup Overlaps Assessment Screen After Device Sleep/Resume (FM-884)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -112,6 +112,10 @@ export class GameplayFlowManager {
         this.addEventListeners();
     }
 
+    public isAssessmentOpen(): boolean {
+        return this.isAssessmentInProgress;
+    }
+
     // #region Public Flow Control
     /**
      * Determines the next game flow after a puzzle event (solved or timed out).

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -441,6 +441,10 @@ export class GameplayScene {
   }
 
   public handleVisibilityChange(): void {
+    if (this.flowManager?.isAssessmentOpen()) {
+      return;
+    }
+
     gameStateService.publish(gameStateService.EVENTS.GAME_PAUSE_STATUS_EVENT, true);
     this.pauseGamePlay();
   }


### PR DESCRIPTION
# Changes
- Added method in `gameplay-flow-manager.ts` that returns the `boolean` flag `this.isAssessmentInProgress`.
- Added if condition in `gameplay-scene.ts - handleVisibilityChange` method that skips if the `this.isAssessmentInProgress` is `true`. Making the pause popup to not appear behind the assessment.

# How to test
- Run `npm run dev` to start the app.
- Open the localhost in browser with `?cr_lang=englishwestafrican`.
- In the start page scene, enable dev. Then press on the screen.
- In level selection, select level 2.
- Play the game until the assessment shows up.
- When the assessment shows up, open another tab to trigger the handle visibility event.
- Then return back to the tab of FTM.
- There should be no pause popup present behind the assessment.

Ref: [FM-884](https://curiouslearning.atlassian.net/browse/FM-884)


[FM-884]: https://curiouslearning.atlassian.net/browse/FM-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug where assessments could be interrupted when the application loses focus. Assessments now remain uninterrupted during visibility changes, providing a more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->