### PR TITLE
feat: FM-949 Added e2e playwright automation to circle ci/cd pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,10 +106,16 @@ jobs:
             CI: 'true'
       - store_test_results:
           path: test-results
-      - store_artifacts:
-          path: playwright-report
-      - store_artifacts:
-          path: test-results
+      - aws-cli/setup:
+          aws_access_key_id: $AWS_ACCESS_KEY
+          region: $AWS_DEFAULT_REGION
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - run:
+          name: Upload Playwright report to S3
+          when: always
+          command: |
+            aws s3 sync playwright-report \
+              "s3://globallit-aws-s3-static-webapp-test-us-east-2/e2e-reports/${CIRCLE_BRANCH}/${CIRCLE_BUILD_NUM}/"
 
 # TODO: move invalidate-cloudfront-cache parameters to project env variables
 # Eventually these will be the new cloudfront name for apps and app name respectively.
@@ -122,6 +128,8 @@ workflows:
     jobs:
       - node/test
       - e2e-tests:
+          context:
+            - aws-context
           requires:
             - node/test
       - build-and-deploy-dev:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,24 @@ jobs:
           distribution-id: 'E2QD6IZIYBGTJK'
           paths: '"/*"'
 
+  e2e-tests:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.60.0-jammy
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Run Playwright E2E tests
+          command: npm run test:e2e
+          environment:
+            CI: 'true'
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: playwright-report
+      - store_artifacts:
+          path: test-results
+
 # TODO: move invalidate-cloudfront-cache parameters to project env variables
 # Eventually these will be the new cloudfront name for apps and app name respectively.
 
@@ -103,9 +121,15 @@ workflows:
   s3-deploy-workflow:
     jobs:
       - node/test
+      - e2e-tests:
+          requires:
+            - node/test
       - build-and-deploy-dev:
           context:
             - aws-context
+          requires:
+            - node/test
+            - e2e-tests
           filters:
             branches:
               only:
@@ -115,6 +139,7 @@ workflows:
             - aws-context
           requires:
             - node/test
+            - e2e-tests
           filters:
             branches:
               only:
@@ -124,6 +149,7 @@ workflows:
             - aws-context
           requires:
             - node/test
+            - e2e-tests
           filters:
             branches:
               only:
@@ -133,6 +159,7 @@ workflows:
             - aws-context
           requires:
             - node/test
+            - e2e-tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,10 @@ jobs:
     steps:
       - checkout
       - node/install-packages
+      - run:
+          name: Install unzip (required by aws-cli/setup)
+          command: |
+            apt-get update && apt-get install -y unzip
       - aws-cli/setup:
           aws_access_key_id: $AWS_ACCESS_KEY
           region: $AWS_DEFAULT_REGION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,10 @@ jobs:
     steps:
       - checkout
       - node/install-packages
+      - aws-cli/setup:
+          aws_access_key_id: $AWS_ACCESS_KEY
+          region: $AWS_DEFAULT_REGION
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
       - run:
           name: Run Playwright E2E tests
           command: npm run test:e2e
@@ -106,16 +110,12 @@ jobs:
             CI: 'true'
       - store_test_results:
           path: test-results
-      - aws-cli/setup:
-          aws_access_key_id: $AWS_ACCESS_KEY
-          region: $AWS_DEFAULT_REGION
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
       - run:
           name: Upload Playwright report to S3
           when: always
           command: |
             aws s3 sync playwright-report \
-              "s3://globallit-aws-s3-static-webapp-test-us-east-2/e2e-reports/${CIRCLE_BRANCH}/${CIRCLE_BUILD_NUM}/"
+              "s3://globallit-aws-s3-static-webapp-test-us-east-2/feed-the-monster-e2e-reports/${CIRCLE_BRANCH}/${CIRCLE_BUILD_NUM}/"
 
 # TODO: move invalidate-cloudfront-cache parameters to project env variables
 # Eventually these will be the new cloudfront name for apps and app name respectively.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
     ['json', { outputFile: 'test-results/results.json' }],
   ],
   use: {
-    baseURL: 'http://localhost:8080',
+    headless: process.env.CI ? true : false,
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
     // Capture screenshot on every failure for debugging
     screenshot: 'only-on-failure',
     // Retain video for failed tests so failures are reproducible


### PR DESCRIPTION
# Changes
- Added e2e playwright automation to circle ci/cd pipeline

# How to test
- Run the ci pipeline and check if e2e runs after jest test

Ref: [FM-949](https://curiouslearning.atlassian.net/browse/FM-949)


[FM-949]: https://curiouslearning.atlassian.net/browse/FM-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Playwright end-to-end tests to the delivery pipeline.
  * Automatically uploads end-to-end test reports for easier post-run review.

* **Bug Fixes**
  * Deployments to dev, test, release, and production now wait for end-to-end tests to complete successfully before proceeding, reducing the risk of shipping broken changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->