### PR TITLE
fix: highest_level_completed is now 1-based indexing (MR-89)

### DIFF
--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -436,7 +436,7 @@ export class GameplayFlowManager {
                 number_of_successful_puzzles: this.score / 100,
                 level_number: this.levelData.levelMeta.levelNumber,
                 duration: (endTime - this.startTime) / 1000,
-                highest_level_completed: GameScore.getHighestLevelReached()
+                highest_level_completed: GameScore.getHighestLevelReached() + 1 // from 0-based index
             }
         );
     }


### PR DESCRIPTION
# Changes
- fix: highest level completed in level completed event is now 1-based index


Ref: [MR-89](https://curiouslearning.atlassian.net/browse/MR-89)


[MR-89]: https://curiouslearning.atlassian.net/browse/MR-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ