### PR TITLE
fix: Large Screen UI Issue — Chest Appears Oversized in Assessment and Small in Mini-Game

### DIFF
--- a/src/assessment/assessment-survey-manager.ts
+++ b/src/assessment/assessment-survey-manager.ts
@@ -156,7 +156,7 @@ export class AssessmentSurveyManager {
   }
 
   private getAssessmentTreasureChestLayout() {
-    const img: any = document.querySelector('.as-ui-mode-new #chestImage');
+    const img: any = document.querySelector('#chestImage');
     if (!img) return null;
 
     const rect = img.getBoundingClientRect();

--- a/src/assessment/assessment-survey-manager.ts
+++ b/src/assessment/assessment-survey-manager.ts
@@ -8,6 +8,7 @@ import {
   createAssessmentCloseButton,
   createAssessmentPlayerElement,
 } from './ui/assessment-player-element';
+import miniGameStateService from '@miniGameStateService';
 
 export interface AssessmentSurveyOpenOptions {
   dataKey?: string;
@@ -120,6 +121,14 @@ export class AssessmentSurveyManager {
       userId: pseudoId,
       onLoaded: () => {
         console.log('[assessment-survey] loaded');
+        const assessmentTreasureChestLayout = this.getAssessmentTreasureChestLayout();
+
+        miniGameStateService.publish(
+          miniGameStateService.EVENTS.USE_ASSESSMENT_TREASURE_CHEST_LAYOUT,
+          {
+            assessmentTreasureChestLayout
+          }
+        );
         options.onLoaded?.();
       },
       onComplete: (payload) => {
@@ -144,6 +153,20 @@ export class AssessmentSurveyManager {
     });
 
     this.assessmentOverlay.openWithChildren([playerElement, closeButton]);
+  }
+
+  private getAssessmentTreasureChestLayout() {
+    const img: any = document.querySelector('.as-ui-mode-new #chestImage');
+    if (!img) return null;
+
+    const rect = img.getBoundingClientRect();
+
+    return {
+      x: rect.left,
+      y: rect.top,
+      width: img.offsetWidth,
+      height: img.offsetHeight,
+    };
   }
 
   public close(): void {

--- a/src/miniGame/miniGameStateService/miniGameStateService.spec.ts
+++ b/src/miniGame/miniGameStateService/miniGameStateService.spec.ts
@@ -37,6 +37,7 @@ describe('Testing MiniGameStateService.', () => {
       expect(service.EVENTS).toEqual({
         IS_MINI_GAME_DONE: 'IS_MINI_GAME_DONE',
         MINI_GAME_WILL_START: 'MINI_GAME_WILL_START',
+        USE_ASSESSMENT_TREASURE_CHEST_LAYOUT: 'USE_ASSESSMENT_TREASURE_CHEST_LAYOUT'
       });
 
       // Ensure treasureChestCompletedLevel includes expected keys (2, 5, 15, 25, etc.)

--- a/src/miniGame/miniGameStateService/miniGameStateService.ts
+++ b/src/miniGame/miniGameStateService/miniGameStateService.ts
@@ -10,6 +10,7 @@ export class MiniGameStateService extends PubSub {
   public EVENTS: {
     IS_MINI_GAME_DONE: string;
     MINI_GAME_WILL_START: string;
+    USE_ASSESSMENT_TREASURE_CHEST_LAYOUT: string;
   }
   public audioPlayer: AudioPlayer = new AudioPlayer();
 
@@ -19,7 +20,8 @@ export class MiniGameStateService extends PubSub {
     super();
     this.EVENTS = {
       IS_MINI_GAME_DONE: 'IS_MINI_GAME_DONE',
-      MINI_GAME_WILL_START: 'MINI_GAME_WILL_START'
+      MINI_GAME_WILL_START: 'MINI_GAME_WILL_START',
+      USE_ASSESSMENT_TREASURE_CHEST_LAYOUT: 'USE_ASSESSMENT_TREASURE_CHEST_LAYOUT'
     };
     //Add states here needed for mini games
     this.treasureChestCompletedLevel = {};

--- a/src/miniGame/miniGames/treasureChest/treasureChest.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChest.ts
@@ -40,6 +40,11 @@ export default class TreasureChest {
         this.assessmentChestX = data?.assessmentTreasureChestLayout?.x ?? this.assessmentChestX;
         this.assessmentChestY = data?.assessmentTreasureChestLayout?.y ?? this.assessmentChestY;
         this.shouldUseAssessmentChestLayout = Boolean(data?.assessmentTreasureChestLayout);
+
+        if (data?.assessmentTreasureChestLayout?.height) {
+          //Hard minus 50px to properly adjust the height to look as same as assessment treasure chest.
+          this.chestHeight = this.chestHeight - 50; 
+        }
       }
     );
   }
@@ -60,31 +65,22 @@ export default class TreasureChest {
     const chestX = width / 2 - this.chestWidth / 2;
     const chestY = height - this.chestHeight - 20;
 
-    let scale = 1;
-    let rotation = 0;
     this.ctx.save();
-    
-    if (!this.shouldUseAssessmentChestLayout) {
-      this.ctx.translate(
-        chestX + this.chestWidth / 2,
-        chestY + this.chestHeight / 2
-      );
-      this.ctx.rotate(rotation);
-      this.ctx.scale(scale, scale);
-    }
+
+    this.ctx.translate(
+      chestX + this.chestWidth / 2,
+      chestY + this.chestHeight / 2
+    );
+    this.ctx.rotate(0);
+    this.ctx.scale(1, 1);
 
     // Apply shake offset for chest-hit animation
     const offset = this.getShakeOffset(time, stateStartTime);
 
-    const { x, y } = this.getResolvedChestPosition(
-      -this.chestWidth / 2 + offset,
-      -this.chestHeight / 2
-    );
-
     this.ctx.drawImage(
       this.closedChestImg,
-      x, 
-      y,
+      -this.chestWidth / 2 + offset, 
+      -this.chestHeight / 2,
       this.chestWidth, 
       this.chestHeight
     );
@@ -122,23 +118,15 @@ export default class TreasureChest {
     const chestX = width / 2 - this.chestWidth / 2;
     const chestY = height - this.chestHeight - 20;
 
-    const { x, y } = this.getResolvedChestPosition(chestX, chestY);
-
     this.ctx.drawImage(
       this.openChestImg,
-      x,
-      y,
+      chestX,
+      chestY,
       this.chestWidth,
       this.chestHeight
     );
   }
 
-  private getResolvedChestPosition(chestX: number, chestY: number) {
-    return {
-      x: this.shouldUseAssessmentChestLayout ? this.assessmentChestX : chestX,
-      y: this.shouldUseAssessmentChestLayout ? this.assessmentChestY : chestY
-    };
-  }
   /**
    * Calculates horizontal shake offset based on elapsed animation time.
    * Produces a left-right jitter effect for a limited duration.

--- a/src/miniGame/miniGames/treasureChest/treasureChest.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChest.ts
@@ -127,6 +127,11 @@ export default class TreasureChest {
     );
   }
 
+  public dispose(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
   /**
    * Calculates horizontal shake offset based on elapsed animation time.
    * Produces a left-right jitter effect for a limited duration.

--- a/src/miniGame/miniGames/treasureChest/treasureChest.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChest.ts
@@ -1,4 +1,5 @@
 import { CLOSED_CHEST, OPEN_CHEST } from '@constants';
+import miniGameStateService from '@miniGameStateService';
 
 /**
  * TreasureChest class handles rendering of the closed and open chest
@@ -9,6 +10,12 @@ export default class TreasureChest {
   private openChestImg: HTMLImageElement; // Image for open chest state
   private ctx: CanvasRenderingContext2D; // Canvas context used for drawing
   public shakeDuration: number = 1000; // 1s; Default seconds of shaking animation.
+  private chestWidth: number;
+  private chestHeight: number;
+  private unsubscribe: any;
+  private assessmentChestX: number = 0;
+  private assessmentChestY: number = 0;
+  private shouldUseAssessmentChestLayout: boolean = false;
 
   /**
    * @param ctx - Canvas rendering context to draw the chest
@@ -21,6 +28,20 @@ export default class TreasureChest {
 
     this.openChestImg = new Image();
     this.openChestImg.src = OPEN_CHEST; // Path to open chest asset
+
+    this.chestWidth = 200; //Default size
+    this.chestHeight = 184; //Default size
+
+    this.unsubscribe = miniGameStateService.subscribe(
+      miniGameStateService.EVENTS.USE_ASSESSMENT_TREASURE_CHEST_LAYOUT,
+      (data: any) => {
+        this.chestWidth = data?.assessmentTreasureChestLayout?.width ?? this.chestWidth;
+        this.chestHeight = data?.assessmentTreasureChestLayout?.height ?? this.chestHeight;
+        this.assessmentChestX = data?.assessmentTreasureChestLayout?.x ?? this.assessmentChestX;
+        this.assessmentChestY = data?.assessmentTreasureChestLayout?.y ?? this.assessmentChestY;
+        this.shouldUseAssessmentChestLayout = Boolean(data?.assessmentTreasureChestLayout);
+      }
+    );
   }
 
   /**
@@ -36,21 +57,37 @@ export default class TreasureChest {
     width: number,
     height: number,
   ): void {
-    const chestW = 200, chestH = 184;
-    const chestX = width / 2 - chestW / 2;
-    const chestY = height - chestH - 20;
+    const chestX = width / 2 - this.chestWidth / 2;
+    const chestY = height - this.chestHeight - 20;
 
     let scale = 1;
     let rotation = 0;
-    
     this.ctx.save();
-    this.ctx.translate(chestX + chestW / 2, chestY + chestH / 2);
-    this.ctx.rotate(rotation);
-    this.ctx.scale(scale, scale);
+    
+    if (!this.shouldUseAssessmentChestLayout) {
+      this.ctx.translate(
+        chestX + this.chestWidth / 2,
+        chestY + this.chestHeight / 2
+      );
+      this.ctx.rotate(rotation);
+      this.ctx.scale(scale, scale);
+    }
 
     // Apply shake offset for chest-hit animation
     const offset = this.getShakeOffset(time, stateStartTime);
-    this.ctx.drawImage(this.closedChestImg, -chestW / 2 + offset, -chestH / 2, chestW, chestH);
+
+    const { x, y } = this.getResolvedChestPosition(
+      -this.chestWidth / 2 + offset,
+      -this.chestHeight / 2
+    );
+
+    this.ctx.drawImage(
+      this.closedChestImg,
+      x, 
+      y,
+      this.chestWidth, 
+      this.chestHeight
+    );
     this.ctx.restore();
   }
 
@@ -58,7 +95,18 @@ export default class TreasureChest {
    * Draws the closed chest at an arbitrary position and size (used for fly-in animation).
    */
   public drawClosedChestAt(x: number, y: number, w: number, h: number): void {
-    this.ctx.drawImage(this.closedChestImg, x, y, w, h);
+
+    if (this.shouldUseAssessmentChestLayout) {
+      this.ctx.drawImage(
+        this.closedChestImg,
+        this.assessmentChestX,
+        this.assessmentChestY,
+        this.chestWidth,
+        this.chestHeight
+      );
+    } else {
+      this.ctx.drawImage(this.closedChestImg, x, y, w, h);
+    }
   }
 
   /**
@@ -66,13 +114,31 @@ export default class TreasureChest {
    * @param width - Canvas width
    * @param height - Canvas height
    */
-  public drawOpenChest(width: number, height: number): void {
-    const chestW = 200, chestH = 184;
-    const chestX = width / 2 - chestW / 2;
-    const chestY = height - chestH - 20;
-    this.ctx.drawImage(this.openChestImg, chestX, chestY, chestW, chestH);
+  public drawOpenChest(
+    width: number,
+    height: number,
+
+  ): void {
+    const chestX = width / 2 - this.chestWidth / 2;
+    const chestY = height - this.chestHeight - 20;
+
+    const { x, y } = this.getResolvedChestPosition(chestX, chestY);
+
+    this.ctx.drawImage(
+      this.openChestImg,
+      x,
+      y,
+      this.chestWidth,
+      this.chestHeight
+    );
   }
 
+  private getResolvedChestPosition(chestX: number, chestY: number) {
+    return {
+      x: this.shouldUseAssessmentChestLayout ? this.assessmentChestX : chestX,
+      y: this.shouldUseAssessmentChestLayout ? this.assessmentChestY : chestY
+    };
+  }
   /**
    * Calculates horizontal shake offset based on elapsed animation time.
    * Produces a left-right jitter effect for a limited duration.

--- a/src/miniGame/miniGames/treasureChest/treasureChestAnimation.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChestAnimation.ts
@@ -256,6 +256,11 @@ export class TreasureChestAnimation {
     this.isVisible = false;
   }
 
+  public dispose() {
+    this.hide();
+    this.treasureChest.dispose();
+  }
+
   /**
    * Main animation loop.
    * Runs via requestAnimationFrame while visible.

--- a/src/miniGame/miniGames/treasureChest/treasureChestMiniGame.ts
+++ b/src/miniGame/miniGames/treasureChest/treasureChestMiniGame.ts
@@ -114,7 +114,7 @@ export class TreasureChestMiniGame {
     this.earnedStarCount = 0;
     this.collectedStones = 0;
     this.miniGameStatus = false;
-    this.treasureAnimation.hide();
+    this.treasureAnimation.dispose();
     //Reset State
     this.treasureStones = new TreasureStones(this.treasureAnimation.getContext());
   }


### PR DESCRIPTION
# Changes
- Created a method for assessment to extract the layout of the rendered treasure chest.
- Created a event for minigame service for pub and sub event. This ensures the layout adjustment only applies if there is a survey assessment happened.
- Added a subscription for the minigame treasure chest to update its layout to adjust and match the treasure chest.

# How to test
- Run the FTM in local with ?cr_lang=englishwestafrican
- Select level 2 and play the game.
- Upon the assessment render, select the skip.
- As soon as the assessment vanishes, the mini-game should seamlessly rendered to where the treasure chest of the assessment is.

Ref: [FM-914](https://curiouslearning.atlassian.net/browse/FM-914)


[FM-914]: https://curiouslearning.atlassian.net/browse/FM-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treasure chest mini-game now dynamically adjusts its layout and dimensions based on assessment requirements, enabling responsive positioning and flexible sizing that automatically adapts to different contexts without requiring code modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/FeedTheMonsterJS/pull/1974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->