### PR TITLE
feat: added level completed handler for anroid analytics strategy (MR-62)

### DIFF
--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -1,3 +1,4 @@
+import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 import { AndroidAnalyticsStrategy } from './android-analytics-strategy';
 
 const mockLogSummaryData = jest.fn();
@@ -33,7 +34,7 @@ describe('Feature: Android analytics strategy', () => {
   describe('Scenario: Tracking a level_completed event', () => {
     it('Given a level_completed event with a duration, when track is called, then logSummaryData is called with the correct payload', () => {
       // Given
-      const eventName = AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED;
+      const eventName = AnalyticsEventType.LEVEL_COMPLETED;
       const data = { duration: 45 };
 
       // When
@@ -49,7 +50,7 @@ describe('Feature: Android analytics strategy', () => {
 
     it('Given a level_completed event with no duration, when track is called, then time_spent_total_second defaults to 0', () => {
       // Given
-      const eventName = AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED;
+      const eventName = AnalyticsEventType.LEVEL_COMPLETED;
       const data = {};
 
       // When
@@ -59,6 +60,39 @@ describe('Feature: Android analytics strategy', () => {
       expect(mockLogSummaryData).toHaveBeenCalledWith(
         { levels_completed: 1, time_spent_total_second: 0 },
         { levels_completed: 'add', time_spent_total_second: 'add' }
+      );
+    });
+  });
+
+  describe('Scenario: Tracking a puzzle_completed event', () => {
+    it('Given a puzzle_completed event with success_or_failure true, when track is called, then logSummaryData is called with puzzle_success 1 and puzzle_failure 0', () => {
+      // Given
+      const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
+      const data = { success_or_failure: true };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogSummaryData).toHaveBeenCalledTimes(1);
+      expect(mockLogSummaryData).toHaveBeenCalledWith(
+        { puzzles_completed: 1, puzzle_success: 1, puzzle_failure: 0 },
+        { puzzles_completed: 'add', puzzle_success: 'add', puzzle_failure: 'add' }
+      );
+    });
+
+    it('Given a puzzle_completed event with success_or_failure false, when track is called, then logSummaryData is called with puzzle_success 0 and puzzle_failure 1', () => {
+      // Given
+      const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
+      const data = { success_or_failure: false };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogSummaryData).toHaveBeenCalledWith(
+        { puzzles_completed: 1, puzzle_success: 0, puzzle_failure: 1 },
+        { puzzles_completed: 'add', puzzle_success: 'add', puzzle_failure: 'add' }
       );
     });
   });

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -1,5 +1,6 @@
 import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
 import { AndroidInterface } from '@curiouslearning/core';
+import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 
 export interface AndroidAnalyticsStrategyOptions {
   cr_user_id: string;
@@ -8,14 +9,6 @@ export interface AndroidAnalyticsStrategyOptions {
 export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   private readonly cr_user_id: string;
   private readonly androidInterface : AndroidInterface;
-
-  /**
-   * TODO: consolidate these events in one place, current duplication of analytics events.
-   * Events can be shared between in-game functionality and not just analytics.
-   */
-  static readonly EVENTS = {
-    LEVEL_COMPLETED: 'level_completed'
-  };
 
   constructor(options: AndroidAnalyticsStrategyOptions) {
     super();
@@ -33,8 +26,11 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   
   track(eventName: string, data: any): void {
      switch (eventName) {
-      case AndroidAnalyticsStrategy.EVENTS.LEVEL_COMPLETED:
+      case AnalyticsEventType.LEVEL_COMPLETED:
         this.handleLevelCompleted(data);
+        break;
+      case AnalyticsEventType.PUZZLE_COMPLETED:
+        this.handlePuzzleCompleted(data);
         break;
       default:
         console.warn(`Unhandled event: ${event} width data:`, data);
@@ -53,6 +49,19 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     }, {
       levels_completed: 'add',
       time_spent_total_second: 'add'
+    });
+  }
+
+  private handlePuzzleCompleted(data: any) {
+    const { success_or_failure } = data;
+    this.androidInterface .logSummaryData({
+      puzzles_completed: 1,
+      puzzle_success: success_or_failure ? 1 : 0,
+      puzzle_failure: success_or_failure ? 0 : 1,
+    }, {
+      puzzles_completed: 'add',
+      puzzle_success: 'add',
+      puzzle_failure: 'add'
     });
   }
 }


### PR DESCRIPTION
# Changes
- refactored to used `AnalyticsEventType` event names
- feat: added handler for puzzle completed event
- unit tests

# How to test
- npm run test android-analytics-strategy.spec
- alternatively, you can set AndroidInterface to use  `{debug: true, log: true}`
Ref: [MR-62](https://curiouslearning.atlassian.net/browse/MR-62)


[MR-62]: https://curiouslearning.atlassian.net/browse/MR-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ