### PR TITLE
Update level_completed to send user_sessions_data

### DIFF
--- a/src/analytics/analytics-event-interface.ts
+++ b/src/analytics/analytics-event-interface.ts
@@ -115,6 +115,7 @@ export interface CommonEventProperties {
     number_of_successful_puzzles: number;
     duration: number;
     highest_level_completed: number;
+    levelType?: string;
   }
   
   /**

--- a/src/analytics/analytics-event-interface.ts
+++ b/src/analytics/analytics-event-interface.ts
@@ -115,7 +115,7 @@ export interface CommonEventProperties {
     number_of_successful_puzzles: number;
     duration: number;
     highest_level_completed: number;
-    levelType?: string;
+    level_type?: string;
   }
   
   /**

--- a/src/common/global-variables.ts
+++ b/src/common/global-variables.ts
@@ -7,8 +7,11 @@ export var pseudoId = urlParams.get("cr_user_id");
 export var source = urlParams.get("source") == null ? null : urlParams.get("source");
 export var campaign_id = urlParams.get("campaign_id") == null ? null : urlParams.get("campaign_id");
 
-export var lang =
-  urlParams.get("cr_lang") == null ? "english" : urlParams.get("cr_lang");
+// export var lang =
+  // urlParams.get("cr_lang") == null ? "english" : urlParams.get("cr_lang");
+
+export const lang: string =
+  urlParams.get("cr_lang") ?? "english";
 
 export const font = Utils.getLanguageSpecificFont(lang);
 export const Debugger = {

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -85,7 +85,7 @@ describe('Feature: Android analytics strategy', () => {
       const eventName = AnalyticsEventType.LEVEL_COMPLETED;
       const data = {
         level_number: 1,
-        levelType: 'LetterOnly',
+        level_type: 'LetterOnly',
         ftm_language: 'english'
       };
 

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -2,10 +2,12 @@ import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 import { AndroidAnalyticsStrategy } from './android-analytics-strategy';
 
 const mockLogSummaryData = jest.fn();
+const mockLogUserSessionsData = jest.fn();
 
 jest.mock('@curiouslearning/core', () => ({
   AndroidInterface: jest.fn().mockImplementation(() => ({
     logSummaryData: mockLogSummaryData,
+    logUserSessionsData: mockLogUserSessionsData,
   })),
 }));
 
@@ -76,6 +78,32 @@ describe('Feature: Android analytics strategy', () => {
         { levels_completed: 1, time_spent_total_second: 30, highest_level_completed: 0 },
         { levels_completed: 'add', time_spent_total_second: 'add' }
       );
+    });
+
+    it('Given a level_completed event with level type and language, when track is called, then logUserSessionsData is also called with the user session payload', () => {
+      // Given
+      const eventName = AnalyticsEventType.LEVEL_COMPLETED;
+      const data = {
+        level_number: 1,
+        levelType: 'LetterOnly',
+        ftm_language: 'english'
+      };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogUserSessionsData).toHaveBeenCalledTimes(1);
+      expect(mockLogUserSessionsData).toHaveBeenCalledWith({
+        app_id: 'feedthemonster',
+        cr_user_id: 'user-123',
+        data: {
+          type: 'LetterOnly',
+          event_type: 'level_completed',
+          lang: 'english',
+          level: 1,
+        }
+      });
     });
   });
 

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -43,7 +43,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   }
 
   private handleLevelCompleted(data: LevelCompletedEvent) {
-    const { duration, highest_level_completed , levelType, ftm_language ,level_number} = data;
+    const { duration, highest_level_completed , level_type, ftm_language ,level_number} = data;
     this.androidInterface .logSummaryData({
       levels_completed: 1,
       time_spent_total_second: duration ?? 0,
@@ -57,7 +57,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
       app_id: 'feedthemonster',
       cr_user_id: this.cr_user_id,
       data: {
-        type: levelType ?? 'unknown',
+        type: level_type ?? 'unknown',
         event_type: 'level_completed',
         lang: ftm_language ?? 'unknown',
         level: level_number ?? 0,

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -43,7 +43,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   }
 
   private handleLevelCompleted(data: LevelCompletedEvent) {
-    const { duration, highest_level_completed } = data;
+    const { duration, highest_level_completed , levelType, ftm_language ,level_number} = data;
     this.androidInterface .logSummaryData({
       levels_completed: 1,
       time_spent_total_second: duration ?? 0,
@@ -51,6 +51,17 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     }, {
       levels_completed: 'add',
       time_spent_total_second: 'add'
+    });
+
+    this.androidInterface.logUserSessionsData({
+      app_id: 'feedthemonster',
+      cr_user_id: this.cr_user_id,
+      data: {
+        type: levelType ?? 'unknown',
+        event_type: 'level_completed',
+        lang: ftm_language ?? 'unknown',
+        level: level_number ?? 0,
+      }
     });
   }
 

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -435,7 +435,7 @@ export class GameplayFlowManager {
                 success_or_failure: GameScore.calculateStarCount(this.score) >= 3 ? "success" : "failure",
                 number_of_successful_puzzles: this.score / 100,
                 level_number: this.levelData.levelMeta.levelNumber,
-                levelType: this.levelData.levelMeta.levelType,
+                level_type: this.levelData.levelMeta.levelType,
                 duration: (endTime - this.startTime) / 1000,
                 highest_level_completed: GameScore.getHighestLevelReached(),
                 ftm_language:lang,

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -435,8 +435,10 @@ export class GameplayFlowManager {
                 success_or_failure: GameScore.calculateStarCount(this.score) >= 3 ? "success" : "failure",
                 number_of_successful_puzzles: this.score / 100,
                 level_number: this.levelData.levelMeta.levelNumber,
+                levelType: this.levelData.levelMeta.levelType,
                 duration: (endTime - this.startTime) / 1000,
-                highest_level_completed: GameScore.getHighestLevelReached()
+                highest_level_completed: GameScore.getHighestLevelReached(),
+                ftm_language:lang,
             }
         );
     }


### PR DESCRIPTION
# Changes
- src/analytics/analytics-event-interface.ts
- src/common/global-variables.ts
- src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
- src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
- src/scenes/gameplay-scene/gameplay-flow-manager.ts

# How to test
-Complete any level to trigger the level_completed event, which will log the data to the user_sessions_data collection.

Ref: [MR-76](https://curiouslearning.atlassian.net/jira/software/projects/MR/boards/76?selectedIssue=MR-76)


[MR-76]: https://curiouslearning.atlassian.net/browse/MR-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ