### PR TITLE
fix: [MR-145] updated assessment-survey package to 1.2.0 to include english assessment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/android": "^4.4.0",
         "@capacitor/core": "^4.4.0",
         "@curiouslearning/analytics": "^1.3.1",
-        "@curiouslearning/assessment-survey": "^1.1.0",
+        "@curiouslearning/assessment-survey": "^1.2.0",
         "@curiouslearning/core": "^1.13.0",
         "@curiouslearning/features": "^1.3.0",
         "@octokit/rest": "^20.0.1",
@@ -1947,14 +1947,14 @@
       }
     },
     "node_modules/@curiouslearning/assessment-survey": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@curiouslearning/assessment-survey/-/assessment-survey-1.1.0.tgz",
-      "integrity": "sha512-TJhOxr/JfXHyHusIi7tg3TzNN77sX174kGQFoyaD0GVZJ7rylI8tf6maeApWW7Q4x7CC0v1kaoH/p+h49Sd/Zg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/assessment-survey/-/assessment-survey-1.2.0.tgz",
+      "integrity": "sha512-AxkpXZ4GuycouOJjF2gNwaVJVjNurX9f+UaL3LxzR1ApEzUd6Vowe7JQ6ZWLlO1OGbrY78XUoAXLbLx1c0L1Mw==",
       "license": "MIT",
       "dependencies": {
         "@curiouslearning/analytics": "^1.3.1",
         "@curiouslearning/assessment-survey": "file:",
-        "@curiouslearning/core": "^1.10.0",
+        "@curiouslearning/core": "^1.13.0",
         "@curiouslearning/features": "^1.3.1",
         "firebase": "^9.12.1",
         "jest-environment-jsdom": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@capacitor/core": "^4.4.0",
     "@curiouslearning/analytics": "^1.3.1",
     "@curiouslearning/core": "^1.13.0",
-    "@curiouslearning/assessment-survey": "^1.1.0",
+    "@curiouslearning/assessment-survey": "^1.2.0",
     "@curiouslearning/features": "^1.3.0",
     "@octokit/rest": "^20.0.1",
     "@release-it/conventional-changelog": "^8.0.1",

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -89,8 +89,13 @@ class App {
     await this.loadAndCacheFont(font, `./assets/fonts/${font}.ttf`);
     await this.loadTitleFeedbackCustomFont();
     await this.preloadGameAudios();
+    // Strip the leading "v" (e.g. "v1.5.1" -> "1.5.1") so Statsig's App Version
+    // condition compares it as a semver rather than a raw string.
+    const appVersion = (document.getElementById("version-info-id")?.innerHTML || '')
+      .trim()
+      .replace(/^v/i, '');
     featureFlagsService.init({
-      user: { userID: pseudoId, locale: this.lang, custom: { platform: 'ftm' } },
+      user: { userID: pseudoId, locale: this.lang, appVersion, custom: { platform: 'ftm' } },
     });
     featureFlagsService.loadFeatures([
       FEATURE_ANDROID_EVENT_BUBBLE


### PR DESCRIPTION

# Changes
- Upgrade `@curiouslearning/assessment-survey` to `^1.2.0`, which adds the English assessment content.
- Pass the FTM app version (from the `version-info-id` element, `v` prefix stripped) as `appVersion` on the Statsig user in `featureFlagsService.init`. This lets the `assessmentlevels` dynamic config target clients with an **App Version ≥ X** condition, so stale builds that lack a language's assessment content aren't shown an assessment.

# How to test
- Runtime: open FTM, and in DevTools confirm the Statsig `/initialize` request payload includes `"appVersion":"1.5.1"` (no leading `v`).
- In Statsig, add an **App Version ≥** condition to the `assessmentlevels` config and verify the assessment shows only for builds at/above the threshold; older builds are gated out instead of falling back to the Zulu assessment.


Ref: [MR-145](https://curiouslearning.atlassian.net/browse/MR-145)


[MR-145]: https://curiouslearning.atlassian.net/browse/MR-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app version detection so version information is cleaned up before being sent to feature flagging, including removing extra spaces and a leading `v`.
  * This helps ensure users receive the correct feature experience based on the app version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->