### PR TITLE
feat: add android interface level complete event bubbling (MR-61)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
     "^@miniGames(.*)$": ["<rootDir>/src/miniGame/miniGames/$1"],
     "^@miniGameStateService(.*)$": ["<rootDir>/src/miniGame/miniGameStateService/$1"],
     "@curiouslearning/analytics": "<rootDir>/node_modules/@curiouslearning/analytics/dist/index.js",
+    "@curiouslearning/core": "<rootDir>/node_modules/@curiouslearning/core/dist/index.js",
     "@curiouslearning/features": "<rootDir>/node_modules/@curiouslearning/features/dist/index.js",
     "@curiouslearning/assessment-survey/register": "<rootDir>/__mocks__/default-mock.js",
     "@curiouslearning/assessment-survey": "<rootDir>/node_modules/@curiouslearning/assessment-survey/lib/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/core": "^4.4.0",
         "@curiouslearning/analytics": "^1.3.1",
         "@curiouslearning/assessment-survey": "file:vendor/curiouslearning-assessment-survey-0.0.1.tgz",
+        "@curiouslearning/core": "^1.11.0",
         "@curiouslearning/features": "^1.3.0",
         "@octokit/rest": "^20.0.1",
         "@release-it/conventional-changelog": "^8.0.1",
@@ -2631,9 +2632,9 @@
       }
     },
     "node_modules/@curiouslearning/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@curiouslearning/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-1ooRztyv09D4BAWoKVxHrVXIHIMjXEcGFT3pSSkacWwQqmoNcUrt2WZy6OQ/fHx78c09xl+gg1bSgxOR0KCIkg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-ZlEwgJgWmrYHoXU2G/PAmZe4tmbW1sWTicdSNy8gHofw6mUs8ufFZBqw9uqSsam1XxkEih6vHqfXQ2cjKwAcAg==",
       "license": "ISC",
       "dependencies": {
         "@songbaek/fifo-map": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@capacitor/core": "^4.4.0",
     "@curiouslearning/analytics": "^1.3.1",
     "@curiouslearning/assessment-survey": "file:vendor/curiouslearning-assessment-survey-0.0.1.tgz",
+    "@curiouslearning/core": "^1.11.0",
     "@curiouslearning/features": "^1.3.0",
     "@octokit/rest": "^20.0.1",
     "@release-it/conventional-changelog": "^8.0.1",

--- a/src/analytics/base-analytics-integration.ts
+++ b/src/analytics/base-analytics-integration.ts
@@ -34,7 +34,7 @@ import { source, campaign_id, pseudoId } from "@common";
  * @since 1.0.0
  */
 export class BaseAnalyticsIntegration {
-    private analyticsService: AnalyticsService;
+    readonly analyticsService: AnalyticsService;
     private firebaseStrategy: FirebaseStrategy;
     private statsigStrategy: StatsigStrategy;
     private isInitialized: boolean = false;

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -23,7 +23,6 @@ import { featureFlagsService } from '@curiouslearning/features';
 import gameStateService from "./gameStateService";
 import assessmentSurveyManager from '@assessment/assessment-survey-manager';
 import { AssessmentLevelConfig } from '@assessment/config/assessment-level-config';
-import { EventHandler } from './modules/android/services/event-handler';
 import { AndroidAnalyticsStrategy } from './modules/android/services/analytics-strategy/android-analytics-strategy';
 
 declare const window: any;

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -23,6 +23,8 @@ import { featureFlagsService } from '@curiouslearning/features';
 import gameStateService from "./gameStateService";
 import assessmentSurveyManager from '@assessment/assessment-survey-manager';
 import { AssessmentLevelConfig } from '@assessment/config/assessment-level-config';
+import { EventHandler } from './modules/android/services/event-handler';
+import { AndroidAnalyticsStrategy } from './modules/android/services/analytics-strategy/android-analytics-strategy';
 
 declare const window: any;
 
@@ -116,6 +118,8 @@ class App {
       this.handleCachedScenario(this.dataModal);
     }
     this.registerWorkbox();
+
+    this.initAndroidModule();
   }
 
   private async loadTitleFeedbackCustomFont() {
@@ -129,6 +133,19 @@ class App {
       }
     });
   }
+
+  /**
+   * Needs to happen after await AnalyticsIntegration.initializeAnalytics();
+   * because this registers a strategy
+   */
+  private initAndroidModule() {
+    const androidStrategy = new AndroidAnalyticsStrategy({ cr_user_id: pseudoId ?? '' });
+    AnalyticsIntegration.getInstance().analyticsService.register(
+      'android',
+      androidStrategy
+    );
+  }
+
   private logDownloadPercentageComplete(percentage: number, timeDifferenceFromSessonStart: number) {
     const eventData = {
       json_version_number: this.getJsonVersionNumber(),

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -1,0 +1,71 @@
+import { AndroidAnalyticsStrategy } from './android-analytics-strategy';
+
+const mockLogSummaryData = jest.fn();
+
+jest.mock('@curiouslearning/core', () => ({
+  AndroidInterface: jest.fn().mockImplementation(() => ({
+    logSummaryData: mockLogSummaryData,
+  })),
+}));
+
+jest.mock('@curiouslearning/analytics', () => ({
+  AbstractAnalyticsStrategy: class {
+    initialize(): Promise<void> { return Promise.resolve(); }
+    track(_eventName: string, _data: any): void {}
+    dispose(): void {}
+  },
+}));
+
+describe('Feature: Android analytics strategy', () => {
+  let strategy: AndroidAnalyticsStrategy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    strategy = new AndroidAnalyticsStrategy({ cr_user_id: 'user-123' });
+  });
+
+  describe('Scenario: Initializing the strategy', () => {
+    it('Given a valid cr_user_id, when initialize is called, then it resolves without error', async () => {
+      await expect(strategy.initialize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Scenario: Tracking a level_completed event', () => {
+    it('Given a level_completed event with a duration, when track is called, then logSummaryData is called with the correct payload', () => {
+      // Given
+      const eventName = AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED;
+      const data = { duration: 45 };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogSummaryData).toHaveBeenCalledTimes(1);
+      expect(mockLogSummaryData).toHaveBeenCalledWith(
+        { levels_completed: 1, time_spent_total_second: 45 },
+        { levels_completed: 'add', time_spent_total_second: 'add' }
+      );
+    });
+
+    it('Given a level_completed event with no duration, when track is called, then time_spent_total_second defaults to 0', () => {
+      // Given
+      const eventName = AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED;
+      const data = {};
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogSummaryData).toHaveBeenCalledWith(
+        { levels_completed: 1, time_spent_total_second: 0 },
+        { levels_completed: 'add', time_spent_total_second: 'add' }
+      );
+    });
+  });
+
+  describe('Scenario: Disposing the strategy', () => {
+    it('Given an initialized strategy, when dispose is called, then it completes without error', () => {
+      expect(() => strategy.dispose()).not.toThrow();
+    });
+  });
+});

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -1,0 +1,58 @@
+import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
+import { AndroidInterface } from '@curiouslearning/core';
+
+export interface AndroidAnalyticsStrategyOptions {
+  cr_user_id: string;
+}
+
+export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
+  private readonly cr_user_id: string;
+  private readonly androidInterface : AndroidInterface;
+
+  /**
+   * TODO: consolidate these events in one place, current duplication of analytics events.
+   * Events can be shared between in-game functionality and not just analytics.
+   */
+  static readonly EVENTS = {
+    LEVEL_COMPLETED: 'level_completed'
+  };
+
+  constructor(options: AndroidAnalyticsStrategyOptions) {
+    super();
+    this.cr_user_id = options.cr_user_id;
+    this.androidInterface = new AndroidInterface({
+      app_id: 'feed-the-monster',
+      cr_user_id: this.cr_user_id ?? ''
+    });
+  }
+
+  async initialize(): Promise<void> {
+    // No initialization needed for Android interface
+    return Promise.resolve();
+  }
+  
+  track(eventName: string, data: any): void {
+     switch (eventName) {
+      case AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED:
+        this.handleLevelCompleted(data);
+        break;
+      default:
+        console.warn(`Unhandled event: ${event} width data:`, data);
+    }
+  }
+  
+  dispose(): void {
+    // nothing to dispose for Android interface
+  }
+
+  private handleLevelCompleted(data: any) {
+    const { duration } = data;
+    this.androidInterface .logSummaryData({
+      levels_completed: 1,
+      time_spent_total_second: duration ?? 0
+    }, {
+      levels_completed: 'add',
+      time_spent_total_second: 'add'
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -78,7 +78,7 @@
     },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "types": ["jest", "node"],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     // "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
# Changes
- updated core package
- created android strategy
- integrated strategy to analytics integration

# How to test
- npm run test android-analytics-strategy
- Setting `debug=true, log=true` in `const androidStrategy = new AndroidAnalyticsStrategy({ cr_user_id: pseudoId ?? '' });`
  - completed a level
  - observe logs
 

Ref: [MR-61](https://curiouslearning.atlassian.net/browse/MR-61)


[MR-61]: https://curiouslearning.atlassian.net/browse/MR-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ