### PR TITLE
feat: [MR-83] register container_app_version as a Firebase user property

### DIFF
--- a/src/analytics/base-analytics-integration.ts
+++ b/src/analytics/base-analytics-integration.ts
@@ -1,6 +1,6 @@
 import { AnalyticsService, FirebaseStrategy, StatsigStrategy } from '@curiouslearning/analytics';
 import { firebaseConfig, statsigConfig } from "./analytics-config";
-import { source, campaign_id, pseudoId } from "@common";
+import { source, campaign_id, container_app_version, pseudoId } from "@common";
 
 /**
  * `BaseAnalyticsIntegration` is the foundational analytics integration class
@@ -79,7 +79,8 @@ export class BaseAnalyticsIntegration {
                 },
                 userProperties: {
                     campaign_id: campaign_id || '',
-                    source: source || ''
+                    source: source || '',
+                    container_app_version: container_app_version || ''
                 }
             });
 

--- a/src/assessment/assessment-survey-manager.spec.ts
+++ b/src/assessment/assessment-survey-manager.spec.ts
@@ -397,6 +397,7 @@ describe('AssessmentSurveyManager', () => {
         appId: 'test-app-id',
         measurementId: 'test-measurement-id',
         firebaseName: 'AssessmentSurveyEmbed',
+        container_app_version: '',
       });
     } finally {
       restoreFirebaseEnv(envSnapshot);

--- a/src/assessment/assessment-survey-manager.ts
+++ b/src/assessment/assessment-survey-manager.ts
@@ -1,6 +1,6 @@
 import '@curiouslearning/assessment-survey/register';
 import { AnalyticsConfig, AssessmentCompletedPayload } from '@curiouslearning/assessment-survey';
-import { pseudoId } from '../common/global-variables';
+import { pseudoId, container_app_version } from '../common/global-variables';
 import { resolveAssessmentDataKey } from './assessment-data-key';
 import { AssessmentCacheClient } from './assessment-cache-client';
 import { AssessmentOverlay } from './ui/assessment-overlay';
@@ -73,6 +73,8 @@ export class AssessmentSurveyManager {
   }
 
   private resolveAnalyticsConfig(): AnalyticsConfig | undefined {
+    
+    // TODO(MR-83): Add Container App Version to analytics config once the assessment package is updated with the new config
     const config = {
       apiKey: process.env.FIREBASE_API_KEY,
       authDomain: process.env.FIREBASE_AUTH_DOMAIN,
@@ -87,7 +89,7 @@ export class AssessmentSurveyManager {
 
     const isValidConfig = Object.values(config).every(Boolean);
 
-    return isValidConfig ? config : undefined;
+    return isValidConfig ? ({ ...config, container_app_version: container_app_version || '' } as AnalyticsConfig) : undefined;
   }
 
   public async open(options: AssessmentSurveyOpenOptions): Promise<void> {

--- a/src/common/global-variables.ts
+++ b/src/common/global-variables.ts
@@ -6,6 +6,7 @@ import { Utils } from "@common";
 export var pseudoId = urlParams.get("cr_user_id");
 export var source = urlParams.get("source") == null ? null : urlParams.get("source");
 export var campaign_id = urlParams.get("campaign_id") == null ? null : urlParams.get("campaign_id");
+export var container_app_version = urlParams.get("container_app_version");
 
 export var lang =
   urlParams.get("cr_lang") == null ? "english" : urlParams.get("cr_lang");

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -12,7 +12,7 @@ import {
   unsubscribeAll
 } from "./utils";
 import { TimeoutRegistry } from "./timeout-registry";
-import { Debugger, lang, font, pseudoId, Window, source, campaign_id } from "./global-variables";
+import { Debugger, lang, font, pseudoId, Window, source, campaign_id, container_app_version } from "./global-variables";
 import {
   CLICK,
   LOADPUZZLE,
@@ -37,6 +37,7 @@ export {
   pseudoId,
   source,
   campaign_id,
+  container_app_version,
   Window,
   CLICK,
   LOADPUZZLE,


### PR DESCRIPTION
# Changes
- Parse the new `container_app_version` URL parameter via `URLSearchParams` in `src/common/global-variables.ts` and re-export it through `@common`.
- Register it as a Firebase user property in `BaseAnalyticsIntegration` alongside `campaign_id` and `source`, via the `FirebaseStrategy` constructor's `userProperties` option.
- Forward it to the embedded `assessment-survey-player` web component through the analytics config built by `AssessmentSurveyManager.resolveAnalyticsConfig()`, so the embedded assessment can register the same property on its own Firebase app instance.
- Includes a `TODO(MR-83)` in `assessment-survey-manager.ts` flagging that the embedded path is wired but unverified end-to-end until a `@curiouslearning/assessment-survey` release with matching MR-83 handling is published and consumed.

# How to test
- `npm run dev`, then open `http://localhost:8080/?cr_user_id=test&container_app_version=2.34.2&source=test&campaign_id=test`.
- Play through to fire `puzzle_completed` / `level_completed` events.
- In Firebase Console → `ftm-b9d99` → Analytics → Realtime / DebugView, confirm `Container App Version = 2.34.2` appears as a user property.
- BigQuery (after ~24h propagation for newly-mapped users): `container_app_version` should appear on every event row for users whose `session_start` fired post-deploy, alongside the existing `campaign_id` and `source` user properties.

Ref: [MR-83](https://curiouslearning.atlassian.net/browse/MR-83)


[MR-83]: https://curiouslearning.atlassian.net/browse/MR-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container app version tracking to analytics for improved telemetry collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->