### PR TITLE
fix: [FM-907] fix for the update prompt to only appear after the update has be…

### DIFF
--- a/src/sw-src.js
+++ b/src/sw-src.js
@@ -7,10 +7,9 @@ workbox.precaching.precacheAndRoute(self.__WB_MANIFEST, {
 });
 var number = 0;
 var version = 1.26;
-// self.addEventListener('activate', function(e) {
-//     console.log("activated");
-//
-// });
+
+// True when a previous SW is already active, meaning this is an update rather than a first install.
+const isUpdate = !!self.registration.active;
 
 self.addEventListener("install", async function (e) {
   self.skipWaiting();
@@ -18,7 +17,19 @@ self.addEventListener("install", async function (e) {
 });
 const channel = new BroadcastChannel("my-channel");
 self.addEventListener("activate", function (event) {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    self.clients.claim().then(() => {
+      // Notify only after the new SW has fully activated and claimed all clients,
+      // so a reload triggered by the prompt is guaranteed to be served by the new SW.
+      if (isUpdate) {
+        return self.clients.matchAll({ type: "window" }).then((clients) => {
+          clients.forEach((client) =>
+            client.postMessage({ msg: "Update Found" })
+          );
+        });
+      }
+    })
+  );
 });
 channel.addEventListener("message", async function (event) {
   if (event.data.command === "Cache") {
@@ -40,21 +51,6 @@ channel.addEventListener("message", async function (event) {
       },
     });
   }
-});
-
-self.registration.addEventListener("updatefound", function (e) {
-  caches.keys().then((cacheNames) => {
-    cacheNames.forEach((cacheName) => {
-      if (cacheName == workbox.core.cacheNames.precache) {
-        // caches.delete(cacheName);
-        self.clients.matchAll().then((clients) => {
-          clients.forEach((client) =>
-            client.postMessage({ msg: "Update Found" })
-          );
-        });
-      }
-    });
-  });
 });
 
 // Preload additional assets


### PR DESCRIPTION
# Changes
- changed the update prompt to appear after the update is finished instead of when an update is detected

# How to test
- Throttle down network then try to update the game. Update prompt should appear after the download is complete

Ref: [FM-907](https://curiouslearning.atlassian.net/browse/FM-907)


[FM-907]: https://curiouslearning.atlassian.net/browse/FM-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of app update notifications during service worker activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/FeedTheMonsterJS/pull/1964)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->