### PR TITLE
fix: [FM-919] forward pseudoId to embedded assessment as user-id

### DIFF
--- a/src/assessment/assessment-survey-manager.ts
+++ b/src/assessment/assessment-survey-manager.ts
@@ -1,5 +1,6 @@
 import '@curiouslearning/assessment-survey/register';
 import { AnalyticsConfig, AssessmentCompletedPayload } from '@curiouslearning/assessment-survey';
+import { pseudoId } from '../common/global-variables';
 import { resolveAssessmentDataKey } from './assessment-data-key';
 import { AssessmentCacheClient } from './assessment-cache-client';
 import { AssessmentOverlay } from './ui/assessment-overlay';
@@ -116,6 +117,7 @@ export class AssessmentSurveyManager {
     const playerElement = createAssessmentPlayerElement({
       playerTag: this.playerTag,
       dataKey: resolvedDataKey,
+      userId: pseudoId,
       onLoaded: () => {
         console.log('[assessment-survey] loaded');
         options.onLoaded?.();

--- a/src/assessment/ui/assessment-player-element.ts
+++ b/src/assessment/ui/assessment-player-element.ts
@@ -6,6 +6,7 @@ import { getAssessmentBasePath } from '../assessment-asset-path';
 export interface AssessmentPlayerElementOptions {
   playerTag: string;
   dataKey: string;
+  userId?: string | null;
   analyticsConfig?: AnalyticsConfig;
   onLoaded?: () => void;
   onClose?: () => void;
@@ -33,7 +34,7 @@ export function createAssessmentPlayerElement(options: AssessmentPlayerElementOp
   playerElement.style.visibility = 'hidden';
 
   playerElement.setAttribute('data-key', options.dataKey);
-  playerElement.setAttribute('user-id', 'ftm-web-user');
+  playerElement.setAttribute('user-id', options.userId || 'ftm-web-user');
   playerElement.setAttribute('user-source', 'feed-the-monster-web');
   playerElement.setAttribute('asset-base-url', assessmentBasePath);
   playerElement.setAttribute('data-base-url', assessmentBasePath);


### PR DESCRIPTION
# Changes
- forward pseudoId to embedded assessment as user-id

Ref: [FM-919](https://curiouslearning.atlassian.net/browse/FM-919)


[FM-919]: https://curiouslearning.atlassian.net/browse/FM-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assessment surveys now support proper user identification, enabling the system to accurately track and attribute each user's responses within the assessment system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/FeedTheMonsterJS/pull/1969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->