### PR TITLE
fix: [FM-894] disposed minigame when disposing gameplay

### DIFF
--- a/src/components/__mocks__/audio-player.ts
+++ b/src/components/__mocks__/audio-player.ts
@@ -1,6 +1,7 @@
 const mockAudioPlayerInstance = {
   preloadGameAudio: jest.fn(),
   playAudio: jest.fn(),
+  stopAudio: jest.fn(),
   stopAllAudios: jest.fn(),
   playButtonClickSound: jest.fn(),
   playPromptAudio: jest.fn(),

--- a/src/scenes/gameplay-scene/gameplay-scene.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.spec.ts
@@ -522,6 +522,9 @@ describe('GameplayScene with BasePopupComponent', () => {
       const mockPausePopup = {
         destroy: jest.fn()
       };
+      const mockMiniGameHandler = {
+        dispose: jest.fn()
+      };
       const tutorial = {
         dispose: jest.fn()
       }
@@ -540,6 +543,7 @@ describe('GameplayScene with BasePopupComponent', () => {
       gameplayScene.uiManager.promptText = mockPromptText as any;
       gameplayScene.uiManager.pauseButton = mockPauseButton as any;
       gameplayScene.uiManager.pausePopupComponent = mockPausePopup as any;
+      (gameplayScene as any).miniGameHandler = mockMiniGameHandler;
       
       // Inject the function mocks
       (gameplayScene as any).unsubscribeEvent = mockUnsubscribeEvent; // Access private property if needed
@@ -562,6 +566,7 @@ describe('GameplayScene with BasePopupComponent', () => {
       expect(mockPromptText.dispose).toHaveBeenCalled();
       expect(mockPauseButton.dispose).toHaveBeenCalled();
       expect(mockPausePopup.destroy).toHaveBeenCalled();
+      expect(mockMiniGameHandler.dispose).toHaveBeenCalled();
       
       // Verify subscription cleanup
       expect(mockUnsubscribeEvent).toHaveBeenCalled();

--- a/src/scenes/gameplay-scene/gameplay-scene.ts
+++ b/src/scenes/gameplay-scene/gameplay-scene.ts
@@ -261,6 +261,11 @@ export class GameplayScene {
         this.flowManager = null;
     }
 
+    if (this.miniGameHandler) {
+      this.miniGameHandler.dispose();
+      this.miniGameHandler = null;
+    }
+
     if(this.puzzleHandler) {
       this.puzzleHandler.dispose();
       this.puzzleHandler = null;

--- a/src/scenes/loading-scene.ts
+++ b/src/scenes/loading-scene.ts
@@ -36,7 +36,7 @@ export class LoadingScene {
   toggleLoadingScreen(shouldShow) {
     shouldShow && this.initCloud();
     this.shouldShowLoading = shouldShow;
-    document.getElementById("loading").style.zIndex = shouldShow ? "10" : "-1";
+    document.getElementById("loading").style.zIndex = shouldShow ? "12" : "-1";
   }
 
   draw(deltaTime: number) {


### PR DESCRIPTION
# Changes
- disposed minigame when disposing gameplay

# How to test
- Play a level with minigame then go out of tab or pause the game, then go to level selection.

Ref: [FM-894](https://curiouslearning.atlassian.net/browse/FM-894)


[FM-894]: https://curiouslearning.atlassian.net/browse/FM-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading screen layering to ensure proper visibility over other interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->