### PR TITLE
MR-76 Flatten analytics payload for Android

### DIFF
--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -95,14 +95,10 @@ describe('Feature: Android analytics strategy', () => {
       // Then
       expect(mockLogUserSessionsData).toHaveBeenCalledTimes(1);
       expect(mockLogUserSessionsData).toHaveBeenCalledWith({
-        app_id: 'feedthemonster',
-        cr_user_id: 'user-123',
-        data: {
-          type: 'LetterOnly',
-          event_type: 'level_completed',
-          lang: 'english',
-          level: 1,
-        }
+        type: 'LetterOnly',
+        event_type: 'level_completed',
+        lang: 'english',
+        level: 1,
       });
     });
   });

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -54,14 +54,10 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     });
 
     this.androidInterface.logUserSessionsData({
-      app_id: 'feedthemonster',
-      cr_user_id: this.cr_user_id,
-      data: {
-        type: level_type ?? 'unknown',
-        event_type: 'level_completed',
-        lang: ftm_language ?? 'unknown',
-        level: level_number ?? 0,
-      }
+      type: level_type ?? 'unknown',
+      event_type: 'level_completed',
+      lang: ftm_language ?? 'unknown',
+      level: level_number ?? 0,
     });
   }
 


### PR DESCRIPTION
# Changes
- src/modules/android/services/analytics-strategy/android-analytics-strategy.ts

# How to test
- Check FireStore logging for user_sessions_data collection

Ref: [MR-76](https://curiouslearning.atlassian.net/jira/software/projects/MR/boards/76?selectedIssue=MR-76)


[MR-76]: https://curiouslearning.atlassian.net/browse/MR-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ