### PR TITLE
Stop StoneHandler.getFoilStones() from mutating shared level data

### DIFF
--- a/src/components/stone-handler/stone-handler.spec.ts
+++ b/src/components/stone-handler/stone-handler.spec.ts
@@ -139,6 +139,34 @@ describe('StoneHandler - Latest Optimizations', () => {
     });
   });
 
+  describe('getFoilStones - shared level data integrity', () => {
+    it('does not mutate the foilStones array on the shared level data', () => {
+      const levelData = {
+        puzzles: [{ targetStones: ['A', 'B'], foilStones: ['C', 'D', 'E'] }],
+      };
+      const originalFoilStones = [...levelData.puzzles[0].foilStones];
+
+      const handler = new StoneHandler(mockContext, mockCanvas, 0, levelData);
+      // The puzzle_completed analytics event reads the foil stones more than once.
+      handler.getFoilStones();
+      handler.getFoilStones();
+
+      expect(levelData.puzzles[0].foilStones).toEqual(originalFoilStones);
+    });
+
+    it('does not drop foil stones from level data when a puzzle has more than eight stones', () => {
+      const levelData = {
+        puzzles: [{ targetStones: ['A'], foilStones: ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'] }],
+      };
+      const originalFoilStones = [...levelData.puzzles[0].foilStones];
+
+      const handler = new StoneHandler(mockContext, mockCanvas, 0, levelData);
+      handler.getFoilStones();
+
+      expect(levelData.puzzles[0].foilStones).toEqual(originalFoilStones);
+    });
+  });
+
   describe('Performance Improvements', () => {
     it('should skip disposed stones in draw loop', () => {
       const mockStones = [

--- a/src/components/stone-handler/stone-handler.ts
+++ b/src/components/stone-handler/stone-handler.ts
@@ -252,27 +252,30 @@ export default class StoneHandler {
   }
 
   public getFoilStones() {
-    this.currentPuzzleData.targetStones.forEach((e) => {
-      const index = this.currentPuzzleData.foilStones.indexOf(e);
+    const targetStones = this.currentPuzzleData.targetStones;
+    // Work on a copy so the shared level data (currentPuzzleData.foilStones) is never mutated.
+    const foilStones = [...this.currentPuzzleData.foilStones];
+
+    targetStones.forEach((e) => {
+      const index = foilStones.indexOf(e);
       if (index !== -1) {
-        this.currentPuzzleData.foilStones.splice(index, 1);
+        foilStones.splice(index, 1);
       }
     });
 
-    const totalStonesCount =
-      this.currentPuzzleData.targetStones.length +
-      this.currentPuzzleData.foilStones.length;
+    const totalStonesCount = targetStones.length + foilStones.length;
 
     if (totalStonesCount > 8) {
       const extraStonesCount = totalStonesCount - 8;
 
-      this.currentPuzzleData.foilStones.splice(0, extraStonesCount);
+      foilStones.splice(0, extraStonesCount);
     }
 
-    this.currentPuzzleData.targetStones.forEach((e) => {
-      this.currentPuzzleData.foilStones.push(e);
+    targetStones.forEach((e) => {
+      foilStones.push(e);
     });
-    return this.currentPuzzleData.foilStones.sort(() => Math.random() - 0.5);
+
+    return foilStones.sort(() => Math.random() - 0.5);
   }
 
   /**

--- a/src/scenes/gameplay-scene/gameplay-flow-manager.ts
+++ b/src/scenes/gameplay-scene/gameplay-flow-manager.ts
@@ -492,6 +492,7 @@ export class GameplayFlowManager {
         const itemSelected = puzzleType === "Word"
           ? (droppedLetters ?? "TIMEOUT")
           : (pickedStone?.text ?? "TIMEOUT");
+        const foilStones = this.stoneHandler.getFoilStones();
 
         this.analyticsIntegration.track(
             AnalyticsEventType.PUZZLE_COMPLETED,
@@ -503,9 +504,7 @@ export class GameplayFlowManager {
                 puzzle_number: this.currentPuzzleIndex,
                 item_selected: itemSelected,
                 target: this.stoneHandler.getCorrectTargetStone(),
-                foils: Array.isArray(this.stoneHandler.getFoilStones())
-                    ? this.stoneHandler.getFoilStones().join(',')
-                    : this.stoneHandler.getFoilStones(),
+                foils: Array.isArray(foilStones) ? foilStones.join(',') : foilStones,
                 response_time: (endTime - this.puzzleTime) / 1000,
             }
         );


### PR DESCRIPTION
This PR proposes a fix that stops `StoneHandler.getFoilStones()` from mutating the shared level data it reads. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/230. You can sign in with your GitHub ID to claim ownership of the project.

## What this fixes

`getFoilStones()` in `src/components/stone-handler/stone-handler.ts` assembles the stones to display by editing `this.currentPuzzleData.foilStones` in place — it removes the target stones, caps the pool to eight by splicing foil stones out, pushes the targets back, then shuffles. The catch is that `currentPuzzleData` is a live reference into `levelData.puzzles[...]`, so each call permanently rewrites your level data instead of computing a fresh list. That makes the method non-idempotent: a second call sees the already-mutated array, and for any puzzle with more than eight stones the spliced-out foil stones are gone for good.

It bites hardest in analytics — `logPuzzleEndFirebaseEvent()` in `src/scenes/gameplay-scene/gameplay-flow-manager.ts` calls `getFoilStones()` two or three times while assembling a single `puzzle_completed` event, so it re-shuffles and re-mutates the pool mid-event. Reproduced on `main` at HEAD with a focused test: for a puzzle with `targetStones: ['A']` and `foilStones: ['B'..'J']` (nine), a single `getFoilStones()` call leaves `levelData.puzzles[0].foilStones` as a shuffled eight-item array with `B` and `C` dropped and `A` injected, instead of the original nine. `npx jest src/components/stone-handler/stone-handler.spec.ts` shows the two added assertions failing against the current code.

The fix builds the result on a local copy (`const foilStones = [...this.currentPuzzleData.foilStones]`) and applies the exact same de-duplication, eight-stone cap and shuffle to that copy, so the value handed to `createStones()` is unchanged while your level data is left untouched; the `puzzle_completed` logging now reads the foils once. The full suite was run before and after the change with no new failures — `npx jest` reports 44 suites and 302 tests passing (the 300 that already passed, plus the two new regression tests that fail without this change).

## How this was managed

We mirrored this repository onto a live board and used it to manage this fix. The story tracking the work is at https://eastagiletracker.com/projects/230/stories/100558, on the board at https://eastagiletracker.com/projects/230 — which imported this repository's issues and pull requests as 1,986 stories.

![board](https://raw.githubusercontent.com/phucluuthien/FeedTheMonsterJS/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed foil stones being removed or lost from shared puzzle data after repeated use.
  * Ensured puzzles with more than eight foil stones retain the correct entries while applying the display limit.
  * Improved end-of-puzzle analytics to consistently report the foil stones shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->