### PR TITLE
feat: added highest level reached in event bubble handling (MR-60)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,8 @@ workflows:
       - build-and-deploy-test:
           context:
             - aws-context
+          requires:
+            - node/test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,13 @@ jobs:
       - build-and-deploy:
           to: 's3://globallit-aws-s3-static-webapp-test-us-east-2/feed-the-monster'
   
+  build-and-deploy-release:
+    docker:
+      - image: cimg/python:3.13.2-node
+    steps:
+      - build-and-deploy:
+          to: 's3://globallit-aws-s3-static-webapp-test-us-east-2/feed-the-monster-release'
+
   build-and-deploy-prod:
     docker:
       - image: cimg/python:3.13.2-node
@@ -103,6 +110,13 @@ workflows:
             branches:
               only:
                 - test
+      - build-and-deploy-release:
+          context:
+            - aws-context
+          filters:
+            branches:
+              only:
+                - /.*epic.*/
       - build-and-deploy-prod:
           context:
             - aws-context

--- a/src/analytics/analytics-event-interface.ts
+++ b/src/analytics/analytics-event-interface.ts
@@ -114,6 +114,7 @@ export interface CommonEventProperties {
     level_number: number;
     number_of_successful_puzzles: number;
     duration: number;
+    highest_level_completed: number;
   }
   
   /**

--- a/src/analytics/analytics-integration.spec.ts
+++ b/src/analytics/analytics-integration.spec.ts
@@ -123,6 +123,7 @@ describe('AnalyticsIntegration Core', () => {
         number_of_successful_puzzles: 3,
         level_number: 5,
         duration: 120,
+        highest_level_completed: 5,
       });
 
       expect(mockAnalyticsService.track).toHaveBeenCalledWith(
@@ -496,7 +497,7 @@ describe('Firebase Event Logging - level_completed', () => {
     logLevelEndFirebaseEvent = () => {
       const endTime = Date.now();
       const levelCompletedData = {
-        cr_user_id: null,
+        cr_user_id: undefined,
         ftm_language: "english",
         profile_number: 0,
         version_number: document.getElementById('version-info-id')?.innerHTML,
@@ -506,6 +507,7 @@ describe('Firebase Event Logging - level_completed', () => {
         number_of_successful_puzzles: score / 100,
         level_number: levelNumber,
         duration: (endTime - startTime) / 1000,
+        highest_level_completed: levelNumber,
       };
       analyticsIntegration.track(AnalyticsEventType.LEVEL_COMPLETED, levelCompletedData);
     };
@@ -517,7 +519,7 @@ describe('Firebase Event Logging - level_completed', () => {
     expect(mockAnalyticsService.track).toHaveBeenCalledWith(
       'level_completed',
       expect.objectContaining({
-        cr_user_id: null,
+        cr_user_id: undefined,
         ftm_language: "english",
         profile_number: 0,
         version_number: '3.4.5',
@@ -542,7 +544,7 @@ describe('Firebase Event Logging - level_completed', () => {
     const startTime = endTime - 8000;
 
     const levelCompletedData = {
-      cr_user_id: null,
+      cr_user_id: undefined,
       ftm_language: "english",
       profile_number: 0,
       version_number: '3.4.5',
@@ -552,6 +554,7 @@ describe('Firebase Event Logging - level_completed', () => {
       number_of_successful_puzzles: score / 100,
       level_number: 9,
       duration: (endTime - startTime) / 1000,
+      highest_level_completed: 9,
     };
 
     analyticsIntegration.track(AnalyticsEventType.LEVEL_COMPLETED, levelCompletedData);

--- a/src/data/game-score.spec.ts
+++ b/src/data/game-score.spec.ts
@@ -1,0 +1,121 @@
+import { GameScore } from './game-score';
+
+jest.mock('@common', () => ({
+  lang: 'en',
+  Debugger: { DebugMode: false },
+}));
+
+const LANG_PREFIX = 'en';
+const HIGHEST_KEY = `${LANG_PREFIX}highestLevelReached`;
+const GAME_INFO_KEY = `${LANG_PREFIX}gamePlayedInfo`;
+
+const makeLevelInfo = (levelNumber: number, starCount: number) => ({
+  levelName: 'type1',
+  levelNumber,
+  score: starCount * 100,
+  starCount,
+  treasureChestMiniGameScore: 0,
+});
+
+describe('Feature: GameScore - highest level tracking', () => {
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    store = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(
+      (key: string) => store[key] ?? null
+    );
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(
+      (key: string, value: string) => { store[key] = value; }
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Scenario: updateHighestLevelReached with multiple played levels', () => {
+    it('Given multiple played levels in storage, when updateHighestLevelReached is called, then the highest levelNumber is persisted to localStorage', () => {
+      // Given
+      store[GAME_INFO_KEY] = JSON.stringify([
+        makeLevelInfo(0, 5),
+        makeLevelInfo(3, 3),
+        makeLevelInfo(1, 4),
+      ]);
+
+      // When
+      GameScore.updateHighestLevelReached();
+
+      // Then
+      expect(store[HIGHEST_KEY]).toBe('3');
+    });
+  });
+
+  describe('Scenario: updateHighestLevelReached with a single played level', () => {
+    it('Given a single played level in storage, when updateHighestLevelReached is called, then that level number is persisted', () => {
+      // Given
+      store[GAME_INFO_KEY] = JSON.stringify([makeLevelInfo(2, 3)]);
+
+      // When
+      GameScore.updateHighestLevelReached();
+
+      // Then
+      expect(store[HIGHEST_KEY]).toBe('2');
+    });
+  });
+
+  describe('Scenario: updateHighestLevelReached with no played levels', () => {
+    it('Given no played levels in storage, when updateHighestLevelReached is called, then localStorage is not written', () => {
+      // Given
+      store[GAME_INFO_KEY] = JSON.stringify([]);
+
+      // When
+      GameScore.updateHighestLevelReached();
+
+      // Then
+      expect(store[HIGHEST_KEY]).toBeUndefined();
+    });
+  });
+
+  describe('Scenario: getHighestLevelReached when value is already cached', () => {
+    it('Given highestLevelReached is already stored in localStorage, when getHighestLevelReached is called, then it returns the cached value without recomputing', () => {
+      // Given
+      store[HIGHEST_KEY] = '7';
+
+      // When
+      const result = GameScore.getHighestLevelReached();
+
+      // Then
+      expect(result).toBe(7);
+      expect(store[GAME_INFO_KEY]).toBeUndefined();
+    });
+  });
+
+  describe('Scenario: getHighestLevelReached reconciles when cache is missing', () => {
+    it('Given no cached value but played levels exist, when getHighestLevelReached is called, then it reconciles from game data and returns the highest level number', () => {
+      // Given
+      store[GAME_INFO_KEY] = JSON.stringify([
+        makeLevelInfo(0, 5),
+        makeLevelInfo(4, 3),
+        makeLevelInfo(2, 4),
+      ]);
+
+      // When
+      const result = GameScore.getHighestLevelReached();
+
+      // Then
+      expect(result).toBe(4);
+      expect(store[HIGHEST_KEY]).toBe('4');
+    });
+  });
+
+  describe('Scenario: getHighestLevelReached when no data exists at all', () => {
+    it('Given no cached value and no played levels, when getHighestLevelReached is called, then it returns -1', () => {
+      // When
+      const result = GameScore.getHighestLevelReached();
+
+      // Then
+      expect(result).toBe(-1);
+    });
+  });
+});

--- a/src/data/game-score.ts
+++ b/src/data/game-score.ts
@@ -88,6 +88,7 @@ export class GameScore {
 
     // Update total star count dynamically
     this.updateTotalStarCount();
+    this.updateHighestLevelReached();
   }
 
   /**
@@ -161,6 +162,24 @@ export class GameScore {
       case score >= 100: return 1;
       default: return 0;
     }
+  }
+
+  public static updateHighestLevelReached(): void {
+    const allLevels = this.getAllGameLevelInfo();
+    if (!allLevels.length) return;
+    const highest = allLevels.reduce(
+      (max, level) => level.levelNumber > max ? level.levelNumber : max,
+      -1
+    );
+    localStorage.setItem(this.currentlanguage + 'highestLevelReached', highest.toString());
+  }
+
+  public static getHighestLevelReached(): number {
+    const stored = localStorage.getItem(this.currentlanguage + 'highestLevelReached');
+    if (stored !== null) return parseInt(stored);
+    this.updateHighestLevelReached();
+    const reconciled = localStorage.getItem(this.currentlanguage + 'highestLevelReached');
+    return reconciled !== null ? parseInt(reconciled) : -1;
   }
 
   public static getDatafromStorage() {

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -32,10 +32,10 @@ describe('Feature: Android analytics strategy', () => {
   });
 
   describe('Scenario: Tracking a level_completed event', () => {
-    it('Given a level_completed event with a duration, when track is called, then logSummaryData is called with the correct payload', () => {
+    it('Given a level_completed event with duration and highest_level_completed, when track is called, then logSummaryData is called with all fields in the correct payload', () => {
       // Given
       const eventName = AnalyticsEventType.LEVEL_COMPLETED;
-      const data = { duration: 45 };
+      const data = { duration: 45, highest_level_completed: 7 };
 
       // When
       strategy.track(eventName, data);
@@ -43,7 +43,7 @@ describe('Feature: Android analytics strategy', () => {
       // Then
       expect(mockLogSummaryData).toHaveBeenCalledTimes(1);
       expect(mockLogSummaryData).toHaveBeenCalledWith(
-        { levels_completed: 1, time_spent_total_second: 45 },
+        { levels_completed: 1, time_spent_total_second: 45, highest_level_completed: 7 },
         { levels_completed: 'add', time_spent_total_second: 'add' }
       );
     });
@@ -51,14 +51,29 @@ describe('Feature: Android analytics strategy', () => {
     it('Given a level_completed event with no duration, when track is called, then time_spent_total_second defaults to 0', () => {
       // Given
       const eventName = AnalyticsEventType.LEVEL_COMPLETED;
-      const data = {};
+      const data = { highest_level_completed: 3 };
 
       // When
       strategy.track(eventName, data);
 
       // Then
       expect(mockLogSummaryData).toHaveBeenCalledWith(
-        { levels_completed: 1, time_spent_total_second: 0 },
+        { levels_completed: 1, time_spent_total_second: 0, highest_level_completed: 3 },
+        { levels_completed: 'add', time_spent_total_second: 'add' }
+      );
+    });
+
+    it('Given a level_completed event with no highest_level_completed, when track is called, then highest_level_completed defaults to 0', () => {
+      // Given
+      const eventName = AnalyticsEventType.LEVEL_COMPLETED;
+      const data = { duration: 30 };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogSummaryData).toHaveBeenCalledWith(
+        { levels_completed: 1, time_spent_total_second: 30, highest_level_completed: 0 },
         { levels_completed: 'add', time_spent_total_second: 'add' }
       );
     });

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -80,10 +80,10 @@ describe('Feature: Android analytics strategy', () => {
   });
 
   describe('Scenario: Tracking a puzzle_completed event', () => {
-    it('Given a puzzle_completed event with success_or_failure true, when track is called, then logSummaryData is called with puzzle_success 1 and puzzle_failure 0', () => {
+    it('Given a puzzle_completed event with success_or_failure "success", when track is called, then logSummaryData is called with puzzle_success 1 and puzzle_failure 0', () => {
       // Given
       const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
-      const data = { success_or_failure: true };
+      const data = { success_or_failure: 'success' };
 
       // When
       strategy.track(eventName, data);
@@ -96,10 +96,10 @@ describe('Feature: Android analytics strategy', () => {
       );
     });
 
-    it('Given a puzzle_completed event with success_or_failure false, when track is called, then logSummaryData is called with puzzle_success 0 and puzzle_failure 1', () => {
+    it('Given a puzzle_completed event with success_or_failure "failure", when track is called, then logSummaryData is called with puzzle_success 0 and puzzle_failure 1', () => {
       // Given
       const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
-      const data = { success_or_failure: false };
+      const data = { success_or_failure: 'failure' };
 
       // When
       strategy.track(eventName, data);

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -1,5 +1,6 @@
 import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
 import { AndroidInterface } from '@curiouslearning/core';
+import { LevelCompletedEvent } from 'src/analytics/analytics-event-interface';
 import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 
 export interface AndroidAnalyticsStrategyOptions {
@@ -27,7 +28,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   track(eventName: string, data: any): void {
      switch (eventName) {
       case AnalyticsEventType.LEVEL_COMPLETED:
-        this.handleLevelCompleted(data);
+        this.handleLevelCompleted(data as LevelCompletedEvent);
         break;
       case AnalyticsEventType.PUZZLE_COMPLETED:
         this.handlePuzzleCompleted(data);
@@ -41,11 +42,12 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     // nothing to dispose for Android interface
   }
 
-  private handleLevelCompleted(data: any) {
-    const { duration } = data;
+  private handleLevelCompleted(data: LevelCompletedEvent) {
+    const { duration, highest_level_completed } = data;
     this.androidInterface .logSummaryData({
       levels_completed: 1,
-      time_spent_total_second: duration ?? 0
+      time_spent_total_second: duration ?? 0,
+      highest_level_completed: highest_level_completed ?? 0
     }, {
       levels_completed: 'add',
       time_spent_total_second: 'add'

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -58,8 +58,8 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     const { success_or_failure } = data;
     this.androidInterface .logSummaryData({
       puzzles_completed: 1,
-      puzzle_success: success_or_failure ? 1 : 0,
-      puzzle_failure: success_or_failure ? 0 : 1,
+      puzzle_success: success_or_failure === 'success' ? 1 : 0,
+      puzzle_failure: success_or_failure === 'failure' ? 1 : 0,
     }, {
       puzzles_completed: 'add',
       puzzle_success: 'add',

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -316,7 +316,6 @@ export class GameplayFlowManager {
         this.uiManager.updateStars(this.currentPuzzleIndex, this.isCorrect);
 
         this.timeoutRegistry.setTimeout(() => {
-            this.logLevelEndFirebaseEvent();
             const starsCount = GameScore.calculateStarCount(this.score);
             const levelEndData = {
                 starCount: starsCount,
@@ -326,11 +325,6 @@ export class GameplayFlowManager {
                 score: this.score,
             };
 
-            gameStateService.publish(
-                gameStateService.EVENTS.LEVEL_END_DATA_EVENT,
-                { levelEndData, data: this.data }
-            );
-
             // Save to local storage.
             GameScore.setGameLevelScore(
                 this.levelData,
@@ -338,6 +332,11 @@ export class GameplayFlowManager {
                 this.treasureChestScore
             );
 
+            this.logLevelEndFirebaseEvent();
+            gameStateService.publish(
+                gameStateService.EVENTS.LEVEL_END_DATA_EVENT,
+                { levelEndData, data: this.data }
+            );
             this.switchSceneAtGameEnd(starsCount, this.treasureChestScore);
             this.monsterController.dispose();
         }, delay);
@@ -437,6 +436,7 @@ export class GameplayFlowManager {
                 number_of_successful_puzzles: this.score / 100,
                 level_number: this.levelData.levelMeta.levelNumber,
                 duration: (endTime - this.startTime) / 1000,
+                highest_level_completed: GameScore.getHighestLevelReached()
             }
         );
     }

--- a/src/scenes/level-selection-scene/level-selection-controller.spec.ts
+++ b/src/scenes/level-selection-scene/level-selection-controller.spec.ts
@@ -1,4 +1,5 @@
 import { levelSelectionController } from './level-selection-controller';
+import { GameScore } from '@data';
 import { AudioPlayer } from "@components";
 
 jest.mock("@components", () => ({
@@ -9,11 +10,24 @@ jest.mock("@components", () => ({
   })),
 }));
 
+jest.mock('@data', () => ({
+  GameScore: {
+    getHighestLevelReached: jest.fn(),
+    getGameLevelData: jest.fn(),
+  },
+}));
+
+const mockGetHighestLevelReached = GameScore.getHighestLevelReached as jest.Mock;
+const mockGetGameLevelData = GameScore.getGameLevelData as jest.Mock;
+
 describe('levelSelectionController', () => {
   let controller: any;
   let startGameCallback: jest.Mock;
 
   beforeEach(() => {
+    mockGetHighestLevelReached.mockReturnValue(-1);
+    mockGetGameLevelData.mockReturnValue(null);
+
     document.body.innerHTML = `<div id="root"></div>`;
 
     startGameCallback = jest.fn();
@@ -23,7 +37,7 @@ describe('levelSelectionController', () => {
       options: { selectors: { root: '#root' } },
       startGameCallback,
       maxGameLevels: 12,
-      playedGameLevels: [{ levelNumber: 0, starCount: 3 }],
+      playedGameLevels: [],
       previousPlayedLevel: 0,
       isDebuggerOn: false,
       gameLevels: [],
@@ -32,6 +46,7 @@ describe('levelSelectionController', () => {
 
   afterEach(() => {
     controller.dispose?.();
+    jest.clearAllMocks();
   });
 
   it('should initialize with correct total pages and current page', () => {
@@ -60,32 +75,99 @@ describe('levelSelectionController', () => {
     expect(startGameCallback).toHaveBeenCalledWith(0);
   });
 
+  describe('Feature: updateNextPlayableLevel', () => {
+    describe('Scenario: No levels have been played yet', () => {
+      it('Given getHighestLevelReached returns -1, when updateNextPlayableLevel is called, then nextPlayableLevel is set to 1', () => {
+        // Given
+        mockGetHighestLevelReached.mockReturnValue(-1);
+
+        // When
+        controller.updateNextPlayableLevel();
+
+        // Then
+        expect(controller.nextPlayableLevel).toBe(1);
+      });
+    });
+
+    describe('Scenario: Highest level was passed', () => {
+      it('Given the highest played level (0-based 2) was passed with 3 stars, when updateNextPlayableLevel is called, then nextPlayableLevel advances past it', () => {
+        // Given
+        mockGetHighestLevelReached.mockReturnValue(2);
+        mockGetGameLevelData.mockReturnValue({ starCount: 3 });
+
+        // When
+        controller.updateNextPlayableLevel();
+
+        // Then — (2 + 1) + 1 = 4
+        expect(controller.nextPlayableLevel).toBe(4);
+      });
+
+      it('Given the highest played level (0-based 2) was passed with 5 stars, when updateNextPlayableLevel is called, then nextPlayableLevel advances past it', () => {
+        // Given
+        mockGetHighestLevelReached.mockReturnValue(2);
+        mockGetGameLevelData.mockReturnValue({ starCount: 5 });
+
+        // When
+        controller.updateNextPlayableLevel();
+
+        // Then — (2 + 1) + 1 = 4
+        expect(controller.nextPlayableLevel).toBe(4);
+      });
+    });
+
+    describe('Scenario: Highest level was failed', () => {
+      it('Given the highest played level (0-based 2) was failed with 1 star, when updateNextPlayableLevel is called, then nextPlayableLevel stays on that level', () => {
+        // Given
+        mockGetHighestLevelReached.mockReturnValue(2);
+        mockGetGameLevelData.mockReturnValue({ starCount: 1 });
+
+        // When
+        controller.updateNextPlayableLevel();
+
+        // Then — (2 + 1) + 0 = 3
+        expect(controller.nextPlayableLevel).toBe(3);
+      });
+
+      it('Given the highest played level (0-based 2) was failed with 2 stars, when updateNextPlayableLevel is called, then nextPlayableLevel stays on that level', () => {
+        // Given
+        mockGetHighestLevelReached.mockReturnValue(2);
+        mockGetGameLevelData.mockReturnValue({ starCount: 2 });
+
+        // When
+        controller.updateNextPlayableLevel();
+
+        // Then — (2 + 1) + 0 = 3
+        expect(controller.nextPlayableLevel).toBe(3);
+      });
+    });
+  });
+
   describe('nextLevelIsPlayable', () => {
     it('should return true for next level when previous level is passed', () => {
-      controller.playedGameLevels = [
-        { levelNumber: 0, starCount: 3 },
-      ];
-      controller.updateNextPlayableLevel();
+      // Given
+      mockGetHighestLevelReached.mockReturnValue(0);
+      mockGetGameLevelData.mockReturnValue({ starCount: 3 });
+      controller.updateNextPlayableLevel(); // nextPlayableLevel = (0+1)+1 = 2
 
       const result = controller.nextLevelIsPlayable(2);
       expect(result).toBe(true);
     });
 
     it('should return true for same level when previous level is failed', () => {
-      controller.playedGameLevels = [
-        { levelNumber: 0, starCount: 1 },
-      ];
-      controller.updateNextPlayableLevel();
+      // Given
+      mockGetHighestLevelReached.mockReturnValue(0);
+      mockGetGameLevelData.mockReturnValue({ starCount: 1 });
+      controller.updateNextPlayableLevel(); // nextPlayableLevel = (0+1)+0 = 1
 
       const result = controller.nextLevelIsPlayable(1);
       expect(result).toBe(true);
     });
 
     it('should return false for other levels', () => {
-      controller.playedGameLevels = [
-        { levelNumber: 0, starCount: 3 },
-      ];
-      controller.updateNextPlayableLevel();
+      // Given
+      mockGetHighestLevelReached.mockReturnValue(0);
+      mockGetGameLevelData.mockReturnValue({ starCount: 3 });
+      controller.updateNextPlayableLevel(); // nextPlayableLevel = 2
 
       const result = controller.nextLevelIsPlayable(3);
       expect(result).toBe(false);
@@ -105,10 +187,10 @@ describe('levelSelectionController', () => {
   });
 
   it('should lock levels higher than current playable level', () => {
-    controller.playedGameLevels = [
-      { levelNumber: 0, starCount: 3 },
-    ];
-    controller.updateNextPlayableLevel();
+    // Given
+    mockGetHighestLevelReached.mockReturnValue(0);
+    mockGetGameLevelData.mockReturnValue({ starCount: 3 });
+    controller.updateNextPlayableLevel(); // nextPlayableLevel = 2
 
     const isLocked = controller.isGameLocked(3, 2);
     expect(isLocked).toBe(true);

--- a/src/scenes/level-selection-scene/level-selection-controller.ts
+++ b/src/scenes/level-selection-scene/level-selection-controller.ts
@@ -8,6 +8,7 @@ import {
   BACK_BTN_IMG,
   AUDIO_INTRO
  } from '@constants';
+import { GameScore } from '@data';
 import { LevelSelectionGameBtn, LevelSelectionNavBtn } from '@buttons';
 import { AudioPlayer } from "@components";
 
@@ -248,29 +249,14 @@ export class levelSelectionController extends BaseHTML {
   }
 
   private updateNextPlayableLevel() {
-    if (this.playedGameLevels?.length) {
-      // Find highest played level
-      let highestPrevLevel = 0;
-      let isLevelFailed = false;
-
-      for (const levelData of this.playedGameLevels) {
-
-        if (highestPrevLevel < levelData?.levelNumber || this.playedGameLevels.length === 1) {
-          highestPrevLevel = levelData?.levelNumber;
-          isLevelFailed = levelData?.starCount < 3;
-        }
-      }
-
-      // Convert to 1-based game level
-      highestPrevLevel = highestPrevLevel + 1;
-
-      // Determine next playable level.
-      this.nextPlayableLevel = highestPrevLevel + (isLevelFailed ? 0 : 1);
-
-    } else {
-      // First level if no data exists
+    const highestLevelNumber = GameScore.getHighestLevelReached();
+    if (highestLevelNumber === -1) {
       this.nextPlayableLevel = 1;
+      return;
     }
+    const levelData = GameScore.getGameLevelData(highestLevelNumber);
+    const isLevelFailed = (levelData?.starCount ?? 0) < 3;
+    this.nextPlayableLevel = (highestLevelNumber + 1) + (isLevelFailed ? 0 : 1);
   }
 
   private nextLevelIsPlayable(currentGameLevel: number): boolean {


### PR DESCRIPTION
# Changes
- Minor refactor and moved highest level reached logic to game score
- Updated usage in level scene selector
- Added highest level reached in level completed event
- Added highest level reached in android strategy
- Updated unit tests
- Added test env builds for epic branches for parallel testing

# How to test
- npm run test
- Set debug and log to true in android strategy, to observe logs.

Ref: [MR-60](https://curiouslearning.atlassian.net/browse/MR-60)


[MR-60]: https://curiouslearning.atlassian.net/browse/MR-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ