### PR TITLE
fix: [MR-77] added "puzzle_completed" event to Firestore

### DIFF
--- a/src/analytics/analytics-event-interface.ts
+++ b/src/analytics/analytics-event-interface.ts
@@ -98,6 +98,7 @@ export interface CommonEventProperties {
     target: string;
     foils: string[] | string;
     response_time: number;
+    level_type?: string;
   }
   
   /**

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -144,7 +144,6 @@ describe('Feature: Android analytics strategy', () => {
         ftm_language: 'english',
         level_number: 1,
         puzzle_number: 1,
-        version_number: 'v2.34',
       };
 
       // When
@@ -159,7 +158,6 @@ describe('Feature: Android analytics strategy', () => {
         is_success: true,
         level: 1,
         puzzle: 1,
-        app_version: 'v2.34',
       });
     });
 
@@ -172,7 +170,6 @@ describe('Feature: Android analytics strategy', () => {
         ftm_language: 'english',
         level_number: 2,
         puzzle_number: 3,
-        version_number: 'v2.34',
       };
 
       // When
@@ -186,7 +183,6 @@ describe('Feature: Android analytics strategy', () => {
         is_success: false,
         level: 2,
         puzzle: 3,
-        app_version: 'v2.34',
       });
     });
   });

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -134,6 +134,61 @@ describe('Feature: Android analytics strategy', () => {
         { puzzles_completed: 'add', puzzle_success: 'add', puzzle_failure: 'add' }
       );
     });
+
+    it('Given a puzzle_completed event with level type, language, level, puzzle and version, when track is called, then logUserSessionsData is also called with the user session payload', () => {
+      // Given
+      const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
+      const data = {
+        success_or_failure: 'success',
+        level_type: 'LetterOnly',
+        ftm_language: 'english',
+        level_number: 1,
+        puzzle_number: 1,
+        version_number: 'v2.34',
+      };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogUserSessionsData).toHaveBeenCalledTimes(1);
+      expect(mockLogUserSessionsData).toHaveBeenCalledWith({
+        type: 'LetterOnly',
+        event_type: 'puzzle_completed',
+        lang: 'english',
+        is_success: true,
+        level: 1,
+        puzzle: 1,
+        app_version: 'v2.34',
+      });
+    });
+
+    it('Given a puzzle_completed event with success_or_failure "failure", when track is called, then logUserSessionsData is called with is_success false', () => {
+      // Given
+      const eventName = AnalyticsEventType.PUZZLE_COMPLETED;
+      const data = {
+        success_or_failure: 'failure',
+        level_type: 'Word',
+        ftm_language: 'english',
+        level_number: 2,
+        puzzle_number: 3,
+        version_number: 'v2.34',
+      };
+
+      // When
+      strategy.track(eventName, data);
+
+      // Then
+      expect(mockLogUserSessionsData).toHaveBeenCalledWith({
+        type: 'Word',
+        event_type: 'puzzle_completed',
+        lang: 'english',
+        is_success: false,
+        level: 2,
+        puzzle: 3,
+        app_version: 'v2.34',
+      });
+    });
   });
 
   describe('Scenario: Disposing the strategy', () => {

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -1,6 +1,6 @@
 import { AbstractAnalyticsStrategy } from '@curiouslearning/analytics';
 import { AndroidInterface } from '@curiouslearning/core';
-import { LevelCompletedEvent } from 'src/analytics/analytics-event-interface';
+import { LevelCompletedEvent, PuzzleCompletedEvent } from 'src/analytics/analytics-event-interface';
 import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 
 export interface AndroidAnalyticsStrategyOptions {
@@ -61,8 +61,8 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     });
   }
 
-  private handlePuzzleCompleted(data: any) {
-    const { success_or_failure } = data;
+  private handlePuzzleCompleted(data: PuzzleCompletedEvent) {
+    const { success_or_failure, level_type, ftm_language, level_number, puzzle_number, version_number } = data;
     this.androidInterface .logSummaryData({
       puzzles_completed: 1,
       puzzle_success: success_or_failure === 'success' ? 1 : 0,
@@ -71,6 +71,16 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
       puzzles_completed: 'add',
       puzzle_success: 'add',
       puzzle_failure: 'add'
+    });
+
+    this.androidInterface.logUserSessionsData({
+      type: level_type ?? 'unknown',
+      event_type: 'puzzle_completed',
+      lang: ftm_language ?? 'unknown',
+      is_success: success_or_failure === 'success',
+      level: level_number ?? 0,
+      puzzle: puzzle_number ?? 0,
+      app_version: version_number ?? 'unknown',
     });
   }
 }

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -79,8 +79,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
       lang: ftm_language ?? 'unknown',
       is_success: success_or_failure === 'success',
       level: level_number ?? 0,
-      puzzle: puzzle_number ?? 0,
-      app_version: version_number ?? 'unknown',
+      puzzle: puzzle_number ?? 0
     });
   }
 }

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -415,6 +415,7 @@ export class GameplayFlowManager {
                 json_version_number: this.jsonVersionNumber,
                 success_or_failure: isCorrect ? "success" : "failure",
                 level_number: this.levelData.levelMeta.levelNumber,
+                level_type: this.levelData.levelMeta.levelType,
                 puzzle_number: this.currentPuzzleIndex,
                 item_selected: itemSelected,
                 target: this.stoneHandler.getCorrectTargetStone(),


### PR DESCRIPTION
# Changes
- On puzzle completion, FTM now also emits a `user_sessions_data` payload to the Android/CRContainer Firestore bridge, in addition to the existing `summary_data` counters (which are unchanged). Payload fields: `type`, `event_type: "puzzle_completed"`, `lang`, `is_success` (boolean), `level`, `puzzle`, `app_version` — giving QA a per-puzzle audit trail to validate the aggregated `puzzle_success`/`puzzle_failure` summary counts.
- Added optional `level_type` to `PuzzleCompletedEvent` and forwarded it from `gameplay-flow-manager` so the Android strategy can populate `type` (mirrors the existing `level_completed` flow). Note: `level_type` now also appears as a parameter on the Firebase `puzzle_completed` event — additive, reuses the existing `level_type` custom dimension.
- Routing stays gated by the existing `mr-75` Android event-bubbling flag (the strategy is only registered when it's on); no new flag.
- Added unit tests for the new `user_sessions_data` payload (success and failure cases).

# How to test
- Manual (with `mr-75` enabled): load FTM inside the CRContainer debug app, complete a puzzle, and confirm via logcat (`BRIDGE_PAYLOAD … "collection":"user_sessions_data" … "event_type":"puzzle_completed"` → `User session saved docId=…`) that the document is written to the Firestore `user_sessions_data` collection with the boolean `is_success` and numeric `level`/`puzzle`.


Ref: [MR-77](https://curiouslearning.atlassian.net/browse/MR-77)


[MR-77]: https://curiouslearning.atlassian.net/browse/MR-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ