### PR TITLE
fix: removed the npm run installation and rely on bundled cimg/python…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ commands:
         default: 'build:prod'
     steps:
       - checkout
-      - run: sudo npm install -g npm@latest
       - node/install-packages
       - run: npm run << parameters.build-script >>
       # - aws-cli/setup:


### PR DESCRIPTION
…-node

# Changes
- Change 1

# How to test
- Test method 1

Ref: [<JIRA-CODE>](https://curiouslearning.atlassian.net/browse/<JIRA-CODE>)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the continuous integration workflow by removing an unnecessary npm installation step.
  * Dependency installation now runs directly after code checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->