### PR TITLE
feat: [MR-97] send sub-app appVersion to container as payload metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/core": "^4.4.0",
         "@curiouslearning/analytics": "^1.3.1",
         "@curiouslearning/assessment-survey": "file:vendor/curiouslearning-assessment-survey-0.0.1.tgz",
-        "@curiouslearning/core": "^1.11.0",
+        "@curiouslearning/core": "^1.13.0",
         "@curiouslearning/features": "^1.3.0",
         "@octokit/rest": "^20.0.1",
         "@release-it/conventional-changelog": "^8.0.1",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@curiouslearning/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@curiouslearning/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-ZlEwgJgWmrYHoXU2G/PAmZe4tmbW1sWTicdSNy8gHofw6mUs8ufFZBqw9uqSsam1XxkEih6vHqfXQ2cjKwAcAg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/core/-/core-1.13.0.tgz",
+      "integrity": "sha512-Ou0Z8CMVOHpJiw/iZisOYAABLa7+j8NcuibJufTHB3+oDM9mnRumtwuIoZ5XiN9J+lE5dzcjMVj/0XzWmUaBzw==",
       "license": "ISC",
       "dependencies": {
         "@songbaek/fifo-map": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@capacitor/core": "^4.4.0",
     "@curiouslearning/analytics": "^1.3.1",
     "@curiouslearning/assessment-survey": "file:vendor/curiouslearning-assessment-survey-0.0.1.tgz",
-    "@curiouslearning/core": "^1.11.0",
+    "@curiouslearning/core": "^1.13.0",
     "@curiouslearning/features": "^1.3.0",
     "@octokit/rest": "^20.0.1",
     "@release-it/conventional-changelog": "^8.0.1",

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -145,7 +145,7 @@ class App {
     if (featureFlagsService.isFeatureEnabled(FEATURE_ANDROID_EVENT_BUBBLE)) {
       const androidStrategy = new AndroidAnalyticsStrategy({
         cr_user_id: pseudoId ?? '',
-        appVersion: document.getElementById("version-info-id")?.innerHTML || ''
+        app_version: document.getElementById("version-info-id")?.innerHTML || ''
       });
       AnalyticsIntegration.getInstance().analyticsService.register(
         'android',

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -143,7 +143,10 @@ class App {
    */
   private initAndroidModule() {
     if (featureFlagsService.isFeatureEnabled(FEATURE_ANDROID_EVENT_BUBBLE)) {
-      const androidStrategy = new AndroidAnalyticsStrategy({ cr_user_id: pseudoId ?? '' });
+      const androidStrategy = new AndroidAnalyticsStrategy({
+        cr_user_id: pseudoId ?? '',
+        appVersion: document.getElementById("version-info-id")?.innerHTML || ''
+      });
       AnalyticsIntegration.getInstance().analyticsService.register(
         'android',
         androidStrategy

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { AnalyticsEventType } from 'src/analytics/analytics-integration';
+import { AndroidInterface } from '@curiouslearning/core';
 import { AndroidAnalyticsStrategy } from './android-analytics-strategy';
 
 const mockLogSummaryData = jest.fn();
@@ -30,6 +31,30 @@ describe('Feature: Android analytics strategy', () => {
   describe('Scenario: Initializing the strategy', () => {
     it('Given a valid cr_user_id, when initialize is called, then it resolves without error', async () => {
       await expect(strategy.initialize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Scenario: Forwarding the sub-app version as metadata', () => {
+    it('Given an appVersion, when the strategy is constructed, then AndroidInterface receives it as metadata.appVersion', () => {
+      // Given / When
+      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', appVersion: 'v1.6.0' });
+
+      // Then
+      expect(AndroidInterface).toHaveBeenCalledWith(
+        expect.objectContaining({
+          app_id: 'feed-the-monster',
+          cr_user_id: 'user-123',
+          metadata: { appVersion: 'v1.6.0' },
+        })
+      );
+    });
+
+    it('Given no appVersion, when the strategy is constructed, then metadata.appVersion defaults to an empty string', () => {
+      // Given / When (beforeEach already constructed without appVersion)
+      // Then
+      expect(AndroidInterface).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { appVersion: '' } })
+      );
     });
   });
 

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -37,14 +37,14 @@ describe('Feature: Android analytics strategy', () => {
   describe('Scenario: Forwarding the sub-app version as metadata', () => {
     it('Given an appVersion, when the strategy is constructed, then AndroidInterface receives it as metadata.appVersion', () => {
       // Given / When
-      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', appVersion: 'v1.6.0' });
+      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', app_version: 'v1.6.0' });
 
       // Then
       expect(AndroidInterface).toHaveBeenCalledWith(
         expect.objectContaining({
           app_id: 'feed-the-monster',
           cr_user_id: 'user-123',
-          metadata: { appVersion: 'v1.6.0' },
+          metadata: { app_version: 'v1.6.0' },
         })
       );
     });
@@ -53,7 +53,7 @@ describe('Feature: Android analytics strategy', () => {
       // Given / When (beforeEach already constructed without appVersion)
       // Then
       expect(AndroidInterface).toHaveBeenCalledWith(
-        expect.objectContaining({ metadata: { appVersion: '' } })
+        expect.objectContaining({ metadata: { app_version: '' } })
       );
     });
   });

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -5,6 +5,8 @@ import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 
 export interface AndroidAnalyticsStrategyOptions {
   cr_user_id: string;
+  /** FTM sub-app version, forwarded to every payload as metadata.appVersion. */
+  appVersion?: string;
 }
 
 export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
@@ -16,7 +18,8 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     this.cr_user_id = options.cr_user_id;
     this.androidInterface = new AndroidInterface({
       app_id: 'feed-the-monster',
-      cr_user_id: this.cr_user_id ?? ''
+      cr_user_id: this.cr_user_id ?? '',
+      metadata: { appVersion: options.appVersion ?? '' }
     });
   }
 

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -5,8 +5,8 @@ import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 
 export interface AndroidAnalyticsStrategyOptions {
   cr_user_id: string;
-  /** FTM sub-app version, forwarded to every payload as metadata.appVersion. */
-  appVersion?: string;
+  /** FTM sub-app version, forwarded to every payload as metadata.app_version. */
+  app_version?: string;
 }
 
 export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
@@ -19,7 +19,8 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     this.androidInterface = new AndroidInterface({
       app_id: 'feed-the-monster',
       cr_user_id: this.cr_user_id ?? '',
-      metadata: { appVersion: options.appVersion ?? '' }
+      // Stored in Firestore as snake_case app_version (consistent with the rest of the payload).
+      metadata: { app_version: options.app_version ?? '' }
     });
   }
 


### PR DESCRIPTION
# Changes
- AndroidAnalyticsStrategy accepts an appVersion option and forwards it as metadata.appVersion via the AndroidInterface constructor so both summary_data and user_sessions_data payloads carry it (no per-call change).
- feedTheMonster.ts supplies the version from the existing version-info-id element when constructing the strategy.
- Bumps @curiouslearning/core to ^1.13.0 (metadata API).

# How to test
- Manual e2e: run via container debug build → complete a level/puzzle → Firestore summary_data/user_sessions_data show metadata.appVersion + metadata.container_app_version.

Ref: [MR-97](https://curiouslearning.atlassian.net/browse/MR-97)


[MR-97]: https://curiouslearning.atlassian.net/browse/MR-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ