### PR TITLE
fixed: Fixed gameplay feedback SFX overlapping with Assessment and Minigame overlay (FM-893)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.spec.ts
@@ -70,7 +70,12 @@ import gameStateService from '@gameStateService';
 import miniGameStateService from '@miniGameStateService';
 import assessmentSurveyManager from '@assessment/assessment-survey-manager';
 import { AssessmentFlowCoordinator } from '@assessment/assessment-flow-coordinator';
+import scheduler from '@services/scheduler';
 import { GameplayFlowManager } from './gameplay-flow-manager';
+
+async function flushPromises() {
+  await Promise.resolve();
+}
 
 function createFlowManager(levelDataOverrides: Partial<any> = {}) {
   const baseLevelData = {
@@ -170,7 +175,11 @@ describe('GameplayFlowManager assessment integration', () => {
     (miniGameStateService.shouldShowMiniGame as jest.Mock).mockReturnValue(0);
   });
 
-  it('runs assessment before mini-game on the same puzzle segment', () => {
+  afterEach(() => {
+    scheduler.destroy();
+  });
+
+  it('runs assessment before mini-game on the same puzzle segment', async () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
     mockAssessmentCoordinator.getAssessmentTypeForCurrentLevel.mockReturnValue('lettersounds');
     (miniGameStateService.shouldShowMiniGame as jest.Mock).mockReturnValue(1);
@@ -184,6 +193,11 @@ describe('GameplayFlowManager assessment integration', () => {
     const { manager, miniGameHandler } = createFlowManager();
 
     manager.determineNextStep(true, false);
+
+    scheduler.update(1500);
+    await flushPromises();
+    scheduler.update(0);
+    await flushPromises();
 
     expect(mockAssessmentCoordinator.startAssessment).toHaveBeenCalledTimes(1);
     expect(mockAssessmentCoordinator.handleAssessmentCompleted).toHaveBeenCalledTimes(1);
@@ -204,7 +218,7 @@ describe('GameplayFlowManager assessment integration', () => {
     manager.dispose();
   });
 
-  it('passes explicit assessment data keys through unchanged in gameplay', () => {
+  it('passes explicit assessment data keys through unchanged in gameplay', async () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
     mockAssessmentCoordinator.getAssessmentTypeForCurrentLevel.mockReturnValue('french-lettersounds');
 
@@ -216,6 +230,9 @@ describe('GameplayFlowManager assessment integration', () => {
 
     manager.determineNextStep(false, false);
 
+    scheduler.update(3000);
+    await flushPromises();
+
     expect(assessmentSurveyManager.open).toHaveBeenCalledWith(
       expect.objectContaining({ dataKey: 'french-lettersounds' })
     );
@@ -223,7 +240,7 @@ describe('GameplayFlowManager assessment integration', () => {
     manager.dispose();
   });
 
-  it('resumes puzzle flow only after assessment closes', () => {
+  it('resumes puzzle flow only after assessment closes', async () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
 
     let closeHandler: (() => void) | undefined;
@@ -238,16 +255,23 @@ describe('GameplayFlowManager assessment integration', () => {
 
     expect(continueAfterPuzzleStepSpy).not.toHaveBeenCalled();
 
+    scheduler.update(3000);
+    await flushPromises();
+
+    expect(continueAfterPuzzleStepSpy).not.toHaveBeenCalled();
+
     closeHandler?.();
 
-    expect(continueAfterPuzzleStepSpy).toHaveBeenCalledWith(1, false, 3000);
+    await flushPromises();
+
+    expect(continueAfterPuzzleStepSpy).toHaveBeenCalledWith(1, false, 3000, 0);
     expect(mockAssessmentCoordinator.handleAssessmentClosed).toHaveBeenCalledTimes(1);
     expect(mockAssessmentCoordinator.handleAssessmentCompleted).not.toHaveBeenCalled();
 
     manager.dispose();
   });
 
-  it('prevents duplicate assessment open while one is already in progress', () => {
+  it('prevents duplicate assessment open while one is already in progress', async () => {
     mockAssessmentCoordinator.shouldStartAssessmentAtPuzzle.mockReturnValue(true);
     (assessmentSurveyManager.open as jest.Mock).mockImplementation(() => new Promise(() => {}));
 
@@ -255,6 +279,9 @@ describe('GameplayFlowManager assessment integration', () => {
 
     manager.determineNextStep(false, false);
     manager.determineNextStep(false, false);
+
+    scheduler.update(3000);
+    await flushPromises();
 
     expect(mockAssessmentCoordinator.startAssessment).toHaveBeenCalledTimes(1);
     expect(assessmentSurveyManager.open).toHaveBeenCalledTimes(1);

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -129,23 +129,39 @@ export class GameplayFlowManager {
             this.isCorrect = isCorrect;
         }
 
-        const loadPuzzleDelay = this.isCorrect ? 1500 : 3000;
+        //Delay before either next puzzle, assessment or mini-game starts to avoid overlapping with feedback SFX.
+        const nextStepDelay = this.isCorrect ? 1500 : 3000;
 
         if (this.assessmentFlowCoordinator.shouldStartAssessmentAtPuzzle(currentPuzzleSegment)) {
-            this.startAssessmentFlow(() => {
-                this.continueAfterPuzzleStep(currentPuzzleSegment, isTimeOver, loadPuzzleDelay);
-            });
+            this.timeoutRegistry.setTimeout(() => {
+                this.startAssessmentFlow(() => {
+                    this.continueAfterPuzzleStep(
+                        currentPuzzleSegment,
+                        isTimeOver,
+                        nextStepDelay, //Delay for loading next puzzle.
+                        0, //Pass 0 to instantly load mini game after assessment survey.
+                    );
+                });
+            }, nextStepDelay);
+
             return;
         }
 
-        this.continueAfterPuzzleStep(currentPuzzleSegment, isTimeOver, loadPuzzleDelay);
+        this.continueAfterPuzzleStep(
+            currentPuzzleSegment,
+            isTimeOver,
+            nextStepDelay, //Delay for loading next puzzle.
+            nextStepDelay //Delay for loading mini game.
+        );
     }
 
     private continueAfterPuzzleStep(
         currentPuzzleSegment: number,
         isTimeOver: boolean,
-        loadPuzzleDelay: number
+        loadPuzzleDelay: number,
+        miniGameDelay: number
     ): void {
+        
         if (currentPuzzleSegment === this.levelForMinigame && !this.hasShownChest) {
             this.hasShownChest = true;
 
@@ -155,8 +171,11 @@ export class GameplayFlowManager {
                 { level: currentPuzzleSegment }
             );
 
-            // Run chest animation (mini game)
-            this.miniGameHandler.start();
+            this.timeoutRegistry.setTimeout(() => {
+                // Run chest animation (mini game)
+                this.miniGameHandler.start();
+            }, miniGameDelay);
+            
             return;
         }
 


### PR DESCRIPTION
# Changes
- Wrapped `this.startAssessmentFlow` and `this.miniGameHandler.start()` with `this.timeoutRegistry.setTimeout` with delay based on `this.isCorrect`, to properly control the flow without it having overlap during the feedback SFX.
- Updated gameplay-flow-manager.spec.ts tests based on the set timeout delays added.

# How to test
- Run npm run dev command.
- Load the FTM app with /?cr_lang=englishwestafrican
- Once FTM is loaded, enable development.
- Go to level selection and select level 2.
- Play the game incorrectly until the assessment shows up.
- The SFX of incorrect letter drop should not overlap when the assessment overlay appears.

Ref: [FM-893](https://curiouslearning.atlassian.net/browse/FM-893)


[FM-893]: https://curiouslearning.atlassian.net/browse/FM-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with improved asynchronous operation handling, including explicit promise management and proper scheduler cleanup between test cases.

* **Refactor**
  * Optimized gameplay flow timing by consolidating delay parameters and improving animation scheduling for better control over timing sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->