### PR TITLE
fix: [MR-177] Added logInitialSummaryData and schema of summary data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/core": "^4.4.0",
         "@curiouslearning/analytics": "^1.3.1",
         "@curiouslearning/assessment-survey": "^1.2.1",
-        "@curiouslearning/core": "^1.13.0",
+        "@curiouslearning/core": "^1.13.1",
         "@curiouslearning/features": "^1.3.0",
         "@octokit/rest": "^20.0.1",
         "@release-it/conventional-changelog": "^8.0.1",
@@ -2352,7 +2352,9 @@
       }
     },
     "node_modules/@curiouslearning/core": {
-      "version": "1.13.0",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@curiouslearning/core/-/core-1.13.1.tgz",
+      "integrity": "sha512-gw/gIqAE3gduQvQuxScQUUm/FXilaJy58eVY90PFUSySEzI70aq5+hf+dgZ18GFBtAgqNsZRfrAepMBzroA8HA==",
       "license": "ISC",
       "dependencies": {
         "@songbaek/fifo-map": "^0.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@capacitor/core": "^4.4.0",
     "@curiouslearning/analytics": "^1.3.1",
     "@curiouslearning/assessment-survey": "^1.2.1",
-    "@curiouslearning/core": "^1.13.0",
+    "@curiouslearning/core": "^1.13.1",
     "@curiouslearning/features": "^1.3.0",
     "@octokit/rest": "^20.0.1",
     "@release-it/conventional-changelog": "^8.0.1",

--- a/src/feedTheMonster.ts
+++ b/src/feedTheMonster.ts
@@ -155,12 +155,19 @@ class App {
     if (featureFlagsService.isFeatureEnabled(FEATURE_ANDROID_EVENT_BUBBLE)) {
       const androidStrategy = new AndroidAnalyticsStrategy({
         cr_user_id: pseudoId ?? '',
-        app_version: document.getElementById("version-info-id")?.innerHTML || ''
+        app_version: document.getElementById("version-info-id")?.innerHTML || '',
+        lang: this.lang
       });
       AnalyticsIntegration.getInstance().analyticsService.register(
         'android',
         androidStrategy
       );
+
+      // Seed the summary document so its numeric fields read 0 instead of being absent for a
+      // player who never completes a puzzle. Called directly rather than through
+      // AnalyticsIntegration.track(), which fans out to every registered strategy and would send
+      // this to Firebase and Statsig too.
+      androidStrategy.logInitialSummaryData();
     }
   }
 

--- a/src/modules/android/constants/summary-data-schema.ts
+++ b/src/modules/android/constants/summary-data-schema.ts
@@ -1,0 +1,33 @@
+/**
+ * The FTM summary_data schema, and the single source of truth for it.
+ *
+ * FtmSummaryData is passed to AndroidInterface as its TSummary argument, which constrains the data
+ * and the options of every summary write. FTM_SUMMARY_DATA_DEFAULTS is what seeding sends, so the
+ * fields read 0 instead of being absent until the first event of that type fires.
+ *
+ * To add a field: add it to the interface, then add its 0 to the defaults — the `Required<>` on the
+ * defaults means the build fails until you do, so the two cannot drift. Core keys its seed marker on
+ * the field set, so the new field is seeded onto existing documents automatically.
+ *
+ * Fields are optional because each event writes only the ones it knows about; seeding covers them
+ * all. They must be numeric: seeding relies on the container mapping "add" to FieldValue.increment,
+ * which is only a safe no-op for numbers.
+ */
+export interface FtmSummaryData {
+  highest_level_completed?: number;
+  levels_completed?: number;
+  puzzles_completed?: number;
+  puzzle_success?: number;
+  puzzle_failure?: number;
+  time_spent_total_second?: number;
+}
+
+/** Seeded values. All 0 — a non-zero default would increment real counts rather than create them. */
+export const FTM_SUMMARY_DATA_DEFAULTS: Required<FtmSummaryData> = {
+  highest_level_completed: 0,
+  levels_completed: 0,
+  puzzles_completed: 0,
+  puzzle_success: 0,
+  puzzle_failure: 0,
+  time_spent_total_second: 0,
+};

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.spec.ts
@@ -2,14 +2,17 @@ import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 import { AndroidInterface } from '@curiouslearning/core';
 import { AndroidAnalyticsStrategy } from './android-analytics-strategy';
 import { appConfig } from '@appConfig';
+import { FTM_SUMMARY_DATA_DEFAULTS } from '../../constants/summary-data-schema';
 
 const mockLogSummaryData = jest.fn();
 const mockLogUserSessionsData = jest.fn();
+const mockLogInitialSummaryData = jest.fn();
 
 jest.mock('@curiouslearning/core', () => ({
   AndroidInterface: jest.fn().mockImplementation(() => ({
     logSummaryData: mockLogSummaryData,
     logUserSessionsData: mockLogUserSessionsData,
+    logInitialSummaryData: mockLogInitialSummaryData,
   })),
 }));
 
@@ -26,7 +29,7 @@ describe('Feature: Android analytics strategy', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    strategy = new AndroidAnalyticsStrategy({ cr_user_id: 'user-123' });
+    strategy = new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', lang: 'english' });
   });
 
   describe('Scenario: Initializing the strategy', () => {
@@ -38,7 +41,7 @@ describe('Feature: Android analytics strategy', () => {
   describe('Scenario: Forwarding the sub-app version as metadata', () => {
     it('Given an appVersion, when the strategy is constructed, then AndroidInterface receives it as metadata.app_version', () => {
       // Given / When
-      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', app_version: 'v1.6.0' });
+      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', app_version: 'v1.6.0', lang: 'english' });
 
       // Then
       expect(AndroidInterface).toHaveBeenCalledWith(
@@ -230,6 +233,44 @@ describe('Feature: Android analytics strategy', () => {
         level: 2,
         puzzle: 3,
       });
+    });
+  });
+
+  describe('Scenario: Seeding the initial summary data', () => {
+    // Core owns the "add" instructions and the once-per-document guard, so those are covered there.
+    // FTM's part is supplying the complete set of defaults, and the language that scopes the guard.
+    it('Given the schema, when seeding, then every field is sent at 0', () => {
+      // When
+      strategy.logInitialSummaryData();
+
+      // Then
+      expect(mockLogInitialSummaryData).toHaveBeenCalledTimes(1);
+      expect(mockLogInitialSummaryData).toHaveBeenCalledWith({
+        highest_level_completed: 0,
+        levels_completed: 0,
+        puzzles_completed: 0,
+        puzzle_success: 0,
+        puzzle_failure: 0,
+        time_spent_total_second: 0,
+      });
+    });
+
+    it('Given the schema constant, when seeding, then the payload matches it exactly so the two cannot drift', () => {
+      // When
+      strategy.logInitialSummaryData();
+
+      // Then every declared field is seeded, and nothing beyond them is
+      expect(mockLogInitialSummaryData).toHaveBeenCalledWith(FTM_SUMMARY_DATA_DEFAULTS);
+    });
+
+    it('Given a language, when the strategy is constructed, then it is forwarded so core can scope the seed', () => {
+      // Given / When
+      new AndroidAnalyticsStrategy({ cr_user_id: 'user-123', lang: 'kembata' });
+
+      // Then core receives the language, since the container keys summaries per language
+      expect(AndroidInterface).toHaveBeenCalledWith(
+        expect.objectContaining({ lang: 'kembata' })
+      );
     });
   });
 

--- a/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
+++ b/src/modules/android/services/analytics-strategy/android-analytics-strategy.ts
@@ -3,23 +3,34 @@ import { AndroidInterface } from '@curiouslearning/core';
 import { LevelCompletedEvent, PuzzleCompletedEvent } from 'src/analytics/analytics-event-interface';
 import { AnalyticsEventType } from 'src/analytics/analytics-integration';
 import { appConfig } from '@appConfig';
+import {
+  FTM_SUMMARY_DATA_DEFAULTS,
+  FtmSummaryData,
+} from '../../constants/summary-data-schema';
 
 export interface AndroidAnalyticsStrategyOptions {
   cr_user_id: string;
   /** FTM sub-app version, forwarded to every payload as metadata.app_version. */
   app_version?: string;
+  /** Selected language. Scopes the seed guard, since the container keys summaries per language. */
+  lang: string;
 }
 
 export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
   private readonly cr_user_id: string;
-  private readonly androidInterface : AndroidInterface;
+  /**
+   * Typed with the FTM summary schema, so every summary write below is checked against it — a field
+   * outside FTM_SUMMARY_DATA_DEFAULTS, or an options key naming one, will not compile.
+   */
+  private readonly androidInterface : AndroidInterface<FtmSummaryData>;
 
   constructor(options: AndroidAnalyticsStrategyOptions) {
     super();
     this.cr_user_id = options.cr_user_id;
-    this.androidInterface = new AndroidInterface({
+    this.androidInterface = new AndroidInterface<FtmSummaryData>({
       app_id: 'feed-the-monster',
       cr_user_id: this.cr_user_id ?? '',
+      lang: options.lang,
       metadata: {
         environment: appConfig.ENV,
         app_version: options.app_version ?? ''
@@ -50,9 +61,18 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
     // nothing to dispose for Android interface
   }
 
+  /**
+   * Seeds this user's summary document with 0 for every field in the schema, so the fields read 0
+   * rather than being absent until the matching event fires. Core handles the once-per-document
+   * guard and never throws, so this is safe to call on every launch.
+   */
+  logInitialSummaryData(): void {
+    this.androidInterface.logInitialSummaryData(FTM_SUMMARY_DATA_DEFAULTS);
+  }
+
   private handleLevelCompleted(data: LevelCompletedEvent) {
     const { duration, highest_level_completed , level_type, ftm_language ,level_number} = data;
-    this.androidInterface .logSummaryData({
+    this.androidInterface.logSummaryData({
       levels_completed: 1,
       time_spent_total_second: duration ?? 0,
       highest_level_completed: highest_level_completed ?? 0
@@ -71,7 +91,7 @@ export class AndroidAnalyticsStrategy extends AbstractAnalyticsStrategy {
 
   private handlePuzzleCompleted(data: PuzzleCompletedEvent) {
     const { success_or_failure, level_type, ftm_language, level_number, puzzle_number, version_number } = data;
-    this.androidInterface .logSummaryData({
+    this.androidInterface.logSummaryData({
       puzzles_completed: 1,
       puzzle_success: success_or_failure === 'success' ? 1 : 0,
       puzzle_failure: success_or_failure === 'failure' ? 1 : 0,


### PR DESCRIPTION
# Changes
- FTM now seeds its Firestore summary document once per launch, writing `0` for every numeric
  summary field. Previously a field only appeared after its first matching event, so a player who
  quit mid-level had no `levels_completed`, `highest_level_completed` or `time_spent_total_second`
  key at all, which read as nulls downstream.
- Added `src/modules/android/constants/summary-data-schema.ts` as the single source of truth for the
  summary schema: the `FtmSummaryData` interface plus `FTM_SUMMARY_DATA_DEFAULTS` typed
  `Required<FtmSummaryData>`, so adding a field to the interface fails the build until it is given a
  default. Adding a field also re-seeds existing documents on the next launch.
- `AndroidInterface` is now constructed as `AndroidInterface<FtmSummaryData>`, so every summary write
  and its per-field options are checked against the schema at compile time, an undeclared field, or
  an options key naming one, no longer compiles.
- Bumped `@curiouslearning/core` to `^1.13.1`, which adds `logInitialSummaryData()`, `isAvailable()`
  and the once-per-document seed guard.

Seeding is safe to repeat: core sends every field with the `"add"` instruction, which the container
maps to `FieldValue.increment`, so a `0` creates an absent field and is a no-op on a real value.

# How to test
- Manual, in Curious Reader (requires `mr-75` enabled for the test user, or the Android strategy is
  never registered and nothing is sent):
  - Launch FTM with a fresh `cr_user_id` and **complete nothing**. A `summary_data` document should
    appear with all six fields at `0`, and `created_at == updated_at`.
  - Complete one puzzle. `puzzles_completed` and `puzzle_success` go `0 → 1` in the *same* document,
    with no second document created.
  - Relaunch. No new write — `updated_at` unchanged.
  - Switch language and launch. A separate document is seeded for that language.
  - Open FTM outside the container. Nothing is sent, and a later in-container launch still seeds.


Ref: [MR-177](https://curiouslearning.atlassian.net/browse/MR-177)


[MR-177]: https://curiouslearning.atlassian.net/browse/MR-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ